### PR TITLE
Add Service Account support and related doc improvements for Package Manager

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.3.13
+version: 0.3.14
 apiVersion: v2
 appVersion: 2022.04.0-7
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,11 @@
+# 0.3.14
+
+- A Service Account is now created by default. This is primarily to facilitate
+  better IAM security when using Package Manager with S3.
+
+- `pod.serviceAccountName` has been deprecated in favour of the new
+  `serviceAccount.name` setting.
+
 # 0.3.13
 
 - Package Manager now enables the bundled R version (which is required to use

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -46,22 +46,44 @@ This chart requires the following in order to function:
 
 ## S3 Configuration
 
-Package Manager can be configured to store data in S3 buckets (see the [Admin Guide](https://docs.rstudio.com/rspm/admin/files-directories/#data-destinations)
-for more details). When configured this way, AWS access credentials are required. You must set the `awsAccessKeyId` and `awsSecretAccessKey` chart values
-to ensure that RSPM will be able to authenticate with your configured S3 buckets.
+Package Manager [can be configured to store its data in S3
+buckets](https://docs.rstudio.com/rspm/admin/files-directories/#data-destinations),
+which eliminates the need to provision shared storage for multiple replicas. A
+`values.yaml` file using S3 might contain something like the following:
 
-Configuring Package Manager to use S3 requires modifying the `.gfcg` configuration file as explained below. A sample chart values configuration might look like the following:
-
-```
-awsAccessKeyId: your-access-key-id
-awsSecretAccessKey: your-secret-access-key
-
+``` yaml
 config:
   Storage:
     Default: s3
   S3Storage:
     Bucket: your-s3-bucket
 ```
+
+If you are running on EKS, we strongly suggest using [IAM Roles for Service
+Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+to manage the credentials needed to access S3. In this scenario, once you have
+[created an IAM
+role](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html),
+you can use this role as an annotation on the existing Service Account:
+
+``` yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+```
+
+If you are unable to use IAM Roles for Service Accounts, there are any number of
+alternatives for injecting AWS credentials into a container. As a fallback, the
+chart supports setting static credentials:
+
+``` yaml
+awsAccessKeyId: your-access-key-id
+awsSecretAccessKey: your-secret-access-key
+```
+
+Bear in mind that static, long-lived credentials are the least secure option and
+should be avoided if at all possible.
 
 ## General Principles
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
+![Version: 0.3.14](https://img.shields.io/badge/Version-0.3.14-informational?style=flat-square) ![AppVersion: 2022.04.0-7](https://img.shields.io/badge/AppVersion-2022.04.0--7-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.13:
+To install the chart with the release name `my-release` at version 0.3.14:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.3.13
+helm install my-release rstudio/rstudio-pm --version=0.3.14
 ```
 
 ## Required Configuration

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -119,7 +119,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | pod.labels | object | `{}` | Additional labels to add to the rstudio-pm pods |
 | pod.lifecycle | object | `{}` | Container [lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) |
 | pod.securityContext | object | `{}` | the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the pod |
-| pod.serviceAccountName | bool | `false` | serviceAccountName is a string representing the service account of the pod spec |
+| pod.serviceAccountName | string | `""` | Deprecated, use `serviceAccount.name` instead |
 | pod.volumeMounts | list | `[]` | volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | volumes is an array of maps that is injected as-is into the "volumes:" component of the pod spec |
 | priorityClassName | string | `nil` | The pod's priorityClassName |
@@ -133,6 +133,9 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | service.nodePort | bool | `false` | The explicit nodePort to use for `service.type` NodePort. If not provided, Kubernetes will choose one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
 | service.type | string | `"ClusterIP"` | The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to expose the service using your cloud provider's load balancer) |
+| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount, if any |
+| serviceAccount.create | bool | `true` | Whether to create a [Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) |
+| serviceAccount.name | string | When `serviceAccount.create` is `true` this defaults to the full name of the release | ServiceAccount to use, if any, or an explicit name for the one we create |
 | serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
 | serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Operator is running). Defaults to the release namespace |

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -24,22 +24,44 @@ This chart requires the following in order to function:
 
 ## S3 Configuration
 
-Package Manager can be configured to store data in S3 buckets (see the [Admin Guide](https://docs.rstudio.com/rspm/admin/files-directories/#data-destinations)
-for more details). When configured this way, AWS access credentials are required. You must set the `awsAccessKeyId` and `awsSecretAccessKey` chart values
-to ensure that RSPM will be able to authenticate with your configured S3 buckets.
+Package Manager [can be configured to store its data in S3
+buckets](https://docs.rstudio.com/rspm/admin/files-directories/#data-destinations),
+which eliminates the need to provision shared storage for multiple replicas. A
+`values.yaml` file using S3 might contain something like the following:
 
-Configuring Package Manager to use S3 requires modifying the `.gfcg` configuration file as explained below. A sample chart values configuration might look like the following:
-
-```
-awsAccessKeyId: your-access-key-id
-awsSecretAccessKey: your-secret-access-key
-
+``` yaml
 config:
   Storage:
     Default: s3
   S3Storage:
     Bucket: your-s3-bucket
 ```
+
+If you are running on EKS, we strongly suggest using [IAM Roles for Service
+Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+to manage the credentials needed to access S3. In this scenario, once you have
+[created an IAM
+role](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html),
+you can use this role as an annotation on the existing Service Account:
+
+``` yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+```
+
+If you are unable to use IAM Roles for Service Accounts, there are any number of
+alternatives for injecting AWS credentials into a container. As a fallback, the
+chart supports setting static credentials:
+
+``` yaml
+awsAccessKeyId: your-access-key-id
+awsSecretAccessKey: your-secret-access-key
+```
+
+Bear in mind that static, long-lived credentials are the least secure option and
+should be avoided if at all possible.
 
 ## General Principles
 

--- a/charts/rstudio-pm/templates/NOTES.txt
+++ b/charts/rstudio-pm/templates/NOTES.txt
@@ -20,3 +20,8 @@ WARNING: `image.pullPolicy` value has been removed in chart version 0.2.7. Pleas
   - It is also easier to remember since this is what the kubernetes value is actually called
   - See `NEWS.md` to note other changes between releases
 {{- end }}
+
+{{- if hasKey .Values.pod "serviceAccountName" }}
+NOTE: `pod.serviceAccountName` is deprecated and will be removed in the future.
+Please use `serviceAccount.name` instead.
+{{- end }}

--- a/charts/rstudio-pm/templates/_helpers.tpl
+++ b/charts/rstudio-pm/templates/_helpers.tpl
@@ -80,3 +80,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ $key }}: {{ $value | quote }}
 {{ end }}
 {{- end -}}
+
+{{/*
+Create the name of the ServiceAccount
+*/}}
+{{- define "rstudio-pm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "rstudio-pm.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
       {{- end }}
       {{- if .Values.pod.serviceAccountName }}
       serviceAccountName: {{ .Values.pod.serviceAccountName }}
+      {{- else }}
+      serviceAccountName: {{ include "rstudio-pm.serviceAccountName" . }}
       {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rstudio-pm/templates/serviceaccount.yaml
+++ b/charts/rstudio-pm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rstudio-pm.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rstudio-pm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -99,8 +99,8 @@ pod:
   volumes: []
   # -- volumeMounts is an array of maps that is injected as-is into the "volumeMounts" component of the pod spec
   volumeMounts: []
-  # -- serviceAccountName is a string representing the service account of the pod spec
-  serviceAccountName: false
+  # -- Deprecated, use `serviceAccount.name` instead
+  serviceAccountName: ""
   # -- annotations is a map of keys / values that will be added as annotations to the pods
   annotations: {}
   # -- Additional labels to add to the rstudio-pm pods
@@ -184,6 +184,16 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+serviceAccount:
+  # -- Whether to create a [Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+  create: true
+  # -- ServiceAccount to use, if any, or an explicit name for the one we create
+  # @default -- When `serviceAccount.create` is `true` this defaults to the full name of the release
+  name: ""
+  # -- Annotations for the ServiceAccount, if any
+  annotations: {}
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
 
 serviceMonitor:
   # -- Whether to create a ServiceMonitor CRD for use with a Prometheus Operator


### PR DESCRIPTION
This PR adds `ServiceAccount` creation for the Package Manager pod, primarily to support the use of [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for S3 access. Not only is this the best-regarded choice from a security perspective, it is also what we use internally.

Relatedly, I've also totally overhauled the S3-related section of the README to guide users towards that path.

cc @rodrigobrim