### PR TITLE
Update Test Pod

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Kubernetes deployment for RStudio Workbench
-version: 0.4.0-rc12
+version: 0.4.0-rc13
 apiVersion: v2
 appVersion: 1.4.1717-3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes deployment for RStudio Workbench
 
-![Version: 0.4.0-rc12](https://img.shields.io/badge/Version-0.4.0--rc12-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
+![Version: 0.4.0-rc13](https://img.shields.io/badge/Version-0.4.0--rc13-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
 
 ## Disclaimer
 
@@ -20,11 +20,11 @@ changes, as well as documentation below on how to use the chart
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.4.0-rc12:
+To install the chart with the release name `my-release` at version 0.4.0-rc13:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc12
+helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc13
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -6,7 +6,7 @@ metadata:
    "helm.sh/hook": test
 spec:
   {{- if .Values.rbac.create }}
-  serviceAccountName: {{ include "rstudio-workbench.fullname" . }}-job-launcher
+  serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
   {{- end }}
   {{- if and (not .Values.rbac.create) (.Values.serviceAccountName) }}
   serviceAccountName: {{ .Values.serviceAccountName }}
@@ -16,4 +16,8 @@ spec:
   {{- $overrideDict := . | deepCopy }}
   {{- $_ := set $overrideDict.Values "enableDiagnostics" true }}
   {{- $_ := set $overrideDict.Values "userCreate" true }}
+  {{- $_ := set $overrideDict.Values "readinessProbe.enabled" false }}
+  {{- $_ := set $overrideDict.Values "livenessProbe.enabled" false }}
+  {{- $_ := set $overrideDict.Values "startupProbe.enabled" false }}
+  {{- $_ := set $overrideDict.Values ".Values.prometheusExporter.enabled" false }}
 {{ include "rstudio-workbench.containers" $overrideDict | indent 2 }}


### PR DESCRIPTION
This PR disables the readiness, startup and liveness probe in the test pod. It also removes the `job-launcher` flag from the `serviceAccountName` since this is not a part of the name generated in the` rstudio-library rbac`