### PR TITLE
Update CI defaults for connect 

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.26
+version: 0.2.27
 apiVersion: v2
-appVersion: 2022.03.2
+appVersion: 2022.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:2022.03.2
+      image: rstudio/rstudio-connect:2022.04.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.27
+
+- Bump Connect version to 2022.04.0
+
 # 0.2.26
 
 - Fix ingress definition issues with older Kubernetes clusters ([#139](https://github.com/rstudio/helm/issues/139))

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.26](https://img.shields.io/badge/Version-0.2.26-informational?style=flat-square) ![AppVersion: 2022.03.2](https://img.shields.io/badge/AppVersion-2022.03.2-informational?style=flat-square)
+![Version: 0.2.27](https://img.shields.io/badge/Version-0.2.27-informational?style=flat-square) ![AppVersion: 2022.04.0](https://img.shields.io/badge/AppVersion-2022.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.26:
+To install the chart with the release name `my-release` at version 0.2.27:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.2.26
+helm install my-release rstudio/rstudio-connect --version=0.2.27
 ```
 
 ## Required Configuration

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -38,15 +38,18 @@ pod:
   sidecar:
     - name: test
       image: "busybox"
+      command: ["sleep"]
+      args: ["infinity"]
       imagePullPolicy: "IfNotPresent"
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: rstudio-team
-          topologyKey: kubernetes.io/hostname
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/part-of: rstudio-team
+            topologyKey: kubernetes.io/hostname
 
 ingress:
   enabled: true


### PR DESCRIPTION
Depends on https://github.com/rstudio/helm/pull/184

We were missing `podAffinityTerm` in our ci/complex-values for connect which was causing the install step to fail. The sidecar was also entering a crashloop backoff because it exits immediately.

I think we still need to provide a `license.key` for connect for this part of CI to work properly but I'm not sure how to do that