### PR TITLE
Add pam

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -64,8 +64,6 @@ jobs:
       - name: Compute and update dependent files
         run: |
           set -xe
-          # pull latest updates (i.e. if the document step above updated things)
-          git pull origin $GITHUB_REF
           cd ./charts/rstudio-launcher-rbac && helm dependency build && cd -
           helm template -n rstudio rstudio-launcher-rbac ./charts/rstudio-launcher-rbac --set removeNamespaceReferences=true > examples/rbac/rstudio-launcher-rbac.yaml
           CHART_VERSION=$(helm show chart ./charts/rstudio-launcher-rbac | grep '^version' | cut -d ' ' -f 2)

--- a/Justfile
+++ b/Justfile
@@ -8,3 +8,6 @@ update-lock:
   done
   echo " --> Done!"
 
+docs:
+  #!/bin/bash
+  helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.0-rc03
+version: 0.5.0-rc04
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -5,11 +5,12 @@
   - Previous versions of the chart are not compatible (by default) with 2021.09 or later
   - If you want to use charts across versions, you will need to change `command`, `args`, and some configmaps.
 - BREAKING: Change RStudio Workbench execution model to use supervisord
-- Add `imagePullSecrets` value option ([#57](https://github.com/rstudio/helm/issues/57))  
-- Add config-maps to configure startup behavior
-- Add a config setting for `sssd` (now in the container by default) - `config.userProvisioning`
-- Add a "secret" configmap for session components (useful for shared database credentials, `odbc.ini`, etc.)
-- Update README to make `job-json-overrides`, profiles, etc. more clear
+- Add `imagePullSecrets` value option ([#57](https://github.com/rstudio/helm/issues/57))
+- Add `config.pam` values option to add pam config files
+- Add config-maps to configure startup behavior (`config.startupCustom`)
+- Add a config setting for `sssd` (now in the container by default) (`config.userProvisioning`)
+- Add a "secret" configmap for session components (useful for shared database credentials, `odbc.ini`, etc.) (`config.sessionSecret`)
+- Update README to make `job-json-overrides`, profiles, user provisioning, etc. more clear
 - Update `rstudio-library` chart dependency
 
 # 0.4.6

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.0-rc03](https://img.shields.io/badge/Version-0.5.0--rc03-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
+![Version: 0.5.0-rc04](https://img.shields.io/badge/Version-0.5.0--rc04-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.0-rc03:
+To install the chart with the release name `my-release` at version 0.5.0-rc04:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.0-rc03
+helm install my-release rstudio/rstudio-workbench --version=0.5.0-rc04
 ```
 
 ## Required Configuration
@@ -284,6 +284,7 @@ config:
 | affinity | object | `{}` |  |
 | args | list | `[]` | args is the pod container's run arguments. |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
+| config.pam | object | `{}` | a map of pam config files. Will be mounted into the container directly / per file, in order to avoid overwriting system pam files |
 | config.profiles | object | `{}` | a map of server-scoped config files (akin to `config.server`), but with specific behavior that supports profiles. See README for more information. |
 | config.secret | object | `{"database.conf":{}}` | a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |
 | config.server | object | `{"jupyter.conf":{"default-session-cluster":"Kubernetes","jupyter-exe":"/opt/python/3.6.5/bin/jupyter","labs-enabled":1,"notebooks-enabled":1},"launcher.conf":{"cluster":{"name":"Kubernetes","type":"Kubernetes"},"server":{"address":"127.0.0.1","admin-group":"rstudio-server","authorization-enabled":1,"enable-debug-logging":0,"port":5559,"server-user":"rstudio-server","thread-pool-size":4}},"logging.conf":{},"rserver.conf":{"admin-enabled":1,"launcher-address":"127.0.0.1","launcher-default-cluster":"Kubernetes","launcher-port":5559,"launcher-sessions-enabled":1,"monitor-graphite-client-id":"rstudio","monitor-graphite-enabled":1,"monitor-graphite-host":"127.0.0.1","monitor-graphite-port":9109,"server-health-check-enabled":1,"server-project-sharing":1,"www-port":8787}}` | a map of server config files. Mounted to `/mnt/configmap/rstudio/` |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -163,6 +163,7 @@ the `XDG_CONFIG_DIRS` environment variable
   - `supervisord` service / unit definition `.conf` files
   - Located at `config.startupCustom.<< name of file >>` helm values
   - Will use the `.ini` file format, by default
+  - Mounted at `/startup/custom`
   - As with all config files above, can override with a verbatim string if desired, like so:
 ```yaml
 config:
@@ -170,7 +171,11 @@ config:
     myfile.conf: |
       file-used-verbatim
 ```
-   
+- PAM configuration
+  - `pam` configuration files
+  - Located at `config.pam.<< name of file >>` helm values
+  - Will be mounted verbatim as individual files (using `subPath` mounts) at `/etc/pam.d/<< name of file >>`
+
 ## User Provisioning
 
 Provisioning users in RStudio Workbench containers is challenging. Session images have users created automatically (with
@@ -195,6 +200,26 @@ However, it is important to be careful of a few points:
 We do not provide such a service out of the box because we intend for RStudio Workbench to solve this problem in a
 future release. Please get in touch with your account representative if you have feedback or questions about this
 workflow.
+
+### PAM
+
+When starting sessions on RStudio Workbench, PAM configuration is often very important, even if PAM is not being used as
+an authentication mechanism. The RStudio Workbench helm chart allows creating custom PAM files via the `config.pam`
+values section.
+
+Each key under `config.pam` will become a PAM config file, and will be mounted into `/etc/pam.d/` in the container. For
+example:
+
+```yaml
+config:
+  pam:
+    rstudio: |
+      # the rstudio PAM config file
+      # will be used verbatim
+    rstudio-session: |
+      # the rstudio-session PAM config file
+      # will be used verbatim
+```
    
 ## RStudio Profiles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -228,7 +228,7 @@ config:
         some-key:
           - value1
           - value2
--     myuser:
+      myuser:
         some-key:
           - value4
           - value5

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -207,7 +207,7 @@ config:
         some-key:
           - value1
           - value2
--     myuser:
+      myuser:
         some-key:
           - value4
           - value5

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -174,6 +174,26 @@ However, it is important to be careful of a few points:
 We do not provide such a service out of the box because we intend for RStudio Workbench to solve this problem in a
 future release. Please get in touch with your account representative if you have feedback or questions about this
 workflow.
+
+### PAM
+
+When starting sessions on RStudio Workbench, PAM configuration is often very important, even if PAM is not being used as
+an authentication mechanism. The RStudio Workbench helm chart allows creating custom PAM files via the `config.pam`
+values section.
+
+Each key under `config.pam` will become a PAM config file, and will be mounted into `/etc/pam.d/` in the container. For
+example:
+
+```yaml
+config:
+  pam:
+    rstudio: |
+      # the rstudio PAM config file
+      # will be used verbatim
+    rstudio-session: |
+      # the rstudio-session PAM config file
+      # will be used verbatim
+```
     
 ## RStudio Profiles
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -142,6 +142,7 @@ the `XDG_CONFIG_DIRS` environment variable
   - `supervisord` service / unit definition `.conf` files
   - Located at `config.startupCustom.<< name of file >>` helm values
   - Will use the `.ini` file format, by default
+  - Mounted at `/startup/custom`
   - As with all config files above, can override with a verbatim string if desired, like so:
 ```yaml
 config:
@@ -149,7 +150,11 @@ config:
     myfile.conf: |
       file-used-verbatim
 ```
-    
+- PAM configuration
+  - `pam` configuration files
+  - Located at `config.pam.<< name of file >>` helm values
+  - Will be mounted verbatim as individual files (using `subPath` mounts) at `/etc/pam.d/<< name of file >>`
+
 ## User Provisioning
 
 Provisioning users in RStudio Workbench containers is challenging. Session images have users created automatically (with

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -146,3 +146,13 @@ config:
     # fake .test ending to avoid killing the image
     somefile.conf.test: |
       some-value
+  pam:
+    pam-example:
+      # NOTE: order is not deterministic when using a dict... BAD for PAM!
+      somekey: |
+        account some_thing.so
+      anotherkey: |
+        session some_other_thing.so
+    pam-example-2: |
+      account some_thing.so
+      session something_else.so

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -114,6 +114,13 @@ containers:
     - name: rstudio-custom-startup
       mountPath: "/startup/custom"
     {{- end }}
+    {{- if .Values.config.pam }}
+      {{- range $i, $pamFileName := keys .Values.config.pam }}
+    - name: rstudio-pam
+      mountPath: "/etc/pam.d/{{ $pamFileName }}"
+      subPath: "{{ $pamFileName }}"
+      {{- end }}
+    {{- end }}
     {{- include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | nindent 4 }}
     {{- /* TODO: path collision problems... would be ideal to not have to maintain both long term */}}
     {{- if .Values.jobJsonOverridesFiles }}
@@ -246,6 +253,12 @@ volumes:
 - name: rstudio-custom-startup
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-start-custom
+    defaultMode: 0755
+{{- end }}
+{{- if .Values.config.pam }}
+- name: rstudio-pam
+  configMap:
+    name: {{ include "rstudio-workbench.fullname" . }}-pam
     defaultMode: 0755
 {{- end }}
 - name: rstudio-secret

--- a/charts/rstudio-workbench/templates/configmap-pam.yaml
+++ b/charts/rstudio-workbench/templates/configmap-pam.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.config.pam }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rstudio-workbench.fullname" . }}-pam
+  namespace: {{ $.Release.Namespace }}
+data:
+  {{- $pamDict := dict "data" .Values.config.pam "commentDelimiter" "#" }}
+  {{- include "rstudio-library.config.txt" $pamDict | nindent 2 }}
+{{- end }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -318,3 +318,5 @@ config:
     launcher-mounts: []
   # -- a map of supervisord .conf files to define custom services. Mounted into the container at /startup/custom/
   startupCustom: {}
+  # -- a map of pam config files. Will be mounted into the container directly / per file, in order to avoid overwriting system pam files
+  pam: {}


### PR DESCRIPTION
Create a `config.pam` values section that allows embedding PAM config files within the main Workbench container

- Creates a configmap with entries
- Mounts each file within `/etc/pam.d` (so the directory is not overwritten) using `subPath`
- add `docs` just target
- fix a typo in the README