### PR TITLE
Fix the workbench test by disabling various settings that should be disabled for the test pod.

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Kubernetes deployment for RStudio Workbench
-version: 0.4.0-rc13
+version: 0.4.0-rc14
 apiVersion: v2
 appVersion: 1.4.1717-3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes deployment for RStudio Workbench
 
-![Version: 0.4.0-rc13](https://img.shields.io/badge/Version-0.4.0--rc13-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
+![Version: 0.4.0-rc14](https://img.shields.io/badge/Version-0.4.0--rc14-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
 
 ## Disclaimer
 
@@ -20,11 +20,11 @@ changes, as well as documentation below on how to use the chart
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.4.0-rc13:
+To install the chart with the release name `my-release` at version 0.4.0-rc14:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc13
+helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc14
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -16,8 +16,11 @@ spec:
   {{- $overrideDict := . | deepCopy }}
   {{- $_ := set $overrideDict.Values "enableDiagnostics" true }}
   {{- $_ := set $overrideDict.Values "userCreate" true }}
-  {{- $_ := set $overrideDict.Values "readinessProbe.enabled" false }}
-  {{- $_ := set $overrideDict.Values "livenessProbe.enabled" false }}
-  {{- $_ := set $overrideDict.Values "startupProbe.enabled" false }}
-  {{- $_ := set $overrideDict.Values ".Values.prometheusExporter.enabled" false }}
+  {{- $disabledObject := dict "enabled" false }}
+  {{- $readinessProbe := dict "readinessProbe" $disabledObject }}
+  {{- $livenessProbe := dict "livenessProbe" $disabledObject }}
+  {{- $startupProbe := dict "startupProbe" $disabledObject }}
+  {{- $prometheusExporter := dict "prometheusExporter" $disabledObject }}
+  {{- $overrideValues := mergeOverwrite $overrideDict.Values $prometheusExporter $startupProbe $livenessProbe $readinessProbe }}
+  {{- $_ := set $overrideDict "Values" $overrideValues }}
 {{ include "rstudio-workbench.containers" $overrideDict | indent 2 }}

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -13,14 +13,12 @@ spec:
   {{- end }}
   shareProcessNamespace: {{ .Values.shareProcessNamespace }}
   restartPolicy: Never
-  {{- $overrideDict := . | deepCopy }}
-  {{- $_ := set $overrideDict.Values "enableDiagnostics" true }}
-  {{- $_ := set $overrideDict.Values "userCreate" true }}
+  {{- $topLevelParams := dict "enableDiagnostics" true "userCreate" true }}
   {{- $disabledObject := dict "enabled" false }}
   {{- $readinessProbe := dict "readinessProbe" $disabledObject }}
   {{- $livenessProbe := dict "livenessProbe" $disabledObject }}
   {{- $startupProbe := dict "startupProbe" $disabledObject }}
   {{- $prometheusExporter := dict "prometheusExporter" $disabledObject }}
-  {{- $overrideValues := mergeOverwrite $overrideDict.Values $prometheusExporter $startupProbe $livenessProbe $readinessProbe }}
-  {{- $_ := set $overrideDict "Values" $overrideValues }}
+  {{- $overrideDict := . | deepCopy }}
+  {{- $_ := mergeOverwrite $overrideDict.Values $prometheusExporter $startupProbe $livenessProbe $readinessProbe $topLevelParams }}
 {{ include "rstudio-workbench.containers" $overrideDict | indent 2 }}


### PR DESCRIPTION

The previous method of calling set and passing . separated names for subkeys does not work. Tested `main` after https://github.com/rstudio/helm/pull/27 was merged and saw that the test pod was still hanging because it was not properly disabling the readiness probe and the exporter container.

This method creates the proper objects for all disabled objects and combines them into the `overrideDictionary.Values` to ensure everything is overridden properly. `mergeOverwrite` is used to ensure that we forcefully disable these settings as they should NEVER be set within a test pod.

