### PR TITLE
Enable the bundled R version in RSPM by default

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.12
+version: 0.3.13
 apiVersion: v2
 appVersion: 2022.04.0-7
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,8 @@
+# 0.3.13
+
+- Package Manager now enables the bundled R version (which is required to use
+  Git-backed packages) by default.
+
 # 0.3.12
 
 - Add the ability to set annotations to the Persistent Volume Claim.

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -88,7 +88,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | awsAccessKeyId | bool | `false` | awsAccessKeyId is the access key id for s3 access, used also to gate file creation |
 | awsSecretAccessKey | string | `nil` | awsSecretAccessKey is the secret access key, needs to be filled if access_key_id is |
 | command | bool | `false` | command is the pod's run command. By default, it uses the container's default |
-| config | object | `{"HTTP":{"Listen":":4242"},"Launcher":{"AdminGroup":"root","ServerUser":"root"},"Metrics":{"Enabled":true}}` | config is a nested map of maps that generates the rstudio-pm.gcfg file |
+| config | object | `{"HTTP":{"Listen":":4242"},"Launcher":{"AdminGroup":"root","ServerUser":"root"},"Metrics":{"Enabled":true},"Server":{"RVersion":"/opt/R/3.6.2/"}}` | config is a nested map of maps that generates the rstudio-pm.gcfg file |
 | extraContainers | list | `[]` | sidecar container list |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template) |
 | fullnameOverride | string | `""` | the full name of the release (can be overridden) |

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.3.12](https://img.shields.io/badge/Version-0.3.12-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
+![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.12:
+To install the chart with the release name `my-release` at version 0.3.13:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.3.12
+helm install my-release rstudio/rstudio-pm --version=0.3.13
 ```
 
 ## Required Configuration

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -198,6 +198,8 @@ serviceMonitor:
 
 # -- config is a nested map of maps that generates the rstudio-pm.gcfg file
 config:
+  Server:
+    RVersion: "/opt/R/3.6.2/"
   HTTP:
     Listen: :4242
   Metrics:


### PR DESCRIPTION
The official image already ships with R to enable Git builds, but they are not turned on by default (because the configuration must point to the install location). This PR adds the bundled R version to the default configuration so that Git builds work out of the box.