### PR TITLE
make PRs run CI universally

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -1,6 +1,10 @@
 name: Document Charts
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   document:

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -1,6 +1,10 @@
 name: Lint and Test Charts
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
try to prevent PR and push triggers happening at the same time

hoping this will make CI work for outside contributors