### PR TITLE
Add connect helm chart full examples

### DIFF
--- a/examples/connect/aws-elb/values.yaml
+++ b/examples/connect/aws-elb/values.yaml
@@ -1,0 +1,18 @@
+# Controls how many instances of RStudio Connect will be created.
+# A value > 1 requires HTTP sticky sessions.
+# See examples/connect/high-availability-nginx-launcher/values.yaml for an example with replicas > 1
+replicas: 1
+
+service:
+  type: LoadBalancer
+  port: 443
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "" # The ARN of the certificate to use
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+# rstudio-connect.gcfg
+config:
+  Server:
+    Address: "" # A valid https:// URL that can be verified by the aws-load-balancer-ssl-cert above

--- a/examples/connect/high-availability-nginx-launcher/values.yaml
+++ b/examples/connect/high-availability-nginx-launcher/values.yaml
@@ -1,0 +1,98 @@
+## This example requires the NGINX Ingress Controller to be installed ##
+#
+# For this example, we assume the following resources already exist. They are not created by the chart:
+# - A valid TLS secret named `connect-tls` for the host `connect.rstudio.com`
+# - A postgres database: `postgres://connect@postgres.rstudio.com:5432/rsc_k8s`
+# - An NFS share: `nfs.rstudio.com:/rstudio-connect`
+
+# Controls how many instances of RStudio Connect will be created.
+replicas: 3
+
+# Configures shared storage for the Connect pod. Note that `sharedStorage.path` has the
+#   same value as `config.Server.DataDir`.
+pod:
+  volumes:
+    - name: data-dir
+      nfs:
+        path: "/rstudio-connect"
+        server: "nfs.rstudio.com"
+  # Note: this volume is mounted in the location specified by `config.Server.DataDir`
+  volumeMounts:
+    - name: data-dir
+      mountPath: "/var/lib/rstudio-connect"
+
+# If you have an existing NFS volume provisioner, you can use a config like the
+#   following instead of setting `pod.volumes` / `pod.volumeMounts`.
+#   If `sharedStorage.create` is true, then this chart will create a PVC using the
+#   specified StorageClass, or the default StorageClass if non is provided. The
+#   resulting PVC will then be mounted to the Connect pod at `sharedStorage.path`.
+#   Also note that the storage provisioned here MUST be available to the content execution pod
+#   when `launcher.enabled` is true. The NFS PVC can be exposed to the content pod
+#   using the `config.Launcher.DataDir` setting.
+# sharedStorage:
+#   create: true
+#   mount: true
+#   path: /var/lib/rstudio-connect
+#   storageClassName: connect-nfs
+#   requests:
+#     storage: 100G
+
+ingress:
+  enabled: true
+
+  # For High Availability installations of RStudio Connect, where multiple `replicas`
+  #   of the Connect pod are in play, it is necessary to enable "sticky sessions" so that
+  #   traffic for a single connection is always routed to the same Connect pod.
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity-mode: persistent
+    nginx.ingress.kubernetes.io/session-cookie-name: RSC-SESSION-COOKIE
+
+  # Defines our virtual hosts in the NGINX configuration.
+  hosts:
+    - host: connect.rstudio.com
+      paths:
+        - /
+
+  # Tell the ingress controller to use the TLS
+  #   secret for connections to connect.rstudio.com.
+  tls:
+    - secretName: connect-tls
+      hosts:
+        - connect.rstudio.com
+
+# Enables building and executing content in separate Kubernetes pods
+launcher:
+  enabled: true
+
+# rstudio-connect.gcfg
+config:
+  Server:
+    # Server.Address matches the FQDN in our TLS certificate.
+    Address: "https://connect.rstudio.com"
+
+    # Note: `DataDir` has the same value as `pod.volumeMounts.mountPath`.
+    DataDir: "/var/lib/rstudio-connect"
+
+  # Enables building and executing Python content.
+  Python:
+    Enabled: true
+    # Note: this setting will no longer be required in a future version of Connect.
+    #   When running Connect with launcher enabled, Python installations should be defined in
+    #   runtime.yaml files, specified by Launcher.ClusterDefinition.
+    Executable:
+      - "/opt/python/3.6.5/bin/python"
+
+  Database:
+    Provider: "Postgres"
+
+  Postgres:
+    URL: "postgres://connect@postgres.rstudio.com:5432/rsc_k8s"
+
+  # Note: the value of `config.Launcher.DataDir`
+  #   is the same NFS export location that is used by the Connect pod
+  #   config.Server.DataDir: "/var/lib/rstudio-connect".  This allows the content
+  #   pods to share data with the Connect pod.
+  Launcher:
+    DataDir: "nfs.rstudio.com:/rstudio-connect"

--- a/examples/connect/high-availability-traefik/values.yaml
+++ b/examples/connect/high-availability-traefik/values.yaml
@@ -1,0 +1,96 @@
+## This example requires the Traefik Ingress Controller to be installed ##
+#
+# For this example, we assume the following resources already exist. They are not created by the chart:
+# - A valid TLS secret named `connect-tls` for the host `connect.rstudio.com`
+# - A postgres database: `postgres://connect@postgres.rstudio.com:5432/rsc_k8s`
+# - An NFS share: `nfs.rstudio.com:/rstudio-connect`
+
+# Controls how many instances of RStudio Connect will be created.
+replicas: 3
+
+# Configures shared storage for the Connect pod. Note that `sharedStorage.path` has the
+#   same value as `config.Server.DataDir`.
+pod:
+  volumes:
+    - name: data-dir
+      nfs:
+        path: "/rstudio-connect"
+        server: "nfs.rstudio.com"
+  # Note: this volume is mounted in the location specified by `config.Server.DataDir`
+  volumeMounts:
+    - name: data-dir
+      mountPath: "/var/lib/rstudio-connect"
+
+# If you have an existing NFS volume provisioner, you can use a config like the
+#   following instead of setting `pod.volumes` / `pod.volumeMounts`.
+#   If `sharedStorage.create` is true, then this chart will create a PVC using the
+#   specified StorageClass, or the default StorageClass if non is provided. The
+#   resulting PVC will then be mounted to the Connect pod at `sharedStorage.path`.
+#   Also note that the storage provisioned here MUST be available to the content execution pod
+#   when `launcher.enabled` is true. The NFS PVC can be exposed to the content pod
+#   using the `config.Launcher.DataDir` setting. For an example where launcher is enabled,
+#   see: connect-ha-nginx-ingress-launcher-values.yaml
+# sharedStorage:
+#   create: true
+#   mount: true
+#   path: /var/lib/rstudio-connect
+#   storageClassName: connect-nfs
+#   requests:
+#     storage: 100G
+
+service:
+  # For High Availability installations of RStudio Connect, where multiple `replicas`
+  #   of the Connect pod are in play, it is necessary to enable "sticky sessions" so that
+  #   traffic for a single connection is always routed to the same Connect pod.
+  annotations:
+    ## Traefik v2.x
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: RSC-SESSION-COOKIE
+    traefik.ingress.kubernetes.io/service.sticky.cookie.secure: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.samesite: "none"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.httponly: "true"
+    ## Traefik v1.x
+    # traefik.ingress.kubernetes.io/affinity: "true"
+    # traefik.ingress.kubernetes.io/session-cookie-name: RSC-SESSION-COOKIE
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: traefik
+
+  # Defines our virtual hosts in the NGINX configuration.
+  hosts:
+    - host: connect.rstudio.com
+      paths:
+        - /
+
+  # Tell the ingress controller to use the TLS
+  #   secret for connections to connect.rstudio.com.
+  tls:
+    - secretName: connect-tls
+      hosts:
+        - connect.rstudio.com
+
+# rstudio-connect.gcfg
+config:
+  Server:
+    # Server.Address matches the FQDN in our TLS certificate.
+    Address: "https://connect.rstudio.com"
+
+    # Note: `DataDir` has the same value as `pod.volumeMounts.mountPath`.
+    DataDir: "/var/lib/rstudio-connect"
+
+  # Enables building and executing Python content.
+  Python:
+    Enabled: true
+    # Note: this setting will no longer be required in a future version of Connect.
+    #   When running Connect with launcher enabled, Python installations should be defined in
+    #   runtime.yaml files, specified by Launcher.ClusterDefinition.
+    Executable:
+      - "/opt/python/3.6.5/bin/python"
+
+  Database:
+    Provider: "Postgres"
+
+  Postgres:
+    URL: "postgres://connect@postgres.rstudio.com:5432/rsc_k8s"


### PR DESCRIPTION
Adds example values files for different provider configurations:

1. `examples/connect/aws-elb`:
  - Single node Connect
  - `service.type = LoadBalancer` with TLS from ACM
2. `examples/connect/high-availability-nginx-launcher`: 
  - 3 node Connect
  - NGINX ingress controller
  - launcher enabled
  - uses a `TLS Secret`
  - enables sticky sessions
  - external postgres and nfs
3. `examples/connect/high-availability-traefik`:
  - 3 node Connect
  - Treafik ingress controller
  - launcher disabled
  - uses a `TLS Secret`
  - enables sticky sessions 
  - external postgres and nfs