### PR TITLE
Tweak profiles

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Kubernetes deployment for RStudio Workbench
-version: 0.4.0-rc14
+version: 0.4.0-rc15
 apiVersion: v2
 appVersion: 1.4.1717-3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -143,7 +143,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | config.server."launcher.conf".server.address | string | `"127.0.0.1"` |  |
 | config.server."launcher.conf".server.admin-group | string | `"rstudio-server"` |  |
 | config.server."launcher.conf".server.authorization-enabled | int | `1` |  |
-| config.server."launcher.conf".server.enable-debug-logging | int | `1` |  |
+| config.server."launcher.conf".server.enable-debug-logging | int | `0` |  |
 | config.server."launcher.conf".server.port | int | `5559` |  |
 | config.server."launcher.conf".server.server-user | string | `"rstudio-server"` |  |
 | config.server."launcher.conf".server.thread-pool-size | int | `4` |  |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes deployment for RStudio Workbench
 
-![Version: 0.4.0-rc14](https://img.shields.io/badge/Version-0.4.0--rc14-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
+![Version: 0.4.0-rc15](https://img.shields.io/badge/Version-0.4.0--rc15-informational?style=flat-square) ![AppVersion: 1.4.1717-3](https://img.shields.io/badge/AppVersion-1.4.1717--3-informational?style=flat-square)
 
 ## Disclaimer
 
@@ -20,11 +20,11 @@ changes, as well as documentation below on how to use the chart
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.4.0-rc14:
+To install the chart with the release name `my-release` at version 0.4.0-rc15:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc14
+helm install my-release rstudio/rstudio-workbench --version=0.4.0-rc15
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -140,7 +140,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | config.server."jupyter.conf".notebooks-enabled | int | `1` |  |
 | config.server."launcher.conf".cluster.name | string | `"Kubernetes"` |  |
 | config.server."launcher.conf".cluster.type | string | `"Kubernetes"` |  |
-| config.server."launcher.conf".server.address | string | `"127.0.0.1"` |  |
+| config.server."launcher.conf".server.address | string | `"0.0.0.0"` |  |
 | config.server."launcher.conf".server.admin-group | string | `"rstudio-server"` |  |
 | config.server."launcher.conf".server.authorization-enabled | int | `1` |  |
 | config.server."launcher.conf".server.enable-debug-logging | int | `0` |  |
@@ -149,10 +149,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | config.server."launcher.conf".server.thread-pool-size | int | `4` |  |
 | config.server."logging.conf" | object | `{}` |  |
 | config.server."rserver.conf".admin-enabled | int | `1` |  |
-| config.server."rserver.conf".launcher-address | string | `"127.0.0.1"` |  |
 | config.server."rserver.conf".launcher-default-cluster | string | `"Kubernetes"` |  |
-| config.server."rserver.conf".launcher-port | int | `5559` |  |
-| config.server."rserver.conf".launcher-sessions-callback-address | string | `"http://127.0.0.1:8787"` |  |
 | config.server."rserver.conf".launcher-sessions-enabled | int | `1` |  |
 | config.server."rserver.conf".monitor-graphite-client-id | string | `"rstudio"` |  |
 | config.server."rserver.conf".monitor-graphite-enabled | int | `1` |  |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -225,7 +225,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | service.annotations | object | `{}` | annotations for the service definition |
 | service.nodePort | bool | `false` | the nodePort to use when using service type NodePort. If not defined, Kubernetes will provide one automatically |
 | service.type | string | `"NodePort"` | the service type (i.e. NodePort, LoadBalancer, etc.) |
-| session.defaultConfigMount | bool | `true` |  |
+| session.defaultConfigMount | bool | `true` | Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this |
 | session.image.repository | string | `"rstudio/r-session-complete"` | The repository to use for the session image |
 | session.image.tag | string | `""` | A tag override for the session image. Overrides the "tagPrefix" above, if set. Default tag is `{{ tagPrefix }}{{ version }}` |
 | session.image.tagPrefix | string | `"bionic-"` | A tag prefix for session images (common selections: bionic-, centos-). Only used if tag is not defined |

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -40,8 +40,8 @@ containers:
     value: "true"
   {{- end }}
   - name: RSTUDIO_LAUNCHER_NAMESPACE
-    value: "{{ $.Release.Namespace }}"
-{{ include "rstudio-library.license-env" (dict "license" ( .Values.license ) "product" ("rstudio-workbench") "envVarPrefix" ("RSW") "fullName" (include "rstudio-workbench.fullname" .)) | indent 2 }}
+    value: "{{ default $.Release.Namespace .Values.launcher.namespace }}"
+  {{- include "rstudio-library.license-env" (dict "license" ( .Values.license ) "product" ("rstudio-workbench") "envVarPrefix" ("RSW") "fullName" (include "rstudio-workbench.fullname" .)) | nindent 2 }}
   - name: RSP_LAUNCHER
     value: "{{ .Values.launcher.enabled }}"
   {{- if .Values.userCreate }}
@@ -98,19 +98,19 @@ containers:
       mountPath: "/etc/rstudio"
     - name: shared-data
       mountPath: "/mnt/load-balancer/rstudio"
-{{ include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | indent 4 }}
-{{/* TODO: path collision problems... would be ideal to not have to maintain both long term */}}
-{{- if .Values.jobJsonOverridesFiles }}
+    {{- include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | nindent 4 }}
+    {{- /* TODO: path collision problems... would be ideal to not have to maintain both long term */}}
+    {{- if .Values.jobJsonOverridesFiles }}
     - name: rstudio-job-overrides-old
       mountPath: "/mnt/job-json-overrides"
-{{- end }}
-{{- if not $useLegacyProfiles }}
+    {{- end }}
+    {{- if not $useLegacyProfiles }}
     - name: rstudio-job-overrides-new
       mountPath: "/mnt/job-json-overrides-new"
-{{- end }}
-{{- if .Values.pod.volumeMounts }}
-{{ toYaml .Values.pod.volumeMounts | indent 4 }}
-{{- end }}
+    {{- end }}
+    {{- if .Values.pod.volumeMounts }}
+    {{- toYaml .Values.pod.volumeMounts | nindent 4 }}
+    {{- end }}
   resources:
     {{- if .Values.resources.requests.enabled }}
     requests:

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -16,9 +16,7 @@
 {{- /* Define the default rserver values - point to the launcher and IDE services in Kubernetes */}}
 {{- $defaultIDEServiceName := include "rstudio-workbench.fullname" . }}
 {{- $defaultIDEServiceURL := printf "http://%s.%s.svc.cluster.local:80" $defaultIDEServiceName $.Release.Namespace }}
-{{- $defaultLauncherServiceName :=  print "%s-launcher" (include "rstudio-workbench.fullname" .) }}
-{{- $defaultLauncherServiceURL := printf "%s.%s.svc.cluster.local" $defaultLauncherServiceName $.Release.Namespace }}
-{{- $defaultRServerConfigValues := dict "launcher-address" ($defaultLauncherServiceURL) "launcher-port" ("80") "launcher-sessions-callback-address" ($defaultIDEServiceURL) }}
+{{- $defaultRServerConfigValues := dict "launcher-sessions-callback-address" ($defaultIDEServiceURL) }}
 {{- $defaultRServerConfig := dict "rserver.conf" ($defaultRServerConfigValues) }}
 ---
 apiVersion: v1
@@ -46,10 +44,10 @@ data:
   {{/* generate the profiles configuration */}}
   {{- include "rstudio-library.profiles.ini.advanced" $profilesDict | nindent 2 }}
 {{- end }}
-{{/* generate the server configuration (dcf files) minus launcher-mounts */}}
-{{ include "rstudio-library.config.dcf" ( omit .Values.config.serverDcf "launcher-mounts" ) | indent 2 }}
-{{/* generate the launcher-mounts file */}}
-{{ include "rstudio-workbench.config.launcherMounts" . | indent 2 }}
+  {{- /* generate the server configuration (dcf files) minus launcher-mounts */}}
+  {{- include "rstudio-library.config.dcf" ( omit .Values.config.serverDcf "launcher-mounts" ) | nindent 2 }}
+  {{- /* generate the launcher-mounts file */}}
+  {{- include "rstudio-workbench.config.launcherMounts" . | nindent 2 }}
 ---
 {{/* The old pattern for job-json-overrides "json" files */}}
 {{- if .Values.jobJsonOverridesFiles }}

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -1,4 +1,4 @@
-{{/* Define the default values that will be merged over */}}
+{{- /* Define the default values that will be merged over */}}
 {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
 {{- $sessionTag := .Values.session.image.tag | default (printf "%s%s" .Values.session.image.tagPrefix $defaultVersion ) }}
 {{- $defaultImages := list (printf "%s:%s" .Values.session.image.repository $sessionTag) }}
@@ -13,6 +13,13 @@
 {{- end }}
 {{- $defaultProfiles := dict "default-container-image" (first $defaultImages) "container-images" $defaultImages "allow-unknown-images" 1 }}
 {{- $defaultProfilesConfig := dict "*" $defaultProfiles }}
+{{- /* Define the default rserver values - point to the launcher and IDE services in Kubernetes */}}
+{{- $defaultIDEServiceName := include "rstudio-workbench.fullname" . }}
+{{- $defaultIDEServiceURL := printf "http://%s.%s.svc.cluster.local:80" $defaultIDEServiceName $.Release.Namespace }}
+{{- $defaultLauncherServiceName :=  print "%s-launcher" (include "rstudio-workbench.fullname" .) }}
+{{- $defaultLauncherServiceURL := printf "%s.%s.svc.cluster.local" $defaultLauncherServiceName $.Release.Namespace }}
+{{- $defaultRServerConfigValues := dict "launcher-address" ($defaultLauncherServiceURL) "launcher-port" ("80") "launcher-sessions-callback-address" ($defaultIDEServiceURL) }}
+{{- $defaultRServerConfig := dict "rserver.conf" ($defaultRServerConfigValues) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -25,8 +32,9 @@ data:
 {{- if .Values.license.server }}
   {{- $licenseParam := dict "server-license-type" "remote" }}
   {{- $licenseServerConf := dict "rserver.conf" $licenseParam}}
-  {{- $overrideDict = mergeOverwrite $overrideDict $licenseServerConf}}
+  {{- $overrideDict = mergeOverwrite $licenseServerConf $overrideDict }}
 {{- end }}
+{{- $overrideDict = mergeOverwrite $defaultRServerConfig $overrideDict }}
 {{ include "rstudio-library.config.ini" $overrideDict | indent 2 }}
 {{/* helper variables to make things here a bit more sane */}}
 {{- $profilesConfig := .Values.config.profiles }}

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -12,10 +12,6 @@
   {{- $defaultOverrides = concat $defaultOverrides ( list $sessionVolumeOverride $sessionVolumeMountOverride ) }}
 {{- end }}
 {{- $defaultProfiles := dict "default-container-image" (first $defaultImages) "container-images" $defaultImages "allow-unknown-images" 1 }}
-{{- if $defaultOverrides }}
-  {{/* if defaultOverrides exist - add them */}}
-  {{- $defaultProfiles = mergeOverwrite $defaultProfiles ( dict "job-json-overrides" $defaultOverrides ) }}
-{{- end }}
 {{- $defaultProfilesConfig := dict "*" $defaultProfiles }}
 ---
 apiVersion: v1
@@ -38,7 +34,7 @@ data:
 {{- $useLegacyProfiles := hasKey .Values.config.server "launcher.kubernetes.profiles.conf" }}
 {{- $jobJsonFilePath := "/mnt/job-json-overrides-new/" }}
 {{- if not $useLegacyProfiles }}
-  {{- $profilesDict := dict "data" ($profilesConfig | deepCopy) "filePath" $jobJsonFilePath }}
+  {{- $profilesDict := dict "data" ($profilesConfig | deepCopy) "filePath" ($jobJsonFilePath) "jobJsonDefaults" ($defaultOverrides) }}
   {{/* generate the profiles configuration */}}
   {{- include "rstudio-library.profiles.ini.advanced" $profilesDict | nindent 2 }}
 {{- end }}
@@ -70,6 +66,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 data:
   {{/* TODO: need to make the json-from-overrides-config take more than one file... only using launcher.kubernetes.profiles.conf today */}}
-  {{- $configValue := dict "data" (get $profilesConfig "launcher.kubernetes.profiles.conf" | deepCopy) "default" (list) }}
+  {{- $configValue := dict "data" (get $profilesConfig "launcher.kubernetes.profiles.conf" | deepCopy) "default" ($defaultOverrides) }}
   {{- include "rstudio-library.profiles.json-from-overrides-config" $configValue | indent 2 }}
 {{- end }}

--- a/charts/rstudio-workbench/templates/configmap-session.yaml
+++ b/charts/rstudio-workbench/templates/configmap-session.yaml
@@ -7,7 +7,13 @@ metadata:
 data:
   {{- include "rstudio-library.config.ini" .Values.config.session | nindent 2 }}
 
-{{- /* if session/target namespace differs - duplicate session configuration there */}}
+{{- /*
+  if session/target namespace differs - duplicate session configuration there
+    - when .Values.session.defaultConfigMount is true, we mount session configuration into the session pods
+    - however, configmaps cannot be mounted across namespaces
+    - so the session configmap should live in both the .Values.launcher.namespace and in the Release Namespace
+  we create this value regardless of the value of .Values.session.defaultConfigMount, in case it is needed for other reasons
+*/}}
 {{- $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
 {{- if ne $targetNamespace $.Release.Namespace }}
 ---

--- a/charts/rstudio-workbench/templates/configmap-session.yaml
+++ b/charts/rstudio-workbench/templates/configmap-session.yaml
@@ -5,5 +5,17 @@ metadata:
   name: {{ include "rstudio-workbench.fullname" . }}-session
   namespace: {{ $.Release.Namespace }}
 data:
-{{ include "rstudio-library.config.ini" .Values.config.session | indent 2 }}
+  {{- include "rstudio-library.config.ini" .Values.config.session | nindent 2 }}
+
+{{- /* if session/target namespace differs - duplicate session configuration there */}}
+{{- $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
+{{- if ne $targetNamespace $.Release.Namespace }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rstudio-workbench.fullname" . }}-session
+  namespace: {{ $targetNamespace }}
+data:
+  {{- include "rstudio-library.config.ini" .Values.config.session | nindent 2 }}
+{{- end }}

--- a/charts/rstudio-workbench/templates/rbac.yaml
+++ b/charts/rstudio-workbench/templates/rbac.yaml
@@ -3,7 +3,7 @@
 {{- $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
 {{- $serviceAccountName := default (include "rstudio-workbench.fullname" .) .Values.rbac.serviceAccount.name }}
 {{- $serviceAccountCreate := .Values.rbac.create }}
-{{- $roleName := $serviceAccountCreate }}
+{{- $roleName := $serviceAccountName }}
 {{- $serviceAccountAnnotations := .Values.serviceAccountAnnotations }}
 {{- $rbacValues1 := dict "namespace" $namespace "serviceAccountName" $serviceAccountName "targetNamespace" $targetNamespace }}
 {{- $rbacValues2 := dict "serviceAccountCreate" $.Values.rbac.create "serviceAccountAnnotations" $serviceAccountAnnotations "roleName" ($roleName) }}
@@ -13,7 +13,7 @@
 {{- /*
   Allow listing pods for the namespace the ServiceAccount is in
   TODO: can remove this once the load-balancer sidecar is not needed
-*/ }}
+*/}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/rstudio-workbench/templates/rbac.yaml
+++ b/charts/rstudio-workbench/templates/rbac.yaml
@@ -1,11 +1,46 @@
 {{- if .Values.rbac.create }}
-{{ $namespace := $.Release.Namespace }}
-{{ $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
-{{ $serviceAccountName := default (include "rstudio-workbench.fullname" .) .Values.rbac.serviceAccount.name }}
-{{ $serviceAccountCreate := .Values.rbac.create }}
-{{ $serviceAccountAnnotations := .Values.serviceAccountAnnotations }}
-{{ $rbacValues1 := dict "namespace" $namespace "serviceAccountName" $serviceAccountName "targetNamespace" $targetNamespace }}
-{{ $rbacValues2 := dict "serviceAccountCreate" $.Values.rbac.create "serviceAccountAnnotations" $serviceAccountAnnotations }}
-{{ $rbacValues := merge $rbacValues1 $rbacValues2 }}
-{{ include "rstudio-library.rbac" $rbacValues }}
+{{- $namespace := $.Release.Namespace }}
+{{- $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
+{{- $serviceAccountName := default (include "rstudio-workbench.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- $serviceAccountCreate := .Values.rbac.create }}
+{{- $roleName := $serviceAccountCreate }}
+{{- $serviceAccountAnnotations := .Values.serviceAccountAnnotations }}
+{{- $rbacValues1 := dict "namespace" $namespace "serviceAccountName" $serviceAccountName "targetNamespace" $targetNamespace }}
+{{- $rbacValues2 := dict "serviceAccountCreate" $.Values.rbac.create "serviceAccountAnnotations" $serviceAccountAnnotations "roleName" ($roleName) }}
+{{- $rbacValues := merge $rbacValues1 $rbacValues2 }}
+{{- include "rstudio-library.rbac" $rbacValues }}
+{{- if ne $namespace $targetNamespace }}
+{{- /*
+  Allow listing pods for the namespace the ServiceAccount is in
+  TODO: can remove this once the load-balancer sidecar is not needed
+*/ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $roleName }}
+  namespace: {{ $namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "list"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $roleName }}
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $serviceAccountName }}
+    namespace: {{ $namespace }}
+{{- end }}
 {{- end }}

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -19,20 +19,3 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
     targetPort: 8787
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "rstudio-workbench.fullname" . }}-launcher
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    {{- include "rstudio-workbench.labels" . | nindent 4 }}
-spec:
-  type: NodePort
-  selector:
-    {{- include "rstudio-workbench.selectorLabels" . | nindent 4 }}
-  ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 5559
----

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -275,7 +275,7 @@ config:
         admin-group: rstudio-server
         authorization-enabled: 1
         thread-pool-size: 4
-        enable-debug-logging: 1
+        enable-debug-logging: 0
       cluster:
         name: Kubernetes
         type: Kubernetes

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -258,6 +258,8 @@ config:
       admin-enabled: 1
       www-port: 8787
       server-project-sharing: 1
+      launcher-address: 127.0.0.1
+      launcher-port: 5559
       launcher-sessions-enabled: 1
       launcher-default-cluster: Kubernetes
       monitor-graphite-enabled: 1
@@ -266,7 +268,7 @@ config:
       monitor-graphite-client-id: rstudio
     launcher.conf:
       server:
-        address: 0.0.0.0
+        address: 127.0.0.1
         port: 5559
         server-user: rstudio-server
         admin-group: rstudio-server

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -7,6 +7,7 @@ fullnameOverride: ""
 versionOverride: ""
 
 session:
+  # -- Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this
   defaultConfigMount: true
   image:
     # -- A tag prefix for session images (common selections: bionic-, centos-). Only used if tag is not defined

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -258,18 +258,15 @@ config:
       admin-enabled: 1
       www-port: 8787
       server-project-sharing: 1
-      launcher-address: 127.0.0.1
-      launcher-port: 5559
       launcher-sessions-enabled: 1
       launcher-default-cluster: Kubernetes
-      launcher-sessions-callback-address: http://127.0.0.1:8787
       monitor-graphite-enabled: 1
       monitor-graphite-host: 127.0.0.1
       monitor-graphite-port: 9109
       monitor-graphite-client-id: rstudio
     launcher.conf:
       server:
-        address: 127.0.0.1
+        address: 0.0.0.0
         port: 5559
         server-user: rstudio-server
         admin-group: rstudio-server


### PR DESCRIPTION
- improve whitespace consistency
- handle a bunch of rough edges
  - duplicate session config to the target namespace (if different from release namespace)
  - change debug logging to off by default
  - ensure launcher / target namespace is passed properly to the launcher (when different)
  - fix profiles / overrides handling of defaults (i.e. mount session configmap by default)
  - add rbac that is needed for the sidecar container (when launching sessions into a different namespace)
  - change default value for session-callback-address (and set programmatically)
  - remove the launcher service - it does not work with a single set of pods because readiness probes cannot support multiple services (probably by design). So we will remove it for now