### PR TITLE
Enable securityContext for pod and container

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.7
+version: 0.3.8
 apiVersion: v2
 appVersion: 2022.04.0-7
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.8
+
+- Add `securityContext` for pod and container as documented [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+
 # 0.3.7
 
 -  Add `extraContainers` value. This allows adding a list of additional containers.

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -114,7 +114,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
-| pod.securityContext | object | `{}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
+| pod.securityContext | object | `{"privileged":true}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
 | pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -112,9 +112,10 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":4242},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | livenessProbe is used to configure the container's livenessProbe |
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
+| pod.containerSecurityContext | object | `{"privileged":true}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
-| pod.securityContext | object | `{}` | pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
+| pod.securityContext | object | `{}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the pod |
 | pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |
@@ -122,7 +123,6 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
-| securityContext | object | `{"privileged":true}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
 | service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -114,7 +114,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
-| pod.securityContext | object | `{"privileged":true}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
+| pod.securityContext | object | `{}` | pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
 | pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |
@@ -122,7 +122,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
-| securityContext | object | `{}` | pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
+| securityContext | object | `{"privileged":true}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
 | service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
+![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.7:
+To install the chart with the release name `my-release` at version 0.3.8:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.3.7
+helm install my-release rstudio/rstudio-pm --version=0.3.8
 ```
 
 ## Required Configuration
@@ -114,6 +114,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
+| pod.securityContext | object | `{}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
 | pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |
@@ -121,6 +122,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
+| securityContext | object | `{}` | pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
 | service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -122,7 +122,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
-| securityContext | object | `{"privileged":true}` | container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings |
+| securityContext | object | `{"privileged":true}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
 | service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -71,11 +71,9 @@ spec:
           containerPort: 2112
 {{- end }}
         securityContext:
-      {{- if .Values.pod.securityContext }}
-        {{- toYaml .Values.pod.securityContext | nindent 10 }}
-      {{- else }}
-          privileged: true
-      {{- end }}
+        {{- if .Values.pod.securityContext }}
+          {{- toYaml .Values.pod.securityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: rstudio-pm-config
             mountPath: "/etc/rstudio-pm/rstudio-pm.gcfg"

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       labels:
         {{- include "rstudio-pm.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.securityContext }}
+      {{- if .Values.pod.securityContext }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.pod.securityContext | nindent 8 }}
       {{- end }}
       {{- if .Values.pod.serviceAccountName }}
       serviceAccountName: {{ .Values.pod.serviceAccountName }}
@@ -71,8 +71,8 @@ spec:
           containerPort: 2112
 {{- end }}
         securityContext:
-        {{- if .Values.pod.securityContext }}
-          {{- toYaml .Values.pod.securityContext | nindent 10 }}
+        {{- if .Values.securityContext }}
+          {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
         volumeMounts:
           - name: rstudio-pm-config

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       labels:
         {{- include "rstudio-pm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
       {{- if .Values.pod.serviceAccountName }}
       serviceAccountName: {{ .Values.pod.serviceAccountName }}
       {{- end }}
@@ -67,7 +71,11 @@ spec:
           containerPort: 2112
 {{- end }}
         securityContext:
+      {{- if .Values.pod.securityContext }}
+        {{- toYaml .Values.pod.securityContext | nindent 10 }}
+      {{- else }}
           privileged: true
+      {{- end }}
         volumeMounts:
           - name: rstudio-pm-config
             mountPath: "/etc/rstudio-pm/rstudio-pm.gcfg"

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
           containerPort: 2112
 {{- end }}
         securityContext:
-        {{- if .Values.securityContext }}
-          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- if .Values.pod.containerSecurityContext }}
+          {{- toYaml .Values.pod.containerSecurityContext | nindent 10 }}
         {{- end }}
         volumeMounts:
           - name: rstudio-pm-config

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -88,8 +88,9 @@ rstudioPMKey: false
 command: false
 # -- args is the pod's run arguments. By default, it uses the container's default
 args: false
-# -- pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
-securityContext: {}
+# -- container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+securityContext:
+  privileged: true
 
 pod:
   # -- env is an array of maps that is injected as-is into the "env:" component of the pod.container spec
@@ -104,9 +105,8 @@ pod:
   annotations: {}
   # -- Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
   lifecycle: {}
-  # -- container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
-  securityContext:
-    privileged: true
+  # -- pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+  securityContext: {}
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -88,9 +88,6 @@ rstudioPMKey: false
 command: false
 # -- args is the pod's run arguments. By default, it uses the container's default
 args: false
-# -- the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container
-securityContext:
-  privileged: true
 
 pod:
   # -- env is an array of maps that is injected as-is into the "env:" component of the pod.container spec
@@ -105,8 +102,11 @@ pod:
   annotations: {}
   # -- Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
   lifecycle: {}
-  # -- pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+  # -- the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the pod
   securityContext: {}
+  # -- the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container
+  containerSecurityContext:
+    privileged: true
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -88,7 +88,7 @@ rstudioPMKey: false
 command: false
 # -- args is the pod's run arguments. By default, it uses the container's default
 args: false
-# -- container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+# -- the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container
 securityContext:
   privileged: true
 

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -88,6 +88,8 @@ rstudioPMKey: false
 command: false
 # -- args is the pod's run arguments. By default, it uses the container's default
 args: false
+# -- pod [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+securityContext: {}
 
 pod:
   # -- env is an array of maps that is injected as-is into the "env:" component of the pod.container spec
@@ -102,6 +104,8 @@ pod:
   annotations: {}
   # -- Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
   lifecycle: {}
+  # -- container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
+  securityContext: {}
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -105,7 +105,8 @@ pod:
   # -- Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
   lifecycle: {}
   # -- container [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings
-  securityContext: {}
+  securityContext:
+    privileged: true
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []


### PR DESCRIPTION
As part of our plan to run the container as an ordinary user, we need to change the default `container[0].securityContext.privileged` from true to false.

We also need the ability to change the pod security context, allowing the `fsGroup` storage parameter.