### PR TITLE
RSC-2021.10.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.6
+version: 0.2.7
 apiVersion: v2
-appVersion: 2021.09.0
+appVersion: 2021.10.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:2021.09.0
+      image: rstudio/rstudio-connect:2021.10.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.7
+
+- Update default RStudio Connect version to 2021.10.0
+
 # 0.2.6
 
 - Update `rstudio-library` chart version

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![AppVersion: 2021.09.0](https://img.shields.io/badge/AppVersion-2021.09.0-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![AppVersion: 2021.10.0](https://img.shields.io/badge/AppVersion-2021.10.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.6:
+To install the chart with the release name `my-release` at version 0.2.7:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.2.6
+helm install my-release rstudio/rstudio-connect --version=0.2.7
 ```
 
 ## Required Configuration


### PR DESCRIPTION
Update to the RStudio Connect 2021.10.0 release.

Depends upon:
https://github.com/rstudio/rstudio-docker-products/pull/228