### PR TITLE
Overhaul RSPM service generation

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.2.9
+version: 0.3.0
 apiVersion: v2
 appVersion: 2021.09.0-1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,10 @@
+# 0.3.0
+
+- BREAKING: The generated service will now have type `ClusterIP` by default.
+- Add support for setting the `loadBalancerIP` or `clusterIP`.
+- Ignore `nodePort` settings when the service is not a `NodePort`.
+- Improve the documentation for some service-related settings.
+
 # 0.2.9
 
 - Add `serviceMonitor` values for use with a Prometheus Operator

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: 2021.09.0-1](https://img.shields.io/badge/AppVersion-2021.09.0--1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.9:
+To install the chart with the release name `my-release` at version 0.3.0:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.2.9
+helm install my-release rstudio/rstudio-pm --version=0.3.0
 ```
 
 ## Required Configuration
@@ -117,10 +117,12 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
-| service.annotations | object | `{}` | The annotations for the service |
-| service.nodePort | bool | `false` | The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically |
+| service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
+| service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
+| service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |
+| service.nodePort | bool | `false` | The explicit nodePort to use for `service.type` NodePort. If not provided, Kubernetes will choose one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
-| service.type | string | `"NodePort"` | The service type (NodePort, LoadBalancer, etc.) |
+| service.type | string | `"ClusterIP"` | The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to expose the service using your cloud provider's load balancer) |
 | serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
 | serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Operator is running). Defaults to the release namespace |

--- a/charts/rstudio-pm/templates/_helpers.tpl
+++ b/charts/rstudio-pm/templates/_helpers.tpl
@@ -75,12 +75,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}
 {{- end -}}
 
-{{- define "rstudio-pm.annotations" -}}
-{{- range $key,$value := $.Values.service.annotations -}}
-{{ $key }}: {{ $value | quote }}
-{{ end }}
-{{- end -}}
-
 {{- define "rstudio-pm.pod.annotations" -}}
 {{- range $key,$value := $.Values.pod.annotations -}}
 {{ $key }}: {{ $value | quote }}

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -12,6 +12,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   selector:
     {{- include "rstudio-pm.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -18,9 +18,9 @@ spec:
   - protocol: TCP
     name: rspm
     port: {{ .Values.service.port }}
-    {{- if .Values.service.nodePort }}
+{{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+{{- end }}
     targetPort: 4242
 {{- if .Values.config.Metrics.Enabled }}
   - name: metrics

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "rstudio-pm.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
   annotations:
-{{ include "rstudio-pm.annotations" . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -64,6 +64,11 @@ service:
   type: NodePort
   # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
+  # -- The cluster-internal IP to use with `service.type` ClusterIP
+  clusterIP: ""
+  # -- The external IP to use with `service.type` LoadBalancer, when supported
+  # by the cloud provider
+  loadBalancerIP: ""
   # -- The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically
   nodePort: false
   # -- The Service port. This is the port your service will run under.

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -69,7 +69,8 @@ service:
   # -- The external IP to use with `service.type` LoadBalancer, when supported
   # by the cloud provider
   loadBalancerIP: ""
-  # -- The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically
+  # -- The explicit nodePort to use for `service.type` NodePort. If not
+  # provided, Kubernetes will choose one automatically
   nodePort: false
   # -- The Service port. This is the port your service will run under.
   port: 80

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -60,8 +60,9 @@ license:
     secret: false
 
 service:
-  # -- The service type (NodePort, LoadBalancer, etc.)
-  type: NodePort
+  # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
+  # expose the service using your cloud provider's load balancer)
+  type: ClusterIP
   # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
   # -- The cluster-internal IP to use with `service.type` ClusterIP

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -62,7 +62,7 @@ license:
 service:
   # -- The service type (NodePort, LoadBalancer, etc.)
   type: NodePort
-  # -- The annotations for the service
+  # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
   # -- The nodePort (for service type NodePort). If not provided, Kubernetes will decide one automatically
   nodePort: false


### PR DESCRIPTION
This PR contains the following changes, bundling the last one from #121:

* Use a `ClusterIP` service by default instead of a `NodePort`. See below.
* Add support for controlling [`loadBalancerIP`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) and [`clusterIP`](https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address), which are commonly-used service features.
* Ignore nodePort settings when the service type is not `NodePort`. Otherwise, this will generate server-side validation errors. It's debatable whether we should just let this issue bubble up to users, but the general conventions in the Helm community seem to lean towards "be liberal in what you accept", so that's what I'd go by here as well.
* Simplify handling of Service annotations. The existing YAML helper is not actually necessary and has a confusing name, so I removed it.
* Tweak documentation for `service.nodePort` and `service.annotations`.

Since the first of these is a breaking change, I bumped the minor version for the chart.

## Moving to ClusterIP

`ClusterIP` is the Kubernetes default, exposing the service in-cluster only. This is a secure, well-understood default. For external users, there are a few options:

* Use an `Ingress`. We support this already and it works with `ClusterIP`.

* Use a `LoadBalancer`. This can be expensive so it makes a poor default.

* Use a `NodePort` and some kind of external load balancing solution.

It seems like the last route (which is the current default) is much more uncommon than the first two, so I'd advocate for this change.

In addition:

* `NodePorts` are a very limited cluster resource, so we should avoid consuming them if we can avoid it.

* Defaulting to `NodePort` is a poor security choice, especially if we have users that don't understand the consequences.