### PR TITLE
Remove the requirement for privileged RSPM containers by default

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.9
+version: 0.3.10
 apiVersion: v2
 appVersion: 2022.04.0-7
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,8 @@
+# 0.3.10
+
+- The Package Manager container no longer runs as privileged by default.
+  Instead, it uses stricter security settings with a smaller set of elevated
+  privileges.
 
 # 0.3.9
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.9:
+To install the chart with the release name `my-release` at version 0.3.10:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.3.9
+helm install my-release rstudio/rstudio-pm --version=0.3.10
 ```
 
 ## Required Configuration
@@ -112,7 +112,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":4242},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | livenessProbe is used to configure the container's livenessProbe |
 | nameOverride | string | `""` | the name of the chart deployment (can be overridden) |
 | pod.annotations | object | `{}` | annotations is a map of keys / values that will be added as annotations to the pods |
-| pod.containerSecurityContext | object | `{"privileged":true}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container |
+| pod.containerSecurityContext | object | `{"capabilities":{"add":["SYS_ADMIN","DAC_OVERRIDE","SETGID","SETUID"],"drop":["ALL"]}}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container |
 | pod.env | list | `[]` | env is an array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
 | pod.securityContext | object | `{}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the pod |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "2112"
+        # Required for the startup R version check that runs under rsandbox when
+        # RSPM runs as root.
+        container.apparmor.security.beta.kubernetes.io/rspm: unconfined
         {{- include "rstudio-pm.pod.annotations" . | nindent 8 }}
       labels:
         {{- include "rstudio-pm.selectorLabels" . | nindent 8 }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -106,7 +106,11 @@ pod:
   securityContext: {}
   # -- the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the main Package Manager container
   containerSecurityContext:
-    privileged: true
+    capabilities:
+      drop: ["ALL"]
+      # These are required for the startup R version check that runs under
+      # rsandbox when RSPM runs as root.
+      add: ["SYS_ADMIN", "DAC_OVERRIDE", "SETGID", "SETUID"]
 
 # -- Extra objects to deploy (value evaluated as a template)
 extraObjects: []


### PR DESCRIPTION
Instead, set a more granular security context: enable only the necessary capabilities (which includes `SYS_ADMIN` at this time) and disable AppArmor via annotation.

This is essentially follow-up work on the sandboxing changes made in the last RSPM release.

Note that the default security context still assumes that RSPM is running as root. When that is the case, RSPM runs an R version check on startup that cannot be disabled even if `Git.AllowUnsandboxedGitBuilds = true`, hence the need to include these settings unconditionally.

When not running as root, no additional capabilities are required and `seccomp` and AppArmor must be disabled only to run sandboxed Git builds, which the user can opt out of.