### PR TITLE
Add support for adding arbitrary labels to RStudio Workbench pods

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.0-rc10
+version: 0.5.0-rc11
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -21,6 +21,7 @@
   etc.) (`config.sessionSecret`)
 - Update README to make `job-json-overrides`, profiles, user provisioning, etc. more clear
 - Update `rstudio-library` chart dependency
+- Add a `pod.labels` values option ([#101](https://github.com/rstudio/helm/issues/101))
 
 # 0.4.6
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.0-rc10](https://img.shields.io/badge/Version-0.5.0--rc10-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
+![Version: 0.5.0-rc11](https://img.shields.io/badge/Version-0.5.0--rc11-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.0-rc10:
+To install the chart with the release name `my-release` at version 0.5.0-rc11:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install --devel my-release rstudio/rstudio-workbench --version=0.5.0-rc10
+helm install --devel my-release rstudio/rstudio-workbench --version=0.5.0-rc11
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -363,8 +363,9 @@ config:
 | loadBalancer.sleepDuration | int | `15` |  |
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | nodeSelector | object | `{}` |  |
-| pod.annotations | object | `{}` | podAnnotations is a map of keys / values that will be added as annotations to the rstudio-pm pods |
+| pod.annotations | object | `{}` | Additional annotations to add to the rstudio-workbench pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
+| pod.labels | object | `{}` | Additional labels to add to the rstudio-workbench pods |
 | pod.sidecar | bool | `false` | sidecar is an array of containers that will be run alongside the main container |
 | pod.volumeMounts | list | `[]` | volumeMounts is injected as-is into the "volumeMounts:" component of the pod.container spec |
 | pod.volumes | list | `[]` | volumes is injected as-is into the "volumes:" component of the pod.container spec |

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -22,6 +22,8 @@ pod:
   volumes:
     - name: key
       emptyDir: {}
+  labels:
+    app.kubernetes.io/part-of: rstudio-team
   annotations:
     testannotation2: three
   sidecar:

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
 {{ include "rstudio-workbench.pod.annotations" . | indent 8 }}
       labels:
         {{- include "rstudio-workbench.selectorLabels" . | nindent 8 }}
+      {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ include "rstudio-workbench.fullname" . }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -232,7 +232,7 @@ pod:
   volumes: []
   # -- volumeMounts is injected as-is into the "volumeMounts:" component of the pod.container spec
   volumeMounts: []
-  # -- podAnnotations is a map of keys / values that will be added as annotations to the rstudio-pm pods
+  # -- Additional annotations to add to the rstudio-workbench pods
   annotations: {}
   # -- Additional labels to add to the rstudio-workbench pods
   labels: {}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -234,6 +234,8 @@ pod:
   volumeMounts: []
   # -- podAnnotations is a map of keys / values that will be added as annotations to the rstudio-pm pods
   annotations: {}
+  # -- Additional labels to add to the rstudio-workbench pods
+  labels: {}
   # -- sidecar is an array of containers that will be run alongside the main container
   sidecar: false
 


### PR DESCRIPTION
This should enable users that have additional integrations (like the Azure AD feature discussed in #101) that need to be injected via pod labels.

Closes #101.