### PR TITLE
Add support for generating a ServiceMonitor CRD for RSPM

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.2.8
+version: 0.2.9
 apiVersion: v2
 appVersion: 2021.09.0-1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.9
+
+- Add `serviceMonitor` values for use with a Prometheus Operator
+
 # 0.2.8
 
 - Update `rstudio-library` chart dependency

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.8:
+To install the chart with the release name `my-release` at version 0.2.9:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.2.8
+helm install my-release rstudio/rstudio-pm --version=0.2.9
 ```
 
 ## Required Configuration
@@ -121,6 +121,9 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | service.nodePort | bool | `false` | The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
 | service.type | string | `"NodePort"` | The service type (NodePort, LoadBalancer, etc.) |
+| serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
+| serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
+| serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Operator is running). Defaults to the release namespace |
 | sharedStorage.accessModes | list | `["ReadWriteMany"]` | accessModes defined for the storage PVC (represented as YAML) |
 | sharedStorage.create | bool | `false` | whether to create the persistentVolumeClaim for shared storage |
 | sharedStorage.mount | bool | `false` | Whether the persistentVolumeClaim should be mounted (even if not created) |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - containerPort: 4242
+{{- if .Values.config.Metrics.Enabled }}
+        - name: metrics
+          containerPort: 2112
+{{- end }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/charts/rstudio-pm/templates/servicemonitor.yaml
+++ b/charts/rstudio-pm/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.config.Metrics.Enabled .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rstudio-pm.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "rstudio-pm.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "rstudio-pm.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -20,4 +20,8 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
     targetPort: 4242
+{{- if .Values.config.Metrics.Enabled }}
+  - name: metrics
+    port: 2112
+{{- end }}
 ---

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -147,6 +147,16 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+serviceMonitor:
+  # -- Whether to create a ServiceMonitor CRD for use with a Prometheus Operator
+  enabled: false
+  # -- Namespace to create the ServiceMonitor in (usually the same as the one in
+  # which the Operator is running). Defaults to the release namespace
+  namespace: ""
+  # -- additionalLabels normally includes the release name of the Prometheus
+  # Operator
+  additionalLabels: {}
+  #   release: kube-prometheus-stack
 
 # -- config is a nested map of maps that generates the rstudio-pm.gcfg file
 config:


### PR DESCRIPTION
This is required in clusters that use the Prometheus Operator instead of a regular Prometheus server. It's also a very common feature of public Helm charts for applications with Prometheus metrics.

Note that there are many other fields [in this CRD][0] that I have not yet exposed via `values.yml`. In researching comparable Helm charts, I found that these fields were very inconsistently exposed, so I decided to start with the smallest useful subset instead.

Also, I personally never used any of the other fields when operating my own clusters, so I'm even more biased towards simplicity here.

~This is a draft PR because I wrote it all from memory and we should actually test it against a real cluster with a local Operator before merging.~

[0]: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint