### PR TITLE
DRAFT: add an adhoc chart-releaser

### DIFF
--- a/.github/workflows/chart-releaser-adhoc.yaml
+++ b/.github/workflows/chart-releaser-adhoc.yaml
@@ -1,0 +1,47 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+name: Release Charts (adhoc)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  release:
+    # from https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/release-adhoc') }}
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/pr-fetch@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.0
+        with:
+          charts_repo_url: https://helm.rstudio.com
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser (other)
+        uses: helm/chart-releaser-action@v1.2.0
+        with:
+          charts_dir: other-charts
+          charts_repo_url: https://helm.rstudio.com
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
add an adhoc chart-releaser that is triggered by the `/release-adhoc`…

This allows for releasing (in an adhoc fashion) from a branch. Unfortunately the behavior and how this will work for non-devel releases is not super well-defined. If chart-releaser adds support for filtering to only certain releases, that would be helpful to make this safer: https://github.com/helm/chart-releaser/issues/196

In particular, it is most concerning if chart A moves to `--devel` version on the `dev` branch, chart B moves to a newer version on `main`, and then CI runs based on a `/release-adhoc` comment. It would also be concerning if chart A or chart B move to a newer version on a branch and then publish a "non-devel" version from the branch.

It requires being an `OWNER` on the repository, although it is unclear if this correlates to `ADMIN` privileges within the organization.