### PR TITLE
Add default mode

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.12
+version: 0.5.13
 apiVersion: v2
 appVersion: 2022.02.1-461.pro1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,8 @@
+# 0.5.13
+
+- Allow specifying `defaultMode` for most/all configMap and secret mounts
+  - this _should_ be backwards compatible. Please let us know if any issues arise
+
 # 0.5.12
 
 - Allow Launcher to Auto Configure Kubernetes variables

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,6 +2,9 @@
 
 - Allow specifying `defaultMode` for most/all configMap and secret mounts
   - this _should_ be backwards compatible. Please let us know if any issues arise
+  - use cases include adding executable startup scripts, additional services,
+    changing access for files to be more/less secure, changing permissions in
+    accordance with different runAs, runAsGroup config.
 
 # 0.5.12
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.12](https://img.shields.io/badge/Version-0.5.12-informational?style=flat-square) ![AppVersion: 2022.02.1-461.pro1](https://img.shields.io/badge/AppVersion-2022.02.1--461.pro1-informational?style=flat-square)
+![Version: 0.5.13](https://img.shields.io/badge/Version-0.5.13-informational?style=flat-square) ![AppVersion: 2022.02.1-461.pro1](https://img.shields.io/badge/AppVersion-2022.02.1--461.pro1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.12:
+To install the chart with the release name `my-release` at version 0.5.13:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.12
+helm install my-release rstudio/rstudio-workbench --version=0.5.13
 ```
 
 ## Required Configuration
@@ -323,6 +323,7 @@ config:
 | affinity | object | `{}` |  |
 | args | list | `[]` | args is the pod container's run arguments. |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
+| config.defaultMode | object | `{"jobJsonOverrides":420,"pam":420,"prestart":493,"secret":384,"server":420,"session":420,"sessionSecret":272,"startup":493,"userProvisioning":384}` | defaultMode used for mounting the various configuration configmaps |
 | config.pam | object | `{}` | a map of pam config files. Will be mounted into the container directly / per file, in order to avoid overwriting system pam files |
 | config.profiles | object | `{}` | a map of server-scoped config files (akin to `config.server`), but with specific behavior that supports profiles. See README for more information. |
 | config.secret | object | `{"database.conf":{}}` | a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -323,7 +323,6 @@ config:
 | affinity | object | `{}` |  |
 | args | list | `[]` | args is the pod container's run arguments. |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
-| config.defaultMode | object | `{"jobJsonOverrides":420,"pam":420,"prestart":493,"secret":384,"server":420,"session":420,"sessionSecret":272,"startup":493,"userProvisioning":384}` | defaultMode used for mounting the various configuration configmaps |
 | config.defaultMode.jobJsonOverrides | int | 0644 | default mode for jobJsonOverrides config |
 | config.defaultMode.pam | int | 0644 | default mode for pam scripts |
 | config.defaultMode.prestart | int | 0755 | default mode for prestart config |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -324,6 +324,15 @@ config:
 | args | list | `[]` | args is the pod container's run arguments. |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
 | config.defaultMode | object | `{"jobJsonOverrides":420,"pam":420,"prestart":493,"secret":384,"server":420,"session":420,"sessionSecret":272,"startup":493,"userProvisioning":384}` | defaultMode used for mounting the various configuration configmaps |
+| config.defaultMode.jobJsonOverrides | int | 0644 | default mode for jobJsonOverrides config |
+| config.defaultMode.pam | int | 0644 | default mode for pam scripts |
+| config.defaultMode.prestart | int | 0755 | default mode for prestart config |
+| config.defaultMode.secret | int | 0600 | default mode for secrets |
+| config.defaultMode.server | int | 0644 | default mode for server config |
+| config.defaultMode.session | int | 0644 | default mode for session files |
+| config.defaultMode.sessionSecret | int | 0420 | default mode for session secrets |
+| config.defaultMode.startup | int | 0755 | default mode for startup config |
+| config.defaultMode.userProvisioning | int | 0600 | default mode for userProvisioning config |
 | config.pam | object | `{}` | a map of pam config files. Will be mounted into the container directly / per file, in order to avoid overwriting system pam files |
 | config.profiles | object | `{}` | a map of server-scoped config files (akin to `config.server`), but with specific behavior that supports profiles. See README for more information. |
 | config.secret | object | `{"database.conf":{}}` | a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -108,6 +108,16 @@ loadBalancer:
       value: "false"
 
 config:
+  defaultMode:
+    session: 0644
+    sessionSecret: 0420
+    secret: 0600
+    userProvisioning: 0600
+    server: 0644
+    jobJsonOverrides: 0644
+    startup: 0755
+    prestart: 0755
+    pam: 0644
   session:
     repos.conf:
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -208,77 +208,78 @@ volumes:
 - name: rstudio-job-overrides-old
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-overrides-old
-    defaultMode: 0644
+    defaultMode: {{ .Values.config.defaultMode.jobJsonOverrides }}
 {{- end }}
 {{- if not $useLegacyProfiles }}
 - name: rstudio-job-overrides-new
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-overrides-new
-    defaultMode: 0644
+    defaultMode: {{ .Values.config.defaultMode.jobJsonOverrides }}
 {{- end }}
 - name: etc-rstudio
   emptyDir: {}
 - name: rstudio-config
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-config
-    defaultMode: 0644
+    defaultMode: {{ .Values.config.defaultMode.server }}
 - name: rstudio-session-config
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-session
-    defaultMode: 0644
+    defaultMode: {{ .Values.config.defaultMode.session }}
 {{- if .Values.config.sessionSecret }}
 - name: rstudio-session-secret
   secret:
     secretName: {{ include "rstudio-workbench.fullname" . }}-session-secret
+    defaultMode: {{ .Values.config.defaultMode.sessionSecret }}
 {{- end }}
 - name: rstudio-prestart
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-prestart
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.prestart }}
 - name: rstudio-rsw-startup
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-start-rsw
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.startup }}
 {{- if .Values.launcher.enabled }}
 - name: rstudio-launcher-startup
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-start-launcher
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.startup }}
 {{- end }}
 {{- if .Values.config.startupUserProvisioning }}
 - name: rstudio-user-startup
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-start-user
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.startup }}
 {{- end }}
 {{- if .Values.config.startupCustom }}
 - name: rstudio-custom-startup
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-start-custom
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.startup }}
 {{- end }}
 {{- if .Values.config.pam }}
 - name: rstudio-pam
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-pam
-    defaultMode: 0644
+    defaultMode: {{ .Values.config.defaultMode.pam }}
 {{- end }}
 - name: rstudio-secret
   secret:
     secretName: {{ include "rstudio-workbench.fullname" . }}-secret
-    defaultMode: 0600
+    defaultMode: {{ .Values.config.defaultMode.secret }}
 {{- if .Values.config.userProvisioning }}
 - name: rstudio-user
   secret:
     secretName: {{ include "rstudio-workbench.fullname" . }}-user
-    defaultMode: 0600
+    defaultMode: {{ .Values.config.defaultMode.userProvisioning }}
 {{- end }}
 {{ include "rstudio-library.license-volume" (dict "license" ( .Values.license ) "fullName" (include "rstudio-workbench.fullname" .)) }}
 {{- if .Values.prometheusExporter.enabled }}
 - name: graphite-exporter-config
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-graphite
-    defaultMode: 0755
+    defaultMode: {{ .Values.config.defaultMode.server }}
 {{- end }}
 {{- if .Values.pod.volumes }}
 {{ toYaml .Values.pod.volumes }}

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -5,7 +5,7 @@
 {{- $defaultOverrides := list }}
 {{- if .Values.session.defaultConfigMount }}
   {{/* default session config mount */}}
-  {{- $sessionVolume := dict "configMap" ( dict "name" (printf "%s-session" ( include "rstudio-workbench.fullname" . ) ) ) "name" "session-config" }}
+  {{- $sessionVolume := dict "configMap" ( dict "defaultMode" .Values.config.defaultMode.session "name" (printf "%s-session" ( include "rstudio-workbench.fullname" . ) ) ) "name" "session-config" }}
   {{- $sessionVolumeMount := dict "mountPath" "/mnt/session-configmap/rstudio" "name" "session-config" }}
   {{- $sessionVolumeOverride := dict "name" "defaultSessionVolume" "target" "/spec/template/spec/volumes/-" "json" $sessionVolume }}
   {{- $sessionVolumeMountOverride := dict "name" "defaultSessionVolumeMount" "target" "/spec/template/spec/containers/0/volumeMounts/-" "json" $sessionVolumeMount }}
@@ -13,7 +13,7 @@
   {{- $defaultOverrides = concat $defaultOverrides ( list $sessionVolumeOverride $sessionVolumeMountOverride ) }}
   {{- if .Values.config.sessionSecret}}
     {{/* default session secret config mount */}}
-    {{- $sessionSecretVolume := dict "secret" ( dict "secretName" (printf "%s-session-secret" ( include "rstudio-workbench.fullname" . ) ) ) "name" "session-secret" }}
+    {{- $sessionSecretVolume := dict "secret" ( dict "defaultMode" .Values.config.defaultMode.sessionSecret "secretName" (printf "%s-session-secret" ( include "rstudio-workbench.fullname" . ) ) ) "name" "session-secret" }}
     {{- $sessionSecretVolumeMount := dict "mountPath" .Values.session.defaultSecretMountPath "name" "session-secret" }}
     {{- $sessionSecretVolumeOverride := dict "name" "defaultSessionSecretVolume" "target" "/spec/template/spec/volumes/-" "json" $sessionSecretVolume }}
     {{- $sessionSecretVolumeMountOverride := dict "name" "defaultSessionSecretVolumeMount" "target" "/spec/template/spec/containers/0/volumeMounts/-" "json" $sessionSecretVolumeMount }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -279,16 +279,33 @@ global:
   secureCookieKey: ""
 
 config:
-  # -- defaultMode used for mounting the various configuration configmaps
   defaultMode:
+    # -- default mode for session files
+    # @default -- 0644
     session: 0644
+    # -- default mode for session secrets
+    # @default -- 0420
     sessionSecret: 0420
+    # -- default mode for secrets
+    # @default -- 0600
     secret: 0600
+    # -- default mode for userProvisioning config
+    # @default -- 0600
     userProvisioning: 0600
+    # -- default mode for server config
+    # @default -- 0644
     server: 0644
+    # -- default mode for jobJsonOverrides config
+    # @default -- 0644
     jobJsonOverrides: 0644
+    # -- default mode for startup config
+    # @default -- 0755
     startup: 0755
+    # -- default mode for prestart config
+    # @default -- 0755
     prestart: 0755
+    # -- default mode for pam scripts
+    # @default -- 0644
     pam: 0644
 
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -279,6 +279,18 @@ global:
   secureCookieKey: ""
 
 config:
+  # -- defaultMode used for mounting the various configuration configmaps
+  defaultMode:
+    session: 0644
+    sessionSecret: 0420
+    secret: 0600
+    userProvisioning: 0600
+    server: 0644
+    jobJsonOverrides: 0644
+    startup: 0755
+    prestart: 0755
+    pam: 0644
+
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.
   session:
     repos.conf:


### PR DESCRIPTION
this sets most (all?) options for defaultMode on configmap and secret volumes in the `rstudio-workbench` chart
using octal numbers in helm is a bit strange, but seems to work correctly

close #151 