### PR TITLE
Add dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ helm-docs
 charts/**/charts/
 /*.values
 /.cr-release-packages
+bin/**
+!bin/README.md

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,12 @@
+setup:
+  #!/bin/bash
+  # TODO: idempotency
+
+  # TODO: check for macos
+  mkdir -p ./bin/helm-docs-1.5.0/
+  curl -L https://github.com/norwoodj/helm-docs/releases/download/v1.5.0/helm-docs_1.5.0_Darwin_x86_64.tar.gz | tar -xzvf - -C ./bin/helm-docs-1.5.0/
+  ln -s $PWD/bin/helm-docs-1.5.0/helm-docs $PWD/bin/helm-docs
+
 update-lock:
   #!/bin/bash
   orig_dir=$(pwd)
@@ -13,8 +22,8 @@ all-docs:
 
 docs:
   #!/bin/bash
-  helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl
-  helm-docs --chart-search-root=other-charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl
+  ./bin/helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl
+  ./bin/helm-docs --chart-search-root=other-charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl
 
 rbac:
   #!/bin/bash

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,3 @@
+A `./bin` directory for various supporting software (i.e. `helm`, `helm-docs`, etc.)
+
+See `just setup` for more detail


### PR DESCRIPTION
Close #72 

- Add a `./bin` directory to provision dev versions within
- Add prototype helper to download and install `helm-docs`