### PR TITLE
fix up workbench flexibility and high availability

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.17
+version: 0.5.18
 apiVersion: v2
 appVersion: 2022.02.3-492.pro3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -2,7 +2,7 @@ name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
 version: 0.5.18
 apiVersion: v2
-appVersion: 2022.02.3-492.pro3
+appVersion: 2022.07.1-554.pro3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:2022.02.3-492.pro3
+      image: rstudio/rstudio-workbench:2022.07.1-554.pro3
     - name: r-session-complete
-      image: rstudio/r-session-complete:bionic-2022.02.3-492.pro3
+      image: rstudio/r-session-complete:bionic-2022.07.1-554.pro3
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,11 @@
+# 0.5.18
+
+- Add `pod.affinity` value for configuration of pod affinity
+- Fix issue where hostnames are not routable within kubernetes while load balancing
+  - Because `hostname` output is not routable between pods, we use `www-host-name=$(hostname -i)`
+    to route by IP address
+  - This fixes a load balancing issue with some hard to understand `asio.netdb` errors
+
 # 0.5.17
 
 - Bump rstudio-library chart version
@@ -6,6 +14,11 @@
 # 0.5.16
 
 - Add the ability to set annotations to the Persistent Volume Claim.
+
+# 0.5.15
+
+- Bump Workbench to version 2022.02.3-492.pro3
+- Fix typo in the README
 
 # 0.5.14
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,6 @@
 # 0.5.18
 
+- Add a ServiceMonitor CRD and values to configure
 - Add `pod.affinity` value for configuration of pod affinity
 - Fix issue where hostnames are not routable within kubernetes while load balancing
   - Because `hostname` output is not routable between pods, we use `www-host-name=$(hostname -i)`

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.18](https://img.shields.io/badge/Version-0.5.18-informational?style=flat-square) ![AppVersion: 2022.02.3-492.pro3](https://img.shields.io/badge/AppVersion-2022.02.3--492.pro3-informational?style=flat-square)
+![Version: 0.5.18](https://img.shields.io/badge/Version-0.5.18-informational?style=flat-square) ![AppVersion: 2022.07.1-554.pro3](https://img.shields.io/badge/AppVersion-2022.07.1--554.pro3-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -408,6 +408,9 @@ config:
 | service.nodePort | bool | `false` | the nodePort to use when using service type NodePort. If not defined, Kubernetes will provide one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
 | service.type | string | `"NodePort"` | the service type (i.e. NodePort, LoadBalancer, etc.) |
+| serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
+| serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
+| serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Prometheus Operator is running). Defaults to the release namespace |
 | session.defaultConfigMount | bool | `true` | Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this |
 | session.defaultSecretMountPath | string | `"/mnt/session-secret/"` | The path to mount the sessionSecret (from `config.sessionSecret`) onto the server and session pods |
 | session.image.repository | string | `"rstudio/r-session-complete"` | The repository to use for the session image |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.17](https://img.shields.io/badge/Version-0.5.17-informational?style=flat-square) ![AppVersion: 2022.02.3-492.pro3](https://img.shields.io/badge/AppVersion-2022.02.3--492.pro3-informational?style=flat-square)
+![Version: 0.5.18](https://img.shields.io/badge/Version-0.5.18-informational?style=flat-square) ![AppVersion: 2022.02.3-492.pro3](https://img.shields.io/badge/AppVersion-2022.02.3--492.pro3-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.17:
+To install the chart with the release name `my-release` at version 0.5.18:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.17
+helm install my-release rstudio/rstudio-workbench --version=0.5.18
 ```
 
 ## Required Configuration
@@ -383,6 +383,7 @@ config:
 | loadBalancer.forceEnabled | bool | `false` | whether to force the loadBalancer to be enabled. Otherwise requires replicas > 1. Worth setting if you are HA but may only have one node |
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | nodeSelector | object | `{}` |  |
+| pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-workbench pods |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.labels | object | `{}` | Additional labels to add to the rstudio-workbench pods |

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -24,7 +24,7 @@ main() {
   if [[ -n "$RSW_LOAD_BALANCING" ]]; then
     _logf "Enabling load-balancing by making sure that the /mnt/load-balancer/rstudio/load-balancer file exists"
     mkdir -p /mnt/load-balancer/rstudio/
-    touch "/mnt/load-balancer/rstudio/load-balancer"
+    echo -e "balancer=sessions\nwww-host-name=$(hostname -i)" > /mnt/load-balancer/rstudio/load-balancer
   fi
 
   _logf 'Preparing dirs'

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -36,6 +36,9 @@ main() {
 
   _writeEtcRstudioReadme
 
+  # TODO: necessary until https://github.com/rstudio/rstudio-pro/issues/3638
+  cp /mnt/configmap/rstudio/health-check /mnt/dynamic/rstudio/
+
   _logf 'Replacing process with %s' "${startup_script}"
   exec "${startup_script}"
 }

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -189,6 +189,9 @@ containers:
   volumeMounts:
     - name: graphite-exporter-config
       mountPath: "/mnt/graphite/"
+  ports:
+  - containerPort: 9108
+    name: metrics
 {{- end }}
 {{- if .Values.pod.sidecar }}
 {{ toYaml .Values.pod.sidecar }}

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -83,6 +83,7 @@ containers:
   imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
   ports:
   - containerPort: 8787
+    name: http
   securityContext:
 {{ toYaml .Values.securityContext | indent 4 }}
   volumeMounts:

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.pod.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
       {{- end }}

--- a/charts/rstudio-workbench/templates/service-monitor.yaml
+++ b/charts/rstudio-workbench/templates/service-monitor.yaml
@@ -18,4 +18,25 @@ spec:
   selector:
     matchLabels:
       {{- include "rstudio-workbench.selectorLabels" . | nindent 6 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rstudio-workbench.fullname" . }}-health
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "rstudio-workbench.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: http
+      path: /health-check
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "rstudio-workbench.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/rstudio-workbench/templates/service-monitor.yaml
+++ b/charts/rstudio-workbench/templates/service-monitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.prometheusExporter.enabled .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rstudio-workbench.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "rstudio-workbench.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "rstudio-workbench.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -14,8 +14,13 @@ spec:
     {{- include "rstudio-workbench.selectorLabels" . | nindent 4 }}
   ports:
   - protocol: TCP
+    name: http
     port: {{ .Values.service.port }}
     {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
     targetPort: 8787
+  {{- if .Values.prometheusExporter.enabled }}
+  - name: metrics
+    port: 9108
+  {{- end }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -388,6 +388,28 @@ config:
       "*":
         log-level: info
         logger-type: stderr
+    health-check: |
+      # HELP active_sessions health_check metric Active RStudio sessions
+      # TYPE active_sessions gauge
+      active_sessions #active-sessions#
+      # HELP idle_seconds health_check metric Time since active RStudio sessions
+      # TYPE idle_seconds gauge
+      idle_seconds #idle-seconds#
+      # HELP cpu_percent health_check metric cpu (percentage)
+      # TYPE cpu_percent gauge
+      cpu_percent #cpu-percent#
+      # HELP memory_percent health_check metric memory used (percentage)
+      # TYPE memory_percent gauge
+      memory_percent #memory-percent#
+      # HELP swap_percent health_check metric swap used (percentage)
+      # TYPE swap_percent gauge
+      swap_percent #swap-percent#
+      # HELP load_average health_check metric cpu load average
+      # TYPE load_average gauge
+      load_average #load-average#
+      # HELP license_days_left the number of days left on the license
+      # TYPE license_days gauge
+      license_days_left #license-days-left#
   # -- a map of server-scoped config files (akin to `config.server`), but with specific behavior that supports profiles. See README for more information.
   profiles: {}
   # -- a map of server-scoped config files (akin to `config.server`), but with .dcf file formatting (i.e. `launcher-mounts`, `launcher-env`, etc.)

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -239,6 +239,8 @@ pod:
   labels: {}
   # -- sidecar is an array of containers that will be run alongside the main container
   sidecar: false
+  # -- A map used verbatim as the pod's "affinity" definition
+  affinity: {}
 
 prometheusExporter:
   # -- whether the  prometheus exporter sidecar should be enabled

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -252,6 +252,17 @@ prometheusExporter:
     tag: "v0.9.0"
     imagePullPolicy: IfNotPresent
 
+serviceMonitor:
+  # -- Whether to create a ServiceMonitor CRD for use with a Prometheus Operator
+  enabled: false
+  # -- Namespace to create the ServiceMonitor in (usually the same as the one in
+  # which the Prometheus Operator is running). Defaults to the release namespace
+  namespace: ""
+  # -- additionalLabels normally includes the release name of the Prometheus
+  # Operator
+  additionalLabels: {}
+  #   release: kube-prometheus-stack
+
 rbac:
   # -- Whether to create rbac. (also depends on launcher.enabled = true)
   create: true


### PR DESCRIPTION
fix ip address issue. Workbench stores the `hostname` in the database and tries to route using that hostname. This is not routable within Kubernetes, so we store the ip address now. This should make load balancing more fault tolerant and remove the intermittent `asio.netdb` errors (which seem to be mostly benign in this setup, but are concerning to customers nonetheless)

Also add:
- affinity
- serviceMonitor
- an attempt at turning our health check into a prometheus end point (currently limited due to https://github.com/rstudio/rstudio-pro/issues/3638)