### PR TITLE
Check storage class

### DIFF
--- a/charts/rstudio-workbench/templates/NOTES.txt
+++ b/charts/rstudio-workbench/templates/NOTES.txt
@@ -38,3 +38,8 @@ NOTE: `.Values.config.server.rserver\.conf.server-license-type` is configured ma
 Please consider removing this configuration value.
 
 {{- end }}
+
+{{- /* check for invalid storage classes */ -}}
+{{- if .Values.homeStorage.create }}
+{{ include "rstudio-library.check-storage-class" (dict "accessModes" .Values.homeStorage.accessModes "storageClassName" .Values.homeStorage.storageClassName "key" "homeStorage" "check" true) }}
+{{- end }}


### PR DESCRIPTION
Close #90 

The motivation: if a user deploys our chart directly onto an EKS cluster setting `homeStorage.create=true`, they will get a not functioning server, a hard to debug situation (have to see that PVC provisioning failed and why), and a hard to fix situation (have to basically delete everything and start over once you have a storage class that supports ReadWriteMany or have set `accessModes` properly - both of which are immutable b/c PVCs cannot be changed once created).

It would be much nicer to give the user an error at install time when they go to use this storage class.

Unfortunately, Kubernetes does not "store" whether a given storage class supports a given access mode. This is documented [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes), but not able to be "looked up" in the Kbuernetes API

As a result, I do a name lookup for ones that we know cause trouble (i.e. `gp2`), as well as provisioners that we know cause trouble (i.e. `kubernetes.io/aws-ebs`).

It's possible that these storage classes change over time, and with different renamings / etc., it is impossible that we catch everything. However, I have seen enough users get tripped up by this to think that it would do us well to catch as many as we can.

Thoughts?


Examples:
```
# success
helm upgrade --install rsw-4 ./charts/rstudio-workbench --set homeStorage.storageClassName=gp2 --set homeStorage.create=true --set 'homeStorage.accessModes[0]'=ReadWriteOnce
Release "rsw-4" has been upgraded. Happy Helming!


# fail b/c specified gp2
helm upgrade --install rsw-4 ./charts/rstudio-workbench --set homeStorage.storageClassName=gp2 --set homeStorage.create=true
Error: UPGRADE FAILED: template: rstudio-workbench/templates/NOTES.txt:44:3: executing "rstudio-workbench/templates/NOTES.txt" at <include "rstudio-library.check-storage-class" (dict "accessModes" .Values.homeStorage.accessModes "storageClassName" .Values.homeStorage.storageClassName "key" "homeStorage" "check" true)>: error calling include: template: rstudio-workbench/templates/_helpers.tpl:439:12: executing "rstudio-library.check-storage-class" at <fail (printf "\n\nThe storage class '%s'%s is known to not support 'ReadWriteMany' PersistentVolumeClaims. This is important for proper disk provisioning. \nFix by setting `%s.accessModes` appropriately, changing `%s.storageClassName` or disabling this check with `%s.checkAccessModes: false`\n\n" $storageClassName $isDefault $key $key $key)>: error calling fail: HELM_ERR_START

The storage class 'gp2' is known to not support 'ReadWriteMany' PersistentVolumeClaims. This is important for proper disk provisioning. 
Fix by setting `homeStorage.accessModes` appropriately, changing `homeStorage.storageClassName` or disabling this check with `homeStorage.checkAccessModes: false`

HELM_ERR_END

# fail b/c default is gp2
✗ helm upgrade --install rsw-4 ./charts/rstudio-workbench  --set homeStorage.create=true
Error: UPGRADE FAILED: template: rstudio-workbench/templates/NOTES.txt:42:3: executing "rstudio-workbench/templates/NOTES.txt" at <include "rstudio-library.check-storage-class" .>: error calling include: template: rstudio-workbench/templates/_helpers.tpl:425:10: executing "rstudio-library.check-storage-class" at <fail (printf "\n\nThe storage class '%s'%s is known to not support ReadWriteMany PersistentVolumeClaims. \nFix by setting `accessModes` appropriately, changing `storageClassName` or disabling this check with `checkAccessModes: false\n\n`" $storageClassName $isDefault)>: error calling fail: HELM_ERR_START

The storage class 'gp2' (the default on this cluster) is known to not support 'ReadWriteMany' PersistentVolumeClaims. 
Fix by setting `homeStorage.accessModes` appropriately, changing `homeStorage.storageClassName` or disabling this check with `homeStorage.checkAccessModes: false`

HELM_ERR_END


```

**EDIT:** Plan is to refactor into the `rstudio-library` chart, although only rolling out for rstudio-workbench for now, so that we can test a bit before integrating with Connect and RSPM.