### PR TITLE
Fix rsw sessions

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.0-rc05
+version: 0.5.0-rc06
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.0-rc05](https://img.shields.io/badge/Version-0.5.0--rc05-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
+![Version: 0.5.0-rc06](https://img.shields.io/badge/Version-0.5.0--rc06-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.0-rc05:
+To install the chart with the release name `my-release` at version 0.5.0-rc06:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.0-rc05
+helm install my-release rstudio/rstudio-workbench --version=0.5.0-rc06
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -16,7 +16,7 @@
     {{- $sessionSecretVolume := dict "secret" ( dict "name" (printf "%s-session-secret" ( include "rstudio-workbench.fullname" . ) ) ) "secretName" "session-secret" }}
     {{- $sessionSecretVolumeMount := dict "mountPath" .Values.session.defaultSecretMountPath "name" "session-secret" }}
     {{- $sessionSecretVolumeOverride := dict "name" "defaultSessionSecretVolume" "target" "/spec/template/spec/volumes/-" "json" $sessionVolume }}
-    {{- $sessionSecretVolumeMountOverride := dict "name" "defaultSessionVolumeMount" "target" "/spec/template/spec/containers/0/volumeMounts/-" "json" $sessionVolumeMount }}
+    {{- $sessionSecretVolumeMountOverride := dict "name" "defaultSessionSecretVolumeMount" "target" "/spec/template/spec/containers/0/volumeMounts/-" "json" $sessionVolumeMount }}
     {{/* build the actual overrides */}}
     {{- $defaultOverrides = concat $defaultOverrides ( list $sessionSecretVolumeOverride $sessionSecretVolumeMountOverride ) }}
   {{- end }}


### PR DESCRIPTION
the "secret" volume mount was accidentally named the same as the "session" volume mount... so the same volume got mounted twice.

We should probably error on that type of thing in the chart when we template...