### PR TITLE
Enable use-templating by default for launcher

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.0-rc14
+version: 0.5.0-rc15
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/prestart-launcher.bash
+++ b/charts/rstudio-workbench/prestart-launcher.bash
@@ -40,6 +40,7 @@ api-url=${k8s_url}
 auth-token=${sa_token}
 kubernetes-namespace=${launcher_ns}
 certificate-authority=${ca_string}
+use-templating=1
 EOF
 
   _logf 'Configuring certs'


### PR DESCRIPTION
Enable templating by adding `use-templating=1` to the
restart-launcher.bash script. This will allow us to use templates that 
allow kubernetes configuration such as annotations that can be hardcoded
or dynamically loaded.