### PR TITLE
add an rsw example

### DIFF
--- a/examples/workbench/rstudio-workbench-with-pv.yaml
+++ b/examples/workbench/rstudio-workbench-with-pv.yaml
@@ -1,0 +1,40 @@
+# this example deploys RStudio Workbench with a PersistentVolume
+# 
+# the PersistentVolume allows setting NFS mountOptions
+# it creates a storage class that RStudio Workbench then takes advantage of
+
+homeStorage:
+  create: true
+  storageClassName: "nfs-workbench-home-pv"
+  requests:
+    storage: "64Gi"
+
+# this is evaluated as a template
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: nfs-workbench-home-pv
+    spec:
+      capacity:
+        storage: {{ .Values.homeStorage.requests.storage }}
+      volumeMode: Filesystem
+      accessModes:
+        - ReadWriteMany
+      persistentVolumeReclaimPolicy: Retain
+      storageClassName: nfs-workbench-home-pv
+      mountOptions:
+        - rw
+        - lookupcache=pos
+        - vers=4
+        - noac
+        - actimeo=1
+      nfs:
+        path: /
+        server: nfs.server.example.com
+
+config:
+  server:
+    rserver.conf:
+      server-shared-storage-path: /home/rstudio-shared-storage/


### PR DESCRIPTION
useful for customers who need to set nfs mount options

The PersistentVolume/PersistentVolumeClaim allows mounting options because [nfs volumes do not](https://github.com/kubernetes/kubernetes/issues/96284)

- `extraObjects` creates the PV
- the `homeStorage` PVC references the `storageClassName` created by the PV
- the RSW pod and the session pods reference the PVC