### PR TITLE
Fix health check

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.0-rc09
+version: 0.5.0-rc10
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -8,6 +8,9 @@
 - BREAKING: Change RStudio Workbench execution model to use supervisord
 - BREAKING: Add `vscode.conf` defaults. This enables VS Code sessions, which is dependent on your images having
   code-server installed at `/opt/code-server/`
+- Create `diagnostics` values (`diagnostics.enabled` and `diagnostics.directory`) to control diagnostic output
+- Add values to `launcher.kubernetesHealthCheck` to control the behavior of the "Kubernetes Health Check" that launcher
+  runs at startup
 - Enable PAM sessions by default (i.e. `auth-pam-sessions-enabled=1`). This is important for proper home
   directory creation, for instance. Disable by setting `config.server.rserver\.conf.auth-pam-sessions-enabled=0`
 - Add `imagePullSecrets` value option ([#57](https://github.com/rstudio/helm/issues/57))

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.0-rc09](https://img.shields.io/badge/Version-0.5.0--rc09-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
+![Version: 0.5.0-rc10](https://img.shields.io/badge/Version-0.5.0--rc10-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.0-rc09:
+To install the chart with the release name `my-release` at version 0.5.0-rc10:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install --devel my-release rstudio/rstudio-workbench --version=0.5.0-rc09
+helm install --devel my-release rstudio/rstudio-workbench --version=0.5.0-rc10
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/prestart-launcher.bash
+++ b/charts/rstudio-workbench/prestart-launcher.bash
@@ -22,12 +22,17 @@ main() {
   _logf 'Ensuring %s exists' "${dyn_dir}"
   mkdir -p "${dyn_dir}"
 
-  _logf 'Checking kubernetes health via %s' "${k8s_url}"
-  curl -fsSL \
-    -H "Authorization: Bearer ${sa_token}" \
-    --cacert "${cacert}" \
-    "${k8s_url}/healthz" 2>&1 | _indent
-  printf '\n'
+  if [[ -z "${RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK}" ]]; then
+    _logf 'Checking kubernetes health via %s' "${k8s_url}"
+    curl ${RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS} \
+      -H "Authorization: Bearer ${sa_token}" \
+      --cacert "${cacert}" \
+      "${k8s_url}/livez?verbose" 2>&1 | _indent
+    printf '\n'
+  else
+    _logf "Not checking kubernetes health because RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK=${RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK}"
+    printf '\n'
+  fi
 
   _logf 'Generating %s' "${launcher_k8s_conf}"
   cat >"${launcher_k8s_conf}" <<EOF

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -31,13 +31,21 @@ containers:
   {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default $defaultVersion }}"
   env:
-  {{- if .Values.enableDiagnostics }}
+  {{- if .Values.diagnostics.enabled }}
   - name: DIAGNOSTIC_DIR
-    value: "/var/log/rstudio"
+    value: "{{ .Values.diagnostics.directory }}"
   - name: DIAGNOSTIC_ONLY
     value: "true"
   - name: DIAGNOSTIC_ENABLE
     value: "true"
+  {{- end }}
+  {{- if not .Values.launcher.kubernetesHealthCheck.enabled }}
+  - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK
+    value: disabled
+  {{- end }}
+  {{- if .Values.launcher.kubernetesHealthCheck.enabled }}
+  - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
+    value: "{{ join " " .Values.launcher.kubernetesHealthCheck.extraCurlArgs }}"
   {{- end }}
   - name: RSTUDIO_LAUNCHER_NAMESPACE
     value: "{{ default $.Release.Namespace .Values.launcher.namespace }}"

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   shareProcessNamespace: {{ .Values.shareProcessNamespace }}
   restartPolicy: Never
-  {{- $topLevelParams := dict "enableDiagnostics" true "userCreate" true }}
+  {{- $topLevelParams := dict "diagnostics" (dict "enabled" true) "userCreate" true }}
   {{- $disabledObject := dict "enabled" false }}
   {{- $readinessProbe := dict "readinessProbe" $disabledObject }}
   {{- $livenessProbe := dict "livenessProbe" $disabledObject }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -6,6 +6,12 @@ fullnameOverride: ""
 # -- A Workbench version to override the "tag" for the RStudio Workbench image and the session images. Necessary until https://github.com/helm/helm/issues/8194
 versionOverride: ""
 
+# -- Settings for enabling server diagnostics
+diagnostics:
+  enabled: false
+  directory: /var/log/rstudio
+
+
 session:
   # -- Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this
   defaultConfigMount: true
@@ -50,6 +56,10 @@ launcher:
   enabled: true
   # -- allow customizing the namespace that sessions are launched into. Note RBAC and some config issues today
   namespace: ""
+  # -- configuration for the "Kubernetes Health Check" that the launcher entrypoint runs at startup
+  kubernetesHealthCheck:
+    enabled: true
+    extraCurlArgs: ["-fsSL"]
 
 homeStorage:
   # -- whether to create the persistentVolumeClaim for homeStorage


### PR DESCRIPTION
A customer environment had issues with `http_proxy` and `https_proxy` being set causing troubles with our health check. It is possible to set `no_proxy` environment variables (although `curl` does not seem to respect CIDR notation - [some discussion on ambiguity here](https://github.com/curl/curl/issues/1208)), but this will enable turning off the health check entirely or adding arguments to curl - i.e. `--noproxy`, etc.

[Worth noting that `healthz` is deprecated in favor of `livez` and `readyz`](https://kubernetes.io/docs/reference/using-api/health-checks/)

Also document and formalize the previously hidden `enableDiagnostics` flag.

Worth noting that all of this entrypoint script will likely go away once we switch to the new launcher with its ability to catch these values from the environment 🙈 