### PR TITLE
Remove old reference to rstudio-helm repo name in favor of rstudio

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+helm.rstudio.com

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -23,8 +23,8 @@ changes, as well as documentation below on how to use the chart
 To install the chart with the release name `my-release` at version {{ template "chart.version" . }}:
 
 ```bash
-helm repo add rstudio-helm https://helm.rstudio.com
-helm install my-release rstudio-helm/{{ template "chart.name" . }} --version={{ template "chart.version" . }}
+helm repo add rstudio https://helm.rstudio.com
+helm install my-release rstudio/{{ template "chart.name" . }} --version={{ template "chart.version" . }}
 ```
 
 {{- end }}

--- a/charts/rstudio-launcher-rbac/Chart.yaml
+++ b/charts/rstudio-launcher-rbac/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-launcher-rbac
 description: RBAC definition for the RStudio Job Launcher
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.2.1
+appVersion: 0.2.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 maintainers:
   - name: sol-eng

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Kubernetes deployment for RStudio Package Manager
-version: 0.2.0-rc02
+version: 0.2.0-rc03
 apiVersion: v2
 appVersion: 1.2.2.1-17
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/examples/rbac/rstudio-launcher-rbac-0.2.1.yaml
+++ b/examples/rbac/rstudio-launcher-rbac-0.2.1.yaml
@@ -1,0 +1,103 @@
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rstudio-launcher-rbac
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rstudio-launcher-rbac
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rstudio-launcher-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rstudio-launcher-rbac
+subjects:
+  - kind: ServiceAccount
+    name: rstudio-launcher-rbac
+    namespace: rstudio
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rstudio-launcher-rbac
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "pods/log"
+      - "pods/attach"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+    verbs:
+      - "create"
+      - "get"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "create"
+      - "update"
+      - "patch"
+      - "get"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rstudio-launcher-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rstudio-launcher-rbac
+subjects:
+  - kind: ServiceAccount
+    name: rstudio-launcher-rbac


### PR DESCRIPTION
This seems to be more idiomatic in the Helm community