### PR TITLE
Simplify handling of Service annotations for RSPM and improve their documentation

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.2.9
+version: 0.2.10
 apiVersion: v2
 appVersion: 2021.09.0-1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.10
+
+- Improve the documentation for `service.annotations`.
+
 # 0.2.9
 
 - Add `serviceMonitor` values for use with a Prometheus Operator

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.9:
+To install the chart with the release name `my-release` at version 0.2.10:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.2.9
+helm install my-release rstudio/rstudio-pm --version=0.2.10
 ```
 
 ## Required Configuration
@@ -117,7 +117,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
-| service.annotations | object | `{}` | The annotations for the service |
+| service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.nodePort | bool | `false` | The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
 | service.type | string | `"NodePort"` | The service type (NodePort, LoadBalancer, etc.) |

--- a/charts/rstudio-pm/templates/_helpers.tpl
+++ b/charts/rstudio-pm/templates/_helpers.tpl
@@ -75,12 +75,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}
 {{- end -}}
 
-{{- define "rstudio-pm.annotations" -}}
-{{- range $key,$value := $.Values.service.annotations -}}
-{{ $key }}: {{ $value | quote }}
-{{ end }}
-{{- end -}}
-
 {{- define "rstudio-pm.pod.annotations" -}}
 {{- range $key,$value := $.Values.pod.annotations -}}
 {{ $key }}: {{ $value | quote }}

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "rstudio-pm.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
   annotations:
-{{ include "rstudio-pm.annotations" . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -62,7 +62,7 @@ license:
 service:
   # -- The service type (NodePort, LoadBalancer, etc.)
   type: NodePort
-  # -- The annotations for the service
+  # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
   # -- The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically
   nodePort: false


### PR DESCRIPTION
I've added mention of [internal load balancer annotations](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) to the documentation, given that this is likely to be the most common reason to use this field.

In addition, the existing YAML helper is not actually necessary and has a confusing name, so I removed it.