### PR TITLE
Added the postStart hook feature

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.4
+version: 0.3.5
 apiVersion: v2
 appVersion: 2021.12.0-3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.5
+version: 0.3.6
 apiVersion: v2
 appVersion: 2022.04.0-7
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.6
+
+-  Add `pod.lifecycle` value. This allows running lifecycle hooks like postStart commands!
+
 # 0.3.5
 
 - Update default RStudio Package Manager version to 2022.04.0-7

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.5:
+To install the chart with the release name `my-release` at version 0.3.6:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.3.5
+helm install my-release rstudio/rstudio-pm --version=0.3.6
 ```
 
 ## Required Configuration
@@ -112,6 +112,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
+| pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
 | pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -56,11 +56,9 @@ spec:
         args: {{ .Values.args }}
         {{- end }}
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        {{- if .Values.pod.postStartCommand }}
+        {{- if .Values.pod.lifecycle }}
         lifecycle:
-          postStart:
-            exec:
-              command: {{ .Values.pod.postStartCommand }}
+          {{- toYaml .Values.pod.lifecycle | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: 4242

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -56,6 +56,12 @@ spec:
         args: {{ .Values.args }}
         {{- end }}
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        {{- if .Values.pod.postStartCommand }}
+        lifecycle:
+          postStart:
+            exec:
+              command: {{ .Values.pod.postStartCommand }}
+        {{- end }}
         ports:
         - containerPort: 4242
 {{- if .Values.config.Metrics.Enabled }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -100,6 +100,8 @@ pod:
   serviceAccountName: false
   # -- annotations is a map of keys / values that will be added as annotations to the pods
   annotations: {}
+  # -- postStart Hook command [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
+  postStartCommand: []
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -100,8 +100,8 @@ pod:
   serviceAccountName: false
   # -- annotations is a map of keys / values that will be added as annotations to the pods
   annotations: {}
-  # -- postStart Hook command [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
-  postStartCommand: []
+  # -- Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
+  lifecycle: {}
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []


### PR DESCRIPTION
### Problem

We need to serve the rstudio-pm Helm release via IaC, but I can't find a way to do so.

### Proposed solution

Add the postStart lifecycle hook into the deployment template, allowing the execution of arbitrary commands.

### Values example

```
...
license:
  file:
    mountPath: /etc/rstudio-licensing
    secret: rspm-license
    secretKey: Data
  server: false
lifecycle:
    postStart:
      exec:
        command:
        - /bin/bash
        - -c
        - |
          sleep 3 &&
          rspm create repo --name=prod-cran --description='Access CRAN packages' &&
          rspm subscribe --repo=prod-cran --source=cran &&
          rspm sync --type=cran& exit
...
```