### PR TITLE
Fix rsw ha

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.3
+version: 0.5.4
 apiVersion: v2
 appVersion: 2021.09.0-351.pro6
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,10 @@
+# 0.5.4
+
+- BUGFIX: address an important issue in RStudio Workbench load balancing
+  - Ever since 0.5.0, we did not create a `load-balancer` file
+  - This means that even "HA" installations of Workbench would function like independent nodes
+  - We now touch an empty file and let the nodes report themselves to the database in this case
+
 # 0.5.3
 
 - Make `startupProbe`, `readinessProbe` and `livenessProbe` more configurable ([#97](https://github.com/rstudio/helm/issues/97))

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 2021.09.0-351.pro6](https://img.shields.io/badge/AppVersion-2021.09.0--351.pro6-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.3:
+To install the chart with the release name `my-release` at version 0.5.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.3
+helm install my-release rstudio/rstudio-workbench --version=0.5.4
 ```
 
 ## Required Configuration
@@ -356,14 +356,7 @@ config:
 | license.key | string | `nil` | key is the license to use |
 | license.server | bool | `false` | server is the <hostname>:<port> for a license server |
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/health-check","port":8787},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | livenessProbe is used to configure the container's livenessProbe |
-| loadBalancer.appLabelKey | string | `"app.kubernetes.io/name"` |  |
-| loadBalancer.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the loadBalancer sidecar spec |
 | loadBalancer.forceEnabled | bool | `false` | whether to force the loadBalancer to be enabled. Otherwise requires replicas > 1. Worth setting if you are HA but may only have one node |
-| loadBalancer.image.imagePullPolicy | string | `"IfNotPresent"` | the imagePullPolicy to use for the side-car pod image |
-| loadBalancer.image.repository | string | `"rstudio/rstudio-server-load-balancer-manager"` | the repository to use for the side-car pod image |
-| loadBalancer.image.tag | string | `"2.2"` | the tag to use for the side-car pod image |
-| loadBalancer.securityContext.capabilities.add[0] | string | `"SYS_PTRACE"` |  |
-| loadBalancer.sleepDuration | int | `15` |  |
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | nodeSelector | object | `{}` |  |
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-workbench pods |

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -21,7 +21,7 @@ main() {
     rm -vf "${launcher_pub}" 2>&1 | _indent
   fi
 
-  if [[ -z "$RSW_LOAD_BALANCING" ]]; then
+  if [[ -n "$RSW_LOAD_BALANCING" ]]; then
     _logf "Enabling load-balancing by making sure that the /mnt/load-balancer/rstudio/load-balancer file exists"
     mkdir -p /mnt/load-balancer/rstudio/
     touch "/mnt/load-balancer/rstudio/load-balancer"

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -21,6 +21,12 @@ main() {
     rm -vf "${launcher_pub}" 2>&1 | _indent
   fi
 
+  if [[ -z "$RSW_LOAD_BALANCING" ]]; then
+    _logf "Enabling load-balancing by making sure that the /mnt/load-balancer/rstudio/load-balancer file exists"
+    mkdir -p /mnt/load-balancer/rstudio/
+    touch "/mnt/load-balancer/rstudio/load-balancer"
+  fi
+
   _logf 'Preparing dirs'
   mkdir -p \
     /var/lib/rstudio-server/monitor/log

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -63,6 +63,10 @@ containers:
   - name: RSW_TESTUSER
     value: ""
   {{- end }}
+  {{- if or (gt .Values.replicas 1) .Values.loadBalancer.forceEnabled }}
+  - name: RSW_LOAD_BALANCING
+    value: true
+  {{- end }}
   - name: XDG_CONFIG_DIRS
     value: "{{ template "rstudio-workbench.xdg-config-dirs" .}}"
   {{- if .Values.pod.env }}

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -65,7 +65,7 @@ containers:
   {{- end }}
   {{- if or (gt (int .Values.replicas) 1) .Values.loadBalancer.forceEnabled }}
   - name: RSW_LOAD_BALANCING
-    value: true
+    value: "true"
   {{- end }}
   - name: XDG_CONFIG_DIRS
     value: "{{ template "rstudio-workbench.xdg-config-dirs" .}}"

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -63,7 +63,7 @@ containers:
   - name: RSW_TESTUSER
     value: ""
   {{- end }}
-  {{- if or (gt .Values.replicas 1) .Values.loadBalancer.forceEnabled }}
+  {{- if or (gt (int .Values.replicas) 1) .Values.loadBalancer.forceEnabled }}
   - name: RSW_LOAD_BALANCING
     value: true
   {{- end }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -169,22 +169,6 @@ readinessProbe:
 loadBalancer:
   # -- whether to force the loadBalancer to be enabled. Otherwise requires replicas > 1. Worth setting if you are HA but may only have one node
   forceEnabled: false
-  appLabelKey: "app.kubernetes.io/name"
-  sleepDuration: 15
-  # -- env is an array of maps that is injected as-is into the "env:" component of the loadBalancer sidecar spec
-  env: []
-  securityContext:
-    capabilities:
-      add:
-        # necessary for sidecar container to function properly in HA
-        - SYS_PTRACE
-  image:
-    # -- the repository to use for the side-car pod image
-    repository: rstudio/rstudio-server-load-balancer-manager
-    # -- the tag to use for the side-car pod image
-    tag: "2.2"
-    # -- the imagePullPolicy to use for the side-car pod image
-    imagePullPolicy: IfNotPresent
 
 # -- command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup
 command: []


### PR DESCRIPTION
pass information to the workbench pod so that it can create the load-balancer file

we omitted this (big woops) on the shift during Ghost Orchid, and forgot to touch the file
this means that workbench has been functioning in a "clusterless" capacity for the most-part

close #137 