### PR TITLE
add daemonsets for prepulling images

### DIFF
--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -15,7 +15,7 @@ They differ only in which repository image they re-pull. This differs based on:
 - Product version
 
 Feel free to download one of these files and modify it for your purposes. It is important that your
-daemonset references the exact same images that are used by your RStudio Workbench installation.
+daemonset references the exact same images that are used by your RStudio Workbench installation to ensure the image you are using is updated.  
 
 ### What is it
 
@@ -24,7 +24,7 @@ A
 runs a single pod on every node of a Kubernetes cluster. In this case, we
 deploy a daemonset that has an `initContainer` with `imagePullPolicy: "Always"`
 that runs a simple `echo` command. Then the `pause` container takes over, and
-nothing else happens for the life of the daemonset.
+nothing else happens for the life of the daemonset. When run in your kubernetes environment, this daemonset will force the specified image to be updated on each node. Later when sessions are started on that same node, they will use the updated image. 
 
 ### Usage
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -1,0 +1,63 @@
+# YAML Files
+
+## Daemonset for `r-session-complete`
+
+The following daemonsets are defined for either pre-pulling or forcing a re-pull of existing images
+
+- [`daemonset-r-session-complete-dockerhub`](daemonset-r-session-complete-dockerhub)
+- [`daemonset-r-session-complete-ghcr`](daemonset-r-session-complete-ghcr)
+
+They differ only in which repository image they re-pull. This differs based on:
+
+- Repository: `ghcr.io` (GitHub container registry) or `DockerHub`.
+    - `DockerHub` images look like `rstudio/r-session-complete:2021.09.2-382.pro1`
+    - `ghcr.io` images look like `ghcr.io/rstudio/r-session-complete:2021.09.2-382.pro1`
+- Product version
+
+Feel free to download one of these files and modify it for your purposes. It is important that your
+daemonset references the exact same images that are used by your RStudio Workbench installation.
+
+### What is it
+
+A
+[daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+runs a single pod on every node of a Kubernetes cluster. In this case, we
+deploy a daemonset that has an `initContainer` with `imagePullPolicy: "Always"`
+that runs a simple `echo` command. Then the `pause` container takes over, and
+nothing else happens for the life of the daemonset.
+
+### Usage
+
+- Let's say that my Workbench installation uses images `rstudio/r-session-complete:2021.09.2-382.pro1`
+- I would choose the repository (`DockerHub`) and product version (`2021.09.2-382.pro1`)
+- This would lead me to the file [`daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml`](./daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml)
+- I would get the "Raw" version of the file, and either download it or copy the URL. In this case, I would get:
+
+https://raw.githubusercontent.com/rstudio/helm/main/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+
+- Apply this daemonset to my kubernetes cluster in the desired namespace (`default` in this case):
+```
+kubectl apply -n default -f https://raw.githubusercontent.com/rstudio/helm/main/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+
+# look at the status of the daemonset
+kubectl -n default get pods
+```
+
+- When finished, if I do not want to keep the daemonset around:
+```
+kubectl delete -n default -f https://raw.githubusercontent.com/rstudio/helm/main/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+```
+
+### Simple Usage for DockerHub
+
+- Modify the below URL to select your desired product version
+
+```
+kubectl apply -n default -f https://raw.githubusercontent.com/rstudio/helm/main/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+
+# look at the status of the daemonset
+kubectl -n default get pods
+
+# When finished, if I do not want to keep the daemonset around:
+# kubectl delete -n default -f https://raw.githubusercontent.com/rstudio/helm/main/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+```

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1056-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1056-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "OoJvOOvxdV"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.3.1056-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1073-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1073-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "3gu1TjylF6"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.3.1073-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1093-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.1093-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "I7c6YhiL9E"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.3.1093-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.959-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.959-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "xEVJRfe5GJ"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.3.959-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.959-2.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.3.959-2.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "tj26ttyhpA"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.3.959-2
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "PdSXMZO5GV"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.1103-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-3.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-3.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "QOqp7yuUkm"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.1103-3
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-4.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1103-4.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "JxnqofmS6A"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.1103-4
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1106-5.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1106-5.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "isGr7iyvdN"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.1106-5
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1717-3.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.1717-3.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "Cj2bfzmi71"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.1717-3
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.702-1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-1.4.702-1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "mDqdyJ4lVS"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-1.4.702-1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.0-351.pro6.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.0-351.pro6.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "eEEzz4fRZL"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-2021.09.0-351.pro6
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.1-372.pro1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.1-372.pro1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "jd1pMBK3l1"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-2021.09.1-372.pro1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "jqmog9PWXj"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-2021.09.2-382.pro1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-latest.yaml
+++ b/examples/yaml/daemonset-r-session-complete-dockerhub/prepull-rstudio-r-session-complete-bionic-latest.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "jqmog9PWXj"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: rstudio/r-session-complete:bionic-latest
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-1.4.1717-3.yaml
+++ b/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-1.4.1717-3.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "kPQExFafgv"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: ghcr.io/rstudio/r-session-complete:bionic-1.4.1717-3
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.0-351.pro6.yaml
+++ b/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.0-351.pro6.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "evuYD0F2LR"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: ghcr.io/rstudio/r-session-complete:bionic-2021.09.0-351.pro6
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.1-372.pro1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.1-372.pro1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "ZqBo9AvHrQ"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: ghcr.io/rstudio/r-session-complete:bionic-2021.09.1-372.pro1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
+++ b/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-2021.09.2-382.pro1.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "01Jrnhp0Rg"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: ghcr.io/rstudio/r-session-complete:bionic-2021.09.2-382.pro1
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause

--- a/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-latest.yaml
+++ b/examples/yaml/daemonset-r-session-complete-ghcr/prepull-ghcr-rstudio-r-session-complete-bionic-latest.yaml
@@ -1,0 +1,28 @@
+---
+# Source: prepull-daemonset/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-daemonset
+  labels:
+    app: prepull-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: prepull-daemonset
+  template:
+    metadata:
+      annotations:
+        rollme: "01Jrnhp0Rg"
+      labels:
+        name: prepull-daemonset
+    spec:
+      initContainers:
+        - name: prepull-prepull-image
+          image: ghcr.io/rstudio/r-session-complete:bionic-latest
+          imagePullPolicy: Always
+          command: ["echo"]
+          args: ["Finished pre-pull"]
+      containers:
+        - name: pause
+          image: gcr.io/google_containers/pause


### PR DESCRIPTION
this can also be used to "force a repull" of images that have been cached on the cluster. Say... in the case that you need a security patch 😅 