### PR TITLE
small fixes for svc.yaml and values.yaml

### DIFF
--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -1,3 +1,4 @@
+{{- $svcPort := .Values.service.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -15,7 +16,7 @@ spec:
   ports:
   - protocol: TCP
     name: rspm
-    port: 80
+    port: {{ $svcPort }}
     {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -64,6 +64,8 @@ service:
   annotations: {}
   # -- The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically
   nodePort: false
+  # -- The Service port. This is the port your service will run under.
+  port: 80
 
 # -- replicas is the number of replica pods to maintain for this service
 replicas: 1


### PR DESCRIPTION
The two main goals of this commit are to simplify the port configuration of the service by adding the missing service port value to the values.yaml with a default value of 80, and also removing the hardcoded port 80 in the service template and replacing it with the $svcPort variable thats used in the ingress allowing the service port to be changed more easily.