### PR TITLE
add pod affinity definition

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.19
+version: 0.2.20
 apiVersion: v2
 appVersion: 2021.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.20
+
+- Add `pod.affinity` value to define affinity for the pod
+
 # 0.2.19
 
 - Update `rstudio-library` chart version. This adds support for `extraObjects`

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -102,7 +102,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-connect pods |
 | pod.env | list | `[]` | An array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.haste | bool | `true` | A helper that defines the RSTUDIO_CONNECT_HASTE environment variable |
-| pod.labels | object | `{}` | Additional labels to add to the rstudio-workbench pods |
+| pod.labels | object | `{}` | Additional labels to add to the rstudio-connect pods |
 | pod.serviceAccountName | bool | `false` | A string representing the service account of the pod spec |
 | pod.sidecar | bool | `false` | An array of containers that will be run alongside the main pod |
 | pod.volumeMounts | list | `[]` | An array of maps that is injected as-is into the "volumeMounts" component of the pod spec |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![AppVersion: 2021.12.1](https://img.shields.io/badge/AppVersion-2021.12.1-informational?style=flat-square)
+![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![AppVersion: 2021.12.1](https://img.shields.io/badge/AppVersion-2021.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.19:
+To install the chart with the release name `my-release` at version 0.2.20:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.2.19
+helm install my-release rstudio/rstudio-connect --version=0.2.20
 ```
 
 ## Required Configuration
@@ -98,6 +98,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | license.server | bool | `false` | server is the <hostname>:<port> for a license server |
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | Used to configure the container's livenessProbe. Only included if enabled = true |
 | nameOverride | string | `""` | The name of the chart deployment (can be overridden) |
+| pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-connect pods |
 | pod.env | list | `[]` | An array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.haste | bool | `true` | A helper that defines the RSTUDIO_CONNECT_HASTE environment variable |

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -39,6 +39,14 @@ pod:
     - name: test
       image: "busybox"
       imagePullPolicy: "IfNotPresent"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: rstudio-team
+          topologyKey: kubernetes.io/hostname
 
 ingress:
   enabled: true

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.pod.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.rbac.create .Values.launcher.enabled }}
       {{ $serviceAccountName := default .Values.rbac.serviceAccount.name (include "rstudio-connect.fullname" .) }}
       serviceAccountName: {{ $serviceAccountName }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -85,6 +85,8 @@ pod:
   labels: {}
   # -- An array of containers that will be run alongside the main pod
   sidecar: false
+  # -- A map used verbatim as the pod's "affinity" definition
+  affinity: {}
 
 # -- The pod's run command. By default, it uses the container's default
 command: []

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -81,7 +81,7 @@ pod:
   serviceAccountName: false
   # -- Additional annotations to add to the rstudio-connect pods
   annotations: {}
-  # -- Additional labels to add to the rstudio-workbench pods
+  # -- Additional labels to add to the rstudio-connect pods
   labels: {}
   # -- An array of containers that will be run alongside the main pod
   sidecar: false


### PR DESCRIPTION
define the `pod.affinity` value as discussed [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
pass along to the pod deployment
bump version

(if we like this pattern, I will go ahead and add to the other charts as well)