### PR TITLE
utilize tpl-data in rsc

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.38
+version: 0.2.39-alpha01
 apiVersion: v2
-appVersion: 2022.06.2
+appVersion: 2022.07.0-dev-228
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,13 @@
+# Devel
+
+- Add support for the `launcher.useTemplates` value
+  - This enables greater customization of session creation as well as better labels and annotations out of the box
+  - To make use of the default session templates, configure values in `launcher.sessionTemplate`
+- Add a toggle for `launcher.useDefaultInitContainer` to turn off the default init container
+  - When using the launcher, it is important that sessions have the RStudio Connect "session runtime" available
+  - By default, we make these available through an init container, but they can also be provided other ways
+  - By disabling this setting, you are opting in to managing this runtime requirement yourself
+
 # 0.2.38
 
 - Bump rstudio-library chart version

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,12 +1,15 @@
 # Devel
 
+- BETA BREAKING: We moved `launcher.contentInitContainer` customizations to `launcher.defaultInitContainer`
+  - This should only affect if you are using `launcher.enabled=true`, which is still in Beta
+  - Values are treated the same, so a simple modification to the key should resolve any issues
 - Add support for the `launcher.useTemplates` value
   - This enables greater customization of session creation as well as better labels and annotations out of the box
   - To make use of the default session templates, configure values in `launcher.sessionTemplate`
-- Add a toggle for `launcher.useDefaultInitContainer` to turn off the default init container
+- Add a toggle for `launcher.defaultInitContainer.enabled` to turn off the default init container
   - When using the launcher, it is important that sessions have the RStudio Connect "session runtime" available
   - By default, we make these available through an init container, but they can also be provided other ways
-  - By disabling this setting, you are opting in to managing this runtime requirement yourself
+  - By disabling this setting, you are opting into managing this runtime requirement yourself
 
 # 0.2.38
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -6,6 +6,7 @@
 - Add support for the `launcher.useTemplates` value
   - This enables greater customization of session creation as well as better labels and annotations out of the box
   - To make use of the default session templates, configure values in `launcher.sessionTemplate`
+- Enable logging using RStudio Connect's new logging configuration (effective with version 2022.07)
 - Add a toggle for `launcher.defaultInitContainer.enabled` to turn off the default init container
   - When using the launcher, it is important that sessions have the RStudio Connect "session runtime" available
   - By default, we make these available through an init container, but they can also be provided other ways

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -83,13 +83,15 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
 | launcher.customRuntimeYaml | bool | `false` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "false," which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. |
 | launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init-preview","tag":""}` | Image definition for the default RStudio Connect Content InitContainer |
+| launcher.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. |
+| launcher.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |
 | launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init-preview"` | The repository to use for the Content InitContainer image |
 | launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.enabled | bool | `false` | Whether to enable the launcher |
 | launcher.launcherKubernetesProfilesConf | object | `{}` | User definition of launcher.kubernetes.profiles.conf for job customization |
 | launcher.namespace | string | `""` | The namespace to launch sessions into. Uses the Release namespace by default |
 | launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"annotations":{},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"serviceAccountName":"","volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the RStudio Connect session templating process |
-| launcher.useTemplates | bool | `false` |  |
+| launcher.useTemplates | bool | `true` | Whether to use launcher templates when launching sessions. Defaults to true |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
 | license.file.contents | bool | `false` | contents is an in-line license file |
 | license.file.mountPath | string | `"/etc/rstudio-licensing"` | mountPath is the place the license file will be mounted into the container |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.38](https://img.shields.io/badge/Version-0.2.38-informational?style=flat-square) ![AppVersion: 2022.06.2](https://img.shields.io/badge/AppVersion-2022.06.2-informational?style=flat-square)
+![Version: 0.2.39-alpha01](https://img.shields.io/badge/Version-0.2.39--alpha01-informational?style=flat-square) ![AppVersion: 2022.07.0-dev-228](https://img.shields.io/badge/AppVersion-2022.07.0--dev--228-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.38:
+To install the chart with the release name `my-release` at version 0.2.39-alpha01:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.2.38
+helm install --devel my-release rstudio/rstudio-connect --version=0.2.39-alpha01
 ```
 
 ## Required Configuration
@@ -70,10 +70,10 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | config | object | [RStudio Connect Configuration Reference](https://docs.rstudio.com/connect/admin/appendix/configuration/) | A nested map of maps that generates the rstudio-connect.gcfg file |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template) |
 | fullnameOverride | string | `""` | The full name of the release (can be overridden) |
-| image | object | `{"imagePullPolicy":"IfNotPresent","imagePullSecrets":[],"repository":"ghcr.io/rstudio/rstudio-connect","tag":""}` | Defines the RStudio Connect image to deploy |
+| image | object | `{"imagePullPolicy":"IfNotPresent","imagePullSecrets":[],"repository":"ghcr.io/rstudio/rstudio-connect-preview","tag":""}` | Defines the RStudio Connect image to deploy |
 | image.imagePullPolicy | string | `"IfNotPresent"` | The imagePullPolicy for the main pod image |
 | image.imagePullSecrets | list | `[]` | an array of kubernetes secrets for pulling the main pod image from private registries |
-| image.repository | string | `"ghcr.io/rstudio/rstudio-connect"` | The repository to use for the main pod image |
+| image.repository | string | `"ghcr.io/rstudio/rstudio-connect-preview"` | The repository to use for the main pod image |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
@@ -82,8 +82,8 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | ingress.tls | list | `[]` |  |
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
 | launcher.customRuntimeYaml | bool | `false` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "false," which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. |
-| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","tag":""}` | Image definition for the default RStudio Connect Content InitContainer |
-| launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init"` | The repository to use for the Content InitContainer image |
+| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init-preview","tag":""}` | Image definition for the default RStudio Connect Content InitContainer |
+| launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init-preview"` | The repository to use for the Content InitContainer image |
 | launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.enabled | bool | `false` | Whether to enable the launcher |
 | launcher.launcherKubernetesProfilesConf | object | `{}` | User definition of launcher.kubernetes.profiles.conf for job customization |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -81,15 +81,14 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | ingress.ingressClassName | string | `""` | The ingressClassName for the ingress resource. Only used for clusters that support networking.k8s.io/v1 Ingress resources |
 | ingress.tls | list | `[]` |  |
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
-| launcher.contentInitContainer | object | `{"repository":"ghcr.io/rstudio/rstudio-connect-content-init","tag":""}` | Image definition for the RStudio Connect Content InitContainer |
-| launcher.contentInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init"` | The repository to use for the Content InitContainer image |
-| launcher.contentInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.customRuntimeYaml | bool | `false` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "false," which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. |
+| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","tag":""}` | Image definition for the default RStudio Connect Content InitContainer |
+| launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init"` | The repository to use for the Content InitContainer image |
+| launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.enabled | bool | `false` | Whether to enable the launcher |
 | launcher.launcherKubernetesProfilesConf | object | `{}` | User definition of launcher.kubernetes.profiles.conf for job customization |
 | launcher.namespace | string | `""` | The namespace to launch sessions into. Uses the Release namespace by default |
-| launcher.sessionTemplate | object | `{"pod":{"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"serviceAccountName":"","volumeMounts":[],"volumes":[]},"service":{"type":"ClusterIP"}}` | Values to pass along to the RStudio Connect session templating process |
-| launcher.useDefaultInitContainer | bool | `true` |  |
+| launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"annotations":{},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"serviceAccountName":"","volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the RStudio Connect session templating process |
 | launcher.useTemplates | bool | `false` |  |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
 | license.file.contents | bool | `false` | contents is an in-line license file |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -88,6 +88,9 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | launcher.enabled | bool | `false` | Whether to enable the launcher |
 | launcher.launcherKubernetesProfilesConf | object | `{}` | User definition of launcher.kubernetes.profiles.conf for job customization |
 | launcher.namespace | string | `""` | The namespace to launch sessions into. Uses the Release namespace by default |
+| launcher.sessionTemplate | object | `{"pod":{"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"serviceAccountName":"","volumeMounts":[],"volumes":[]},"service":{"type":"ClusterIP"}}` | Values to pass along to the RStudio Connect session templating process |
+| launcher.useDefaultInitContainer | bool | `true` |  |
+| launcher.useTemplates | bool | `false` |  |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
 | license.file.contents | bool | `false` | contents is an in-line license file |
 | license.file.mountPath | string | `"/etc/rstudio-licensing"` | mountPath is the place the license file will be mounted into the container |

--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -104,7 +104,7 @@ spec:
         {{- end }}
         {{- with $templateData.pod.initContainers }}
           {{- range . }}
-        - {{- toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
+        - {{ toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
           {{- end }}
         {{- end }}
       containers:

--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -1,0 +1,236 @@
+# Version: 2.1.0
+# DO NOT MODIFY the "Version: " key
+# Helm Version: v1
+{{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    {{- with .Job.metadata.job.annotations }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
+  labels:
+    {{- with .Job.metadata.job.labels }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
+  generateName: {{ toYaml .Job.generateName }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      annotations:
+        {{- if .Job.tags }}
+        {{- $i := 0 }}
+        {{- range .Job.tags }}
+        USER_TAG_{{ $i }}: {{ toYaml . | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- $i = add $i 1 }}
+        {{- end }}
+        {{- end }}
+        stdin: {{ toYaml .Job.stdin | indent 8 | trimPrefix (repeat 8 " ") }}
+        user: {{ toYaml .Job.user }}
+        name: {{ toYaml .Job.name }}
+        service_ports: {{ toYaml .Job.servicePortsJson }}
+        {{- if .Job.metadata }}
+        user_metadata: {{ toJson .Job.metadata | toYaml | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- with .Job.metadata.pod.annotations }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- end }}
+      labels:
+        {{- with .Job.metadata.pod.labels }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- end }}
+      generateName: {{ toYaml .Job.generateName }}
+    spec:
+      {{- if .Job.host }}
+      nodeName: {{ toYaml .Job.host }}
+      {{- end }}
+      restartPolicy: Never
+      {{- with $templateData.pod.serviceAccountName }}
+      serviceAccountName: {{- . }}
+      {{- end }}
+      shareProcessNamespace: {{ .Job.shareProcessNamespace }}
+      {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumes) 0) }}
+      volumes:
+        {{- range .Job.volumes }}
+        - {{ nindent 10 (toYaml .) | trim -}}
+        {{- end }}
+        {{- range $templateData.pod.volumes }}
+        - {{ nindent 10 (toYaml .) | trim -}}
+        {{- end }}
+      {{- end }}
+      {{- if ne (len .Job.placementConstraints) 0 }}
+      nodeSelector:
+        {{- range .Job.placementConstraints }}
+        {{ .name }}: {{ toYaml .value }}
+        {{- end }}
+      {{- end }}
+      {{- $securityContext := dict }}
+      {{- if .Job.container.runAsUserId }}
+        {{- $_ := set $securityContext "runAsUser" .Job.container.runAsUserId }}
+      {{- end }}
+      {{- if .Job.container.runAsGroupId }}
+        {{- $_ := set $securityContext "runAsGroup" .Job.container.runAsGroupId }}
+      {{- end }}
+      {{- if .Job.container.supplementalGroupIds }}
+        {{- $groupIds := list }}
+        {{- range .Job.container.supplementalGroupIds }}
+          {{- $groupIds = append $groupIds . }}
+        {{- end }}
+        {{- $_ := set $securityContext "supplementalGroups" (cat "[" ($groupIds | join ", ") "]") }}
+      {{- end }}
+      {{- if $securityContext }}
+      securityContext:
+        {{- range $key, $val := $securityContext }}
+        {{ $key }}: {{ $val }}
+        {{- end }}
+      {{- end }}
+      {{- with $templateData.pod.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml . | nindent 12 }}
+      {{- end }}
+      initContainers:
+        {{- with .Job.metadata.pod.initContainers }}
+        {{- range . }}
+        - {{ toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
+        {{- end }}
+        {{- end }}
+        {{- with $templateData.pod.initContainers }}
+          {{- range . }}
+        - {{- toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
+          {{- end }}
+        {{- end }}
+      containers:
+        - name: rs-launcher-container
+          image: {{ toYaml .Job.container.image }}
+          {{- with $templateData.pod.imagePullPolicy }}
+          imagePullPolicy: {{- . | nindent 12 }}
+          {{- end }}
+          {{- $isShell := false }}
+          {{- if .Job.command }}
+          command: ['/bin/sh']
+          {{- $isShell = true }}
+          {{- else }}
+          command: [{{ toYaml .Job.exe }}]
+          {{- $isShell = false }}
+          {{- end }}
+          {{- if .Job.stdin }}
+          stdin: true
+          {{- else }}
+          stdin: false
+          {{- end }}
+          stdinOnce: true
+          {{- if .Job.workingDirectory }}
+          workingDir: {{ toYaml .Job.workingDirectory }}
+          {{- end }}
+          {{- if or (ne (len .Job.args) 0) $isShell }}
+          args:
+            {{- if $isShell }}
+            - '-c'
+            {{- if ne (len .Job.args) 0 }}
+            - {{ .Job.args | join " " | cat .Job.command | toYaml | indent 12 | trimPrefix (repeat 12 " ") }}
+            {{- else }}
+            - {{ .Job.command | toYaml | indent 12 | trimPrefix (repeat 12 " ") }}
+            {{- end }}
+            {{- else }}
+            {{- range .Job.args }}
+            - {{ toYaml . | indent 12 | trimPrefix (repeat 12 " ") }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- $secrets := list }}
+          {{- range .Job.config }}
+            {{- if eq .name "secret" }}
+              {{- $packedSecret := .value }}
+              {{- $secret := dict }}
+              {{- $_ := set $secret "secret" (splitList ":" $packedSecret | first) }}
+              {{- $_ := set $secret "key" (slice (splitList ":" $packedSecret) 1 2 | first) }}
+              {{- $_ := set $secret "name" (splitList ":" $packedSecret | last) }}
+              {{- $secrets = append $secrets $secret }}
+            {{- end }}
+          {{- end }}
+          {{- if or (ne (len .Job.environment) 0) (ne (len $secrets) 0) }}
+          env:
+            {{- range .Job.environment }}
+            - name: {{ toYaml .name | indent 14 | trimPrefix (repeat 14 " ") }}
+              value: {{ toYaml .value | indent 14 | trimPrefix (repeat 14 " ") }}
+            {{- end }}
+            {{- range $secrets }}
+            - name: {{ get . "name"}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ get . "secret" }}
+                  key: {{ get . "key" }}
+            {{- end }}
+          {{- end }}
+          {{- $exposedPorts := list }}
+          {{- range .Job.exposedPorts }}
+            {{- if .publishedPort }}
+              {{- $exposedPorts = append $exposedPorts . }}
+            {{- end }}
+          {{- end }}
+          {{- if ne (len $exposedPorts) 0 }}
+          ports:
+            {{- range $exposedPorts }}
+            - containerPort: {{ .targetPort }}
+              hostPort: {{ .publishedPort }}
+            {{- end }}
+          {{- end }}
+          {{- $limits := dict }}
+          {{- $requests := dict }}
+          {{- range .Job.resourceLimits }}
+            {{- if eq .type "cpuCount" }}
+              {{- $_ := set $limits "cpu" .value }}
+              {{- if ne $.Job.cpuRequestRatio 1.0 }}
+                {{- $val := mulf .value $.Job.cpuRequestRatio | toString }}
+                {{- $_ := set $requests "cpu" $val }}
+              {{- end }}
+            {{- else if eq .type "memory" }}
+              {{- $_ := set $limits "memory" (printf "%s%s" .value "M") }}
+              {{- if ne $.Job.memoryRequestRatio 1.0 }}
+                {{- $val := mulf .value $.Job.memoryRequestRatio }}
+                {{- $_ := set $requests "memory" (printf "%.2f%s" $val "M") }}
+              {{- end }}
+            {{- else if eq .type "NVIDIA GPUs" }}
+              {{- $val := float64 .value }}
+              {{- if ne $val 0.0 }}
+                {{- $_ := set $limits "nvidia.com/gpu" $val }}
+              {{- end }}
+            {{- else if eq .type "AMD GPUs" }}
+              {{- $val := float64 .value }}
+              {{- if ne $val 0.0 }}
+                {{- $_ := set $limits "amd.com/gpu" $val }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if any (ne (len $requests) 0) (ne (len $limits) 0) }}
+          resources:
+            {{- if ne (len $requests) 0 }}
+            requests:
+              {{- range $key, $val := $requests }}
+              {{ $key }}: {{ toYaml $val }}
+              {{- end }}
+            {{- end }}
+            {{- if ne (len $limits) 0 }}
+            limits:
+              {{- range $key, $val := $limits }}
+              {{ $key }}: {{ toYaml $val }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumeMounts) 0) }}
+          volumeMounts:
+            {{- range .Job.volumeMounts }}
+            - {{ nindent 14 (toYaml .) | trim -}}
+            {{- end }}
+            {{- range $templateData.pod.volumeMounts }}
+            - {{ nindent 14 (toYaml .) | trim -}}
+            {{- end }}
+          {{- end }}

--- a/charts/rstudio-connect/files/service.tpl
+++ b/charts/rstudio-connect/files/service.tpl
@@ -1,0 +1,37 @@
+# Version: 2.1.0
+# DO NOT MODIFY the "Version: " key
+# Helm Version: v1
+{{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Job.serviceName }}
+  annotations:
+    {{- with .Job.metadata.service.annotations }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
+  labels:
+    job-name: {{ toYaml .Job.id }}
+    {{- with .Job.metadata.service.labels }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+    {{- end }}
+    {{- end }}
+spec:
+  ports:
+    {{- $i := 0 }}
+    {{- range .Job.exposedPorts }}
+    {{- if not .publishedPort }}
+    - name: {{ printf "port%d" $i }}
+      protocol: {{ .protocol }}
+      port: {{ .targetPort }}
+      targetPort: {{ .targetPort }}
+      {{- $i = add $i 1 }}
+    {{- end }}
+    {{- end }}
+  selector:
+    job-name: {{toYaml .Job.id }}
+  clusterIP: ''
+  type: {{ $templateData.service.type }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -38,11 +38,11 @@ pods created by the Launcher. This feature will be removed in the next release o
 {{- if and .Values.launcher.useTemplates .Values.launcher.enabled }}
   {{- range $k,$v :=  .Values.launcher.launcherKubernetesProfilesConf }}
     {{- if hasKey $v "job-json-overrides" }}
-      {{- fail "launcher.launcherKubernetesProfilesConf has `job-json-overrides` defined. This cannot be used with `launcher.useTemplates=true`" }}
+      {{- fail "\n\n`launcher.launcherKubernetesProfilesConf` has `job-json-overrides` defined. This cannot be used with `launcher.useTemplates=true`.\n\nPlease move `job-json-overrides` to the corresponding `launcher.templateValues`, or set `launcher.useTemplates=false`" }}
     {{- end }}
   {{- end }}
 {{- end }}
 
 {{- if .Values.launcher.contentInitContainer }}
-  {{- fail "launcher.contentInitContainer values are now stored at launcher.defaultInitContainer" }}
+  {{- fail "\n\n`launcher.contentInitContainer` values are now stored at `launcher.defaultInitContainer`" }}
 {{- end }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -28,3 +28,11 @@ pods created by the Launcher. This feature will be removed in the next release o
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if and .Values.launcher.useTemplates .Values.launcher.enabled }}
+  {{- range $k,$v :=  .Values.launcher.launcherKubernetesProfilesConf }}
+    {{- if hasKey $v "job-json-overrides" }}
+      {{- fail "launcher.launcherKubernetesProfilesConf has `job-json-overrides` defined. This cannot be used with `launcher.useTemplates=true`" }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -1,7 +1,9 @@
 
 {{ include "rstudio-connect.fullname" . }} successfully deployed to namespace {{ $.Release.Namespace }}
 
+{{- /* Verify configuration values */ -}}
 {{- if hasKey .Values "config" }}
+
 {{- if hasKey .Values.config "Licensing" }}
 {{- if hasKey .Values.config.Licensing "LicenseType" }}
 
@@ -12,6 +14,7 @@ Please consider removing this configuration value.
 
 {{- end }}
 {{- end }}
+
 {{- if hasKey .Values.config "Launcher" }}
 {{- if hasKey .Values.config.Launcher "DataDir" }}
 {{- if contains ":" .Values.config.Launcher.DataDir }}
@@ -27,7 +30,10 @@ pods created by the Launcher. This feature will be removed in the next release o
 {{- end }}
 {{- end }}
 {{- end }}
+
 {{- end }}
+
+{{- /* chart deprecations and misconfiguration warnings */ -}}
 
 {{- if and .Values.launcher.useTemplates .Values.launcher.enabled }}
   {{- range $k,$v :=  .Values.launcher.launcherKubernetesProfilesConf }}
@@ -35,4 +41,8 @@ pods created by the Launcher. This feature will be removed in the next release o
       {{- fail "launcher.launcherKubernetesProfilesConf has `job-json-overrides` defined. This cannot be used with `launcher.useTemplates=true`" }}
     {{- end }}
   {{- end }}
+{{- end }}
+
+{{- if .Values.launcher.contentInitContainer }}
+  {{- fail "launcher.contentInitContainer values are now stored at launcher.defaultInitContainer" }}
 {{- end }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -70,6 +70,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.launcher.useTemplates }}
       {{- $_ := set $launcherSettingsDict "KubernetesUseTemplates" "true" }}
       {{- $_ = set $launcherSettingsDict "ScratchPath" "/var/lib/rstudio-connect-launcher" }}
+    {{- else }}
+      {{- $_ := set $launcherSettingsDict "KubernetesUseTemplates" "false" }}
     {{- end }}
     {{- $launcherDict := dict "Launcher" ( $launcherSettingsDict ) }}
     {{- $pythonSettingsDict := dict "Enabled" ("true") }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -67,6 +67,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.sharedStorage.mountContent }}
       {{- $_ := set $launcherSettingsDict "DataDirPVCName" $dataDirPVCName }}
     {{- end }}
+    {{- if .Values.launcher.useTemplates }}
+      {{- $_ := set $launcherSettingsDict "KubernetesUseTemplates" "true" }}
+      {{- $_ = set $launcherSettingsDict "ScratchPath" "/var/lib/rstudio-connect-launcher" }}
+    {{- end }}
     {{- $launcherDict := dict "Launcher" ( $launcherSettingsDict ) }}
     {{- $pythonSettingsDict := dict "Enabled" ("true") }}
     {{- $pythonDict := dict "Python" ( $pythonSettingsDict ) }}

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -25,7 +25,10 @@ data:
       {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "volumeMounts" ( list  $initContainerVolumeMount ) }}
       {{- $jobJsonInitContainer := dict "target" ("/spec/template/spec/initContainers/0") "name" ("defaultInitContainer") "json" $initContainerJson }}
     {{- /* set up job-json defaults */ -}}
-      {{- $jobJsonDefaults := list $jobJsonRuntimeVolume $jobJsonRuntimeMount $jobJsonInitContainer }}
+      {{- $jobJsonDefaults := list }}
+      {{- if not .Values.launcher.useTemplates }}
+        {{- $jobJsonDefaults = list $jobJsonRuntimeVolume $jobJsonRuntimeMount $jobJsonInitContainer }}
+      {{- end }}
     {{- /* build the configuration */ -}}
       {{- $profilesConfig := .Values.launcher.launcherKubernetesProfilesConf }}
       {{- $completeProfilesConfig := dict "launcher.kubernetes.profiles.conf" ($profilesConfig) }}
@@ -45,6 +48,7 @@ data:
       {{- $volumeMountList := append $sessionTemplate.pod.volumeMounts $rscVolumeMount }}
       {{- $_ := set $sessionTemplate.pod "volumeMounts" $volumeMountList }}
     {{- end }}
+{{- if not .Values.launcher.useTemplates }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,6 +59,7 @@ data:
   {{- /* configuration _files_ for job-json-overrides (uses variables from above) */ -}}
   {{- $configValue := dict "data" ($profilesConfig | deepCopy) "default" ($jobJsonDefaults | deepCopy) }}
   {{- include "rstudio-library.profiles.json-from-overrides-config" $configValue | indent 2 }}
+{{- end }}
 {{- if .Values.launcher.useTemplates }}
 ---
 apiVersion: v1

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   rstudio-connect.gcfg: |
     {{- include "rstudio-connect.config" . | nindent 4 }}
-{{- $sessionTemplate := deepCopy .Values.launcher.sessionTemplate }}
+{{- $sessionTemplate := deepCopy .Values.launcher.templateValues }}
 {{- if .Values.launcher.enabled }}
   runtime.yaml: |
     {{- include "rstudio-connect.runtimeYaml" . | nindent 4 }}
@@ -20,27 +20,27 @@ data:
       {{- $jobJsonRuntimeMount := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMount") "json" ( $rscVolumeMount ) }}
     {{- /* 3 - init container */ -}}
       {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-      {{- $initContainerImage := print .Values.launcher.contentInitContainer.repository ":" ( .Values.launcher.contentInitContainer.tag | default $defaultVersion ) }}
+      {{- $initContainerImage := print .Values.launcher.defaultInitContainer.repository ":" ( .Values.launcher.defaultInitContainer.tag | default $defaultVersion ) }}
+      {{- $initContainerPullPolicy := default .Values.launcher.defaultInitContainer.imagePullPolicy "IfNotPresent" }}
       {{- $initContainerVolumeMount := dict "name" ("rsc-volume") "mountPath" ("/mnt/rstudio-connect-runtime/") }}
-      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "volumeMounts" ( list  $initContainerVolumeMount ) }}
+      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "imagePullPolicy" ($initContainerPullPolicy) "volumeMounts" ( list  $initContainerVolumeMount ) }}
       {{- $jobJsonInitContainer := dict "target" ("/spec/template/spec/initContainers/0") "name" ("defaultInitContainer") "json" $initContainerJson }}
     {{- /* set up job-json defaults */ -}}
       {{- $jobJsonDefaults := list }}
-      {{- if not .Values.launcher.useTemplates }}
+      {{- if and (not .Values.launcher.useTemplates) .Values.launcher.defaultInitContainer.enabled }}
         {{- $jobJsonDefaults = list $jobJsonRuntimeVolume $jobJsonRuntimeMount $jobJsonInitContainer }}
       {{- end }}
-    {{- /* build the configuration */ -}}
+    {{- /* build the configuration for profiles */ -}}
       {{- $profilesConfig := .Values.launcher.launcherKubernetesProfilesConf }}
       {{- $completeProfilesConfig := dict "launcher.kubernetes.profiles.conf" ($profilesConfig) }}
       {{- $jobJsonFilePath := "/mnt/job-json-overrides/" }}
       {{- $profilesArg := dict "data" ($completeProfilesConfig | deepCopy) "jobJsonDefaults" ($jobJsonDefaults | deepCopy) "filePath" $jobJsonFilePath }}
     {{- /*
       may still need profiles, even if using templating (i.e. for resources, etc.)
-      in a bout of laziness, we put job-json-overrides in both places for now for backwards compatibility...
       */ -}}
     {{- include "rstudio-library.profiles.ini.advanced" $profilesArg | nindent 2 }}
     {{- /* append the jobJson stuff onto the template values */ -}}
-    {{- if .Values.launcher.useDefaultInitContainer }}
+    {{- if and .Values.launcher.useTemplates .Values.launcher.defaultInitContainer.enabled }}
       {{- $initList := append $sessionTemplate.pod.initContainers $initContainerJson }}
       {{- $_ := set $sessionTemplate.pod "initContainers" $initList }}
       {{- $volumeList := append $sessionTemplate.pod.volumes $emptyRscVolume }}

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -7,11 +7,11 @@ metadata:
 data:
   rstudio-connect.gcfg: |
     {{- include "rstudio-connect.config" . | nindent 4 }}
+{{- $sessionTemplate := deepCopy .Values.launcher.sessionTemplate }}
 {{- if .Values.launcher.enabled }}
   runtime.yaml: |
     {{- include "rstudio-connect.runtimeYaml" . | nindent 4 }}
-
-  {{- /* configuration for job-json-overrides (also used below) */ -}}
+  {{- /* configuration for job customization (also used below) */ -}}
     {{- /* 1 - volume */ -}}
       {{- $emptyRscVolume := dict "name" ("rsc-volume") "emptydir" (dict) }}
       {{- $jobJsonRuntimeVolume := dict "target" ("/spec/template/spec/volumes/-") "name" ("defaultRuntimeConnectVolume") "json" ( $emptyRscVolume ) }}
@@ -31,7 +31,20 @@ data:
       {{- $completeProfilesConfig := dict "launcher.kubernetes.profiles.conf" ($profilesConfig) }}
       {{- $jobJsonFilePath := "/mnt/job-json-overrides/" }}
       {{- $profilesArg := dict "data" ($completeProfilesConfig | deepCopy) "jobJsonDefaults" ($jobJsonDefaults | deepCopy) "filePath" $jobJsonFilePath }}
+    {{- /*
+      may still need profiles, even if using templating (i.e. for resources, etc.)
+      in a bout of laziness, we put job-json-overrides in both places for now for backwards compatibility...
+      */ -}}
     {{- include "rstudio-library.profiles.ini.advanced" $profilesArg | nindent 2 }}
+    {{- /* append the jobJson stuff onto the template values */ -}}
+    {{- if .Values.launcher.useDefaultInitContainer }}
+      {{- $initList := append $sessionTemplate.pod.initContainers $initContainerJson }}
+      {{- $_ := set $sessionTemplate.pod "initContainers" $initList }}
+      {{- $volumeList := append $sessionTemplate.pod.volumes $emptyRscVolume }}
+      {{- $_ := set $sessionTemplate.pod "volumes" $volumeList }}
+      {{- $volumeMountList := append $sessionTemplate.pod.volumeMounts $rscVolumeMount }}
+      {{- $_ := set $sessionTemplate.pod "volumeMounts" $volumeMountList }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -42,4 +55,20 @@ data:
   {{- /* configuration _files_ for job-json-overrides (uses variables from above) */ -}}
   {{- $configValue := dict "data" ($profilesConfig | deepCopy) "default" ($jobJsonDefaults | deepCopy) }}
   {{- include "rstudio-library.profiles.json-from-overrides-config" $configValue | indent 2 }}
+{{- if .Values.launcher.useTemplates }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rstudio-connect.fullname" . }}-templates
+  namespace: {{ $.Release.Namespace }}
+data:
+  rstudio-library-templates-data.tpl: |
+    {{- $tplData := dict "name" "rstudio-library.templates.data" "value" $sessionTemplate }}
+    {{- include "rstudio-library.templates.dataOutput" $tplData | nindent 4}}
+  job.tpl: |
+    {{- .Files.Get "files/job.tpl" | nindent 4 }}
+  service.tpl: |
+    {{- .Files.Get "files/service.tpl" | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -117,8 +117,10 @@ spec:
             mountPath: "/var/lib/rstudio-connect-launcher/Kubernetes/service.tpl"
             subPath: "service.tpl"
           {{- end }}
+          {{- if not .Values.launcher.useTemplates }}
           - name: overrides
             mountPath: "/mnt/job-json-overrides/"
+          {{- end }}
           - name: rstudio-connect-prestart
             mountPath: "/scripts/"
           {{- end }}
@@ -198,10 +200,12 @@ spec:
           name: {{ include "rstudio-connect.fullname" . }}-templates
           defaultMode: 0644
       {{- end }}
+      {{- if not .Values.launcher.useTemplates }}
       - name: overrides
         configMap:
           name: {{ include "rstudio-connect.fullname" . }}-overrides
           defaultMode: 0644
+      {{- end }}
       - name: rstudio-connect-prestart
         configMap:
           name: {{ include "rstudio-connect.fullname" . }}-prestart

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -106,16 +106,25 @@ spec:
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf"
             subPath: "launcher.kubernetes.profiles.conf"
+          {{- if .Values.launcher.useTemplates }}
+          - name: rstudio-connect-templates
+            mountPath: "/var/lib/rstudio-connect-launcher/Kubernetes/rstudio-library-templates-data.tpl"
+            subPath: "rstudio-library-templates-data.tpl"
+          - name: rstudio-connect-templates
+            mountPath: "/var/lib/rstudio-connect-launcher/Kubernetes/job.tpl"
+            subPath: "job.tpl"
+          - name: rstudio-connect-templates
+            mountPath: "/var/lib/rstudio-connect-launcher/Kubernetes/service.tpl"
+            subPath: "service.tpl"
           {{- end }}
-          {{- if or .Values.sharedStorage.create .Values.sharedStorage.mount }}
-          - name: rstudio-connect-data
-            mountPath: "{{ .Values.sharedStorage.path }}"
-          {{- end }}
-          {{- if .Values.launcher.enabled }}
           - name: overrides
             mountPath: "/mnt/job-json-overrides/"
           - name: rstudio-connect-prestart
             mountPath: "/scripts/"
+          {{- end }}
+          {{- if or .Values.sharedStorage.create .Values.sharedStorage.mount }}
+          - name: rstudio-connect-data
+            mountPath: "{{ .Values.sharedStorage.path }}"
           {{- end }}
           {{ include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | indent 10 }}
       {{- if .Values.pod.volumeMounts }}
@@ -183,6 +192,12 @@ spec:
 {{ toYaml .Values.pod.volumes | indent 6 }}
       {{- end }}
       {{- if .Values.launcher.enabled }}
+      {{- if .Values.launcher.useTemplates }}
+      - name: rstudio-connect-templates
+        configMap:
+          name: {{ include "rstudio-connect.fullname" . }}-templates
+          defaultMode: 0644
+      {{- end }}
       - name: overrides
         configMap:
           name: {{ include "rstudio-connect.fullname" . }}-overrides

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -48,7 +48,7 @@ extraObjects: []
 # -- Defines the RStudio Connect image to deploy
 image:
   # -- The repository to use for the main pod image
-  repository: ghcr.io/rstudio/rstudio-connect
+  repository: ghcr.io/rstudio/rstudio-connect-preview
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # -- The imagePullPolicy for the main pod image
@@ -235,7 +235,7 @@ launcher:
   defaultInitContainer:
     enabled: true
     # -- The repository to use for the Content InitContainer image
-    repository: ghcr.io/rstudio/rstudio-connect-content-init
+    repository: ghcr.io/rstudio/rstudio-connect-content-init-preview
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
     imagePullPolicy: ""

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -211,7 +211,8 @@ launcher:
   customRuntimeYaml: false
   # -- User definition of launcher.kubernetes.profiles.conf for job customization
   launcherKubernetesProfilesConf: {}
-  useTemplates: false
+  # -- Whether to use launcher templates when launching sessions. Defaults to true
+  useTemplates: true
   # -- Values to pass along to the RStudio Connect session templating process
   templateValues:
     service:
@@ -233,11 +234,13 @@ launcher:
       labels: {}
   # -- Image definition for the default RStudio Connect Content InitContainer
   defaultInitContainer:
+    # -- Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way.
     enabled: true
     # -- The repository to use for the Content InitContainer image
     repository: ghcr.io/rstudio/rstudio-connect-content-init-preview
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
+    # -- The imagePullPolicy for the default initContainer
     imagePullPolicy: ""
 
 # -- A nested map of maps that generates the rstudio-connect.gcfg file

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -256,6 +256,13 @@ config:
     DataDir: /var/lib/rstudio-connect
   Scheduler:
     InitTimeout: 5m
+  Logging:
+    Enabled: true
+    ServiceLog: STDOUT
+    ServiceLogLevel: INFO # INFO, WARNING or ERROR
+    ServiceLogFormat: TEXT # TEXT or JSON
+    AccessLog: STDOUT
+    AccessLogFormat: COMMON # COMMON, COMBINED, or JSON
   Metrics:
     Enabled: true
     GraphiteEnabled: true

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -212,9 +212,8 @@ launcher:
   # -- User definition of launcher.kubernetes.profiles.conf for job customization
   launcherKubernetesProfilesConf: {}
   useTemplates: false
-  useDefaultInitContainer: true
   # -- Values to pass along to the RStudio Connect session templating process
-  sessionTemplate:
+  templateValues:
     service:
       type: ClusterIP
       annotations: {}
@@ -232,12 +231,14 @@ launcher:
     job:
       annotations: {}
       labels: {}
-  # -- Image definition for the RStudio Connect Content InitContainer
-  contentInitContainer:
+  # -- Image definition for the default RStudio Connect Content InitContainer
+  defaultInitContainer:
+    enabled: true
     # -- The repository to use for the Content InitContainer image
     repository: ghcr.io/rstudio/rstudio-connect-content-init
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
+    imagePullPolicy: ""
 
 # -- A nested map of maps that generates the rstudio-connect.gcfg file
 # @default -- [RStudio Connect Configuration Reference](https://docs.rstudio.com/connect/admin/appendix/configuration/)

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -262,10 +262,10 @@ config:
   Logging:
     Enabled: true
     ServiceLog: STDOUT
-    ServiceLogLevel: INFO # INFO, WARNING or ERROR
-    ServiceLogFormat: TEXT # TEXT or JSON
+    ServiceLogLevel: INFO    # INFO, WARNING or ERROR
+    ServiceLogFormat: TEXT   # TEXT or JSON
     AccessLog: STDOUT
-    AccessLogFormat: COMMON # COMMON, COMBINED, or JSON
+    AccessLogFormat: COMMON  # COMMON, COMBINED, or JSON
   Metrics:
     Enabled: true
     GraphiteEnabled: true

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -211,6 +211,27 @@ launcher:
   customRuntimeYaml: false
   # -- User definition of launcher.kubernetes.profiles.conf for job customization
   launcherKubernetesProfilesConf: {}
+  useTemplates: false
+  useDefaultInitContainer: true
+  # -- Values to pass along to the RStudio Connect session templating process
+  sessionTemplate:
+    service:
+      type: ClusterIP
+      annotations: {}
+      labels: {}
+    pod:
+      annotations: {}
+      labels: {}
+      serviceAccountName: ""
+      volumes: []
+      volumeMounts: []
+      imagePullPolicy: ""
+      imagePullSecrets: []
+      initContainers: []
+      extraContainers: []
+    job:
+      annotations: {}
+      labels: {}
   # -- Image definition for the RStudio Connect Content InitContainer
   contentInitContainer:
     # -- The repository to use for the Content InitContainer image


### PR DESCRIPTION
- Switches Connect to using templating (potentially breaking if people are using job-json-overrides)
  - Switches to using a ClusterIP service for sessions
- switches `contentInitContainer` to `defaultInitContainer` - breaking if people are using that key
- Enables logging using the new logging configuration for 2022.07
- Bump RSC version to a preview version
- Bump version to a preview / alpha version