### PR TITLE
Moving k8s profile conf to launcher specific location

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.10
+version: 0.2.11
 apiVersion: v2
 appVersion: 2021.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.9
+version: 0.2.10
 apiVersion: v2
-appVersion: 2021.10.0
+appVersion: 2021.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,6 +1,6 @@
 # 0.2.11
 
-- remove "privileged: true", which is not necessary for rstudio-connect server or sessions
+- remove "privileged: true", which is no longer necessary for rstudio-connect server or sessions
 - location for RStudio Connect's KubernetesProfilesConfig file has changed from `/etc/rstudio/launcher.kubernetes.profiles.conf` to `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not conflict with RStudio Workbench
 
 # 0.2.10

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,7 +2,8 @@
 
 - move "privileged: true" into `values.yaml`, because it is no longer necessary
   for rstudio-connect server or sessions when launcher is enabled.
-  - To disable when using the launcher, set `securityContext: {}`
+  - To disable when using the launcher, set `securityContext: null`
+  - NOTE: `securityContext: {}` will not remove the default, because helm values merge objects by default
 - location for RStudio Connect's KubernetesProfilesConfig file has changed from
   `/etc/rstudio/launcher.kubernetes.profiles.conf` to
   `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,7 +1,12 @@
 # 0.2.11
 
-- remove "privileged: true", which is no longer necessary for rstudio-connect server or sessions
-- location for RStudio Connect's KubernetesProfilesConfig file has changed from `/etc/rstudio/launcher.kubernetes.profiles.conf` to `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not conflict with RStudio Workbench
+- move "privileged: true" into `values.yaml`, because it is no longer necessary
+  for rstudio-connect server or sessions when launcher is enabled.
+  - To disable when using the launcher, set `securityContext: {}`
+- location for RStudio Connect's KubernetesProfilesConfig file has changed from
+  `/etc/rstudio/launcher.kubernetes.profiles.conf` to
+  `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not
+  conflict with RStudio Workbench
 
 # 0.2.10
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,7 +1,8 @@
 # 0.2.10
 
 - remove "privileged: true", which is not necessary for rstudio-connect server or sessions
-- location for RStudio Connect's KubernetesProfilesConfig file has changed so as to not conflict with RStudio Workbench
+- location for RStudio Connect's KubernetesProfilesConfig file has changed from `/etc/rstudio/launcher.kubernetes.profiles.conf` to `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not conflict with RStudio Workbench
+- Update default RStudio Connect version to 2021.11.0
 
 # 0.2.9
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,8 @@
+# 0.2.10
+
+- remove "privileged: true", which is not necessary for rstudio-connect server or sessions
+- location for RStudio Connect's KubernetesProfilesConfig file has changed so as to not conflict with RStudio Workbench
+
 # 0.2.9
 
 - Add `imagePullSecrets` value option ([#57](https://github.com/rstudio/helm/issues/57))

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![AppVersion: 2021.11.0](https://img.shields.io/badge/AppVersion-2021.11.0-informational?style=flat-square)
+![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![AppVersion: 2021.11.0](https://img.shields.io/badge/AppVersion-2021.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.10:
+To install the chart with the release name `my-release` at version 0.2.11:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.2.10
+helm install my-release rstudio/rstudio-connect --version=0.2.11
 ```
 
 ## Required Configuration

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -113,7 +113,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | replicas | int | `1` | The number of replica pods to maintain for this service |
 | resources.limits | object | `{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"2Gi"}` | Defines resource limits for the rstudio-connect pod |
 | resources.requests | object | `{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"1Gi"}` | Defines resource requests for the rstudio-connect pod |
-| securityContext | object | `{"privileged":true}` | Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}` |
+| securityContext | object | `{"privileged":true}` | Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: null` |
 | service.annotations | object | `{}` | Annotations that will be added onto the service |
 | service.nodePort | bool | `false` | The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically |
 | service.port | int | `80` | The port to use for the Connect service |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -113,7 +113,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | replicas | int | `1` | The number of replica pods to maintain for this service |
 | resources.limits | object | `{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"2Gi"}` | Defines resource limits for the rstudio-connect pod |
 | resources.requests | object | `{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"1Gi"}` | Defines resource requests for the rstudio-connect pod |
-| securityContext.privileged | bool | `true` |  |
+| securityContext | object | `{"privileged":true}` | Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}` |
 | service.annotations | object | `{}` | Annotations that will be added onto the service |
 | service.nodePort | bool | `false` | The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically |
 | service.port | int | `80` | The port to use for the Connect service |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -113,6 +113,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | replicas | int | `1` | The number of replica pods to maintain for this service |
 | resources.limits | object | `{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"2Gi"}` | Defines resource limits for the rstudio-connect pod |
 | resources.requests | object | `{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"1Gi"}` | Defines resource requests for the rstudio-connect pod |
+| securityContext.privileged | bool | `true` |  |
 | service.annotations | object | `{}` | Annotations that will be added onto the service |
 | service.nodePort | bool | `false` | The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically |
 | service.port | int | `80` | The port to use for the Connect service |

--- a/charts/rstudio-connect/ci/launcher-values-advanced.yaml
+++ b/charts/rstudio-connect/ci/launcher-values-advanced.yaml
@@ -2,6 +2,7 @@ rbac:
   create: true
   serviceAccount:
     create: true
+securityContext: {}
 launcher:
   enabled: true
   customRuntimeYaml:

--- a/charts/rstudio-connect/ci/launcher-values-advanced.yaml
+++ b/charts/rstudio-connect/ci/launcher-values-advanced.yaml
@@ -2,7 +2,7 @@ rbac:
   create: true
   serviceAccount:
     create: true
-securityContext: {}
+securityContext: null
 launcher:
   enabled: true
   customRuntimeYaml:

--- a/charts/rstudio-connect/ci/launcher-values-advanced2.yaml
+++ b/charts/rstudio-connect/ci/launcher-values-advanced2.yaml
@@ -2,7 +2,7 @@ rbac:
   create: true
   serviceAccount:
     create: true
-securityContext: {}
+securityContext: null
 launcher:
   enabled: true
   customRuntimeYaml: |

--- a/charts/rstudio-connect/ci/launcher-values-advanced2.yaml
+++ b/charts/rstudio-connect/ci/launcher-values-advanced2.yaml
@@ -2,6 +2,7 @@ rbac:
   create: true
   serviceAccount:
     create: true
+securityContext: {}
 launcher:
   enabled: true
   customRuntimeYaml: |

--- a/charts/rstudio-connect/ci/launcher-values.yaml
+++ b/charts/rstudio-connect/ci/launcher-values.yaml
@@ -4,4 +4,4 @@ rbac:
     create: true
 launcher:
   enabled: true
-securityContext: {}
+securityContext: null

--- a/charts/rstudio-connect/ci/launcher-values.yaml
+++ b/charts/rstudio-connect/ci/launcher-values.yaml
@@ -4,3 +4,4 @@ rbac:
     create: true
 launcher:
   enabled: true
+securityContext: {}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -62,7 +62,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- /* default launcher configuration */}}
   {{- if .Values.launcher.enabled }}
     {{- $namespace := default $.Release.Namespace .Values.launcher.namespace }}
-    {{- $launcherSettingsDict := dict "Enabled" ("true") "Kubernetes" ("true") "ClusterDefinition" (list "/etc/rstudio-connect/runtime.yaml") "KubernetesNamespace" ($namespace) "KubernetesProfilesConfig" ("/etc/rstudio-connect/launcher.kubernetes.profiles.conf") }}
+    {{- $launcherSettingsDict := dict "Enabled" ("true") "Kubernetes" ("true") "ClusterDefinition" (list "/etc/rstudio-connect/runtime.yaml") "KubernetesNamespace" ($namespace) "KubernetesProfilesConfig" ("/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf") }}
     {{- $launcherDict := dict "Launcher" ( $launcherSettingsDict ) }}
     {{- $pythonSettingsDict := dict "Enabled" ("true") }}
     {{- $pythonDict := dict "Python" ( $pythonSettingsDict ) }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - containerPort: 3939
+        securityContext:
+          {{ toYaml .Values.securityContext | indent 4 }}
         volumeMounts:
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/rstudio-connect.gcfg"

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -78,8 +78,6 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - containerPort: 3939
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/rstudio-connect.gcfg"

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -78,8 +78,10 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - containerPort: 3939
+        {{- with .Values.securityContext }}
         securityContext:
-          {{ toYaml .Values.securityContext | indent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/rstudio-connect.gcfg"

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         ports:
         - containerPort: 3939
         securityContext:
-          {{ toYaml .Values.securityContext | indent 4 }}
+          {{ toYaml .Values.securityContext | indent 10 }}
         volumeMounts:
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/rstudio-connect.gcfg"

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             mountPath: "/etc/rstudio-connect/runtime.yaml"
             subPath: "runtime.yaml"
           - name: rstudio-connect-config
-            mountPath: "/etc/rstudio-connect/launcher.kubernetes.profiles.conf"
+            mountPath: "/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf"
             subPath: "launcher.kubernetes.profiles.conf"
           {{- end }}
           {{- if or .Values.sharedStorage.create .Values.sharedStorage.mount }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -107,7 +107,7 @@ license:
     secret: false
 
 # -- Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when
-# launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}`
+# launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: null`
 securityContext:
   privileged: true
 

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -106,6 +106,8 @@ license:
     # -- secret is an existing secret with a license file in it
     secret: false
 
+# -- Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when
+#    launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}`
 securityContext:
   privileged: true
 

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -107,7 +107,7 @@ license:
     secret: false
 
 # -- Values to set the `securityContext` for Connect pods. It must include "privileged: true" or "CAP_SYS_ADMIN" when
-#    launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}`
+# launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: {}`
 securityContext:
   privileged: true
 

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -106,6 +106,9 @@ license:
     # -- secret is an existing secret with a license file in it
     secret: false
 
+securityContext:
+  privileged: true
+
 prometheusExporter:
   # -- Whether the  prometheus exporter sidecar should be enabled
   enabled: true


### PR DESCRIPTION
**MERGING BLOCKED BY:**: 
- [ ] Not merging until Connect 2021.11.0 release is publically available.
- [ ] Will need to wait for the 2021.11.0 docker image to be available.

Changes:
- remove "privileged: true", which is not necessary for rstudio-connect server or sessions
- location for RStudio Connect's KubernetesProfilesConfig file has changed from `/etc/rstudio/launcher.kubernetes.profiles.conf` to `/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf` so as to not conflict with RStudio Workbench

Connected to: rstudio/connect#19936

Also worth noting that this will probably conflict at some level with #44