### PR TITLE
mount session config to correct subpath

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,13 +1,12 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.4.1
+version: 0.4.2
 apiVersion: v2
 appVersion: 1.4.1717-3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
   - https://github.com/rstudio/helm
-  - https://github.com/rstudio/rstudio-docker-products
 maintainers:
   - name: sol-eng
     email: docker@rstudio.com
@@ -24,6 +23,8 @@ annotations:
       image: rstudio/r-session-complete:bionic-1.4.1717-3
   artifacthub.io/license: MIT
   artifacthub.io/links: |
+    - name: Docker Images
+      url: https://github.com/rstudio/rstudio-docker-products
     - name: RStudio Community
       url: https://community.rstudio.com/c/r-admin/5
     - name: About Workbench

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -218,7 +218,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |
-| prometheusExporter.mappingYaml | string | `nil` | Yaml defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file |
+| prometheusExporter.mappingYaml | string | `nil` | Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file |
 | rbac.create | bool | `true` | Whether to create rbac. (also depends on launcher.enabled = true) |
 | rbac.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | The serviceAccount to be associated with rbac (also depends on launcher.enabled = true) |
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | readinessProbe is used to configure the container's readinessProbe |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -218,6 +218,7 @@ mounting paradigm, you will need to change the `XDG_CONFIG_DIRS` environment var
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |
+| prometheusExporter.mappingYaml | string | `nil` | Yaml defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file |
 | rbac.create | bool | `true` | Whether to create rbac. (also depends on launcher.enabled = true) |
 | rbac.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | The serviceAccount to be associated with rbac (also depends on launcher.enabled = true) |
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | readinessProbe is used to configure the container's readinessProbe |

--- a/charts/rstudio-workbench/ci/other-complex-values.yaml
+++ b/charts/rstudio-workbench/ci/other-complex-values.yaml
@@ -50,11 +50,11 @@ homeStorage:
     storage: "500Gi"
 
 prometheusExporter:
-  mappingYaml:
+  mappingYaml: |
     mappings:
       - match: "rstudio\\.([\\w-]+)\\.system\\.load\\.(.*)"
         match_type: regex
-        name: "rstudio_system_load_test"
+        name: "rstudio_system_load_other_test"
         labels:
           host: "$1"
           duration: "$2"

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -6,7 +6,7 @@
 {{- if .Values.session.defaultConfigMount }}
   {{/* default session config mount */}}
   {{- $sessionVolume := dict "configMap" ( dict "name" (printf "%s-session" ( include "rstudio-workbench.fullname" . ) ) ) "name" "session-config" }}
-  {{- $sessionVolumeMount := dict "mountPath" "/mnt/session-configmap" "name" "session-config" }}
+  {{- $sessionVolumeMount := dict "mountPath" "/mnt/session-configmap/rstudio" "name" "session-config" }}
   {{- $sessionVolumeOverride := dict "name" "defaultSessionVolume" "target" "/spec/template/spec/volumes/-" "json" $sessionVolume }}
   {{- $sessionVolumeMountOverride := dict "name" "defaultSessionVolumeMount" "target" "/spec/template/spec/containers/0/volumeMounts/-" "json" $sessionVolumeMount }}
   {{- $defaultOverrides = concat $defaultOverrides ( list $sessionVolumeOverride $sessionVolumeMountOverride ) }}

--- a/charts/rstudio-workbench/templates/configmap-graphite-exporter.yaml
+++ b/charts/rstudio-workbench/templates/configmap-graphite-exporter.yaml
@@ -7,16 +7,24 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 data:
   graphite-mapping.yaml: |-
+  {{- if .Values.prometheusExporter.mappingYaml }}
+    {{- if kindIs "string" .Values.prometheusExporter.mappingYaml }}
+      {{- .Values.prometheusExporter.mappingYaml | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.prometheusExporter.mappingYaml | nindent 4 }}
+    {{- end }}
+  {{- else }}
     mappings:
-    - match: "rstudio\\.(\\w+)\\.system\\.load\\.(.*)"
+    - match: "rstudio\\.([\\w-]+)\\.system\\.load\\.(.*)"
       match_type: regex
       name: "rstudio_system_load"
       labels:
         host: "$1"
         duration: "$2"
-    - match: "rstudio\\.(\\w+)\\.(.*)"
+    - match: "rstudio\\.([\\w-]+)\\.(.*)"
       match_type: regex
       name: "rstudio_$2"
       labels:
         host: "$1"
+  {{- end }}
 {{- end }}

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- if .Values.prometheusExporter.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "9109"
+        prometheus.io/port: "9108"
       {{- end }}
 {{ include "rstudio-workbench.pod.annotations" . | indent 8 }}
       labels:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -219,7 +219,7 @@ pod:
 prometheusExporter:
   # -- whether the  prometheus exporter sidecar should be enabled
   enabled: true
-  # -- Yaml defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
+  # -- Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
   mappingYaml: null
   image:
     repository: "prom/graphite-exporter"

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -219,6 +219,8 @@ pod:
 prometheusExporter:
   # -- whether the  prometheus exporter sidecar should be enabled
   enabled: true
+  # -- Yaml defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
+  mappingYaml: null
   image:
     repository: "prom/graphite-exporter"
     tag: "v0.9.0"


### PR DESCRIPTION
fix a little buglet where we mount the session config to the wrong location on the session