### PR TITLE
Rsc fixup

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.39-alpha04
+version: 0.2.39-rc01
 apiVersion: v2
 appVersion: 2022.07.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.39-alpha04](https://img.shields.io/badge/Version-0.2.39--alpha04-informational?style=flat-square) ![AppVersion: 2022.07.0](https://img.shields.io/badge/AppVersion-2022.07.0-informational?style=flat-square)
+![Version: 0.2.39-rc01](https://img.shields.io/badge/Version-0.2.39--rc01-informational?style=flat-square) ![AppVersion: 2022.07.0](https://img.shields.io/badge/AppVersion-2022.07.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.39-alpha04:
+To install the chart with the release name `my-release` at version 0.2.39-rc01:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install --devel my-release rstudio/rstudio-connect --version=0.2.39-alpha04
+helm install --devel my-release rstudio/rstudio-connect --version=0.2.39-rc01
 ```
 
 ## Required Configuration
@@ -135,7 +135,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | sharedStorage.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Annotations for the Persistent Volume Claim |
 | sharedStorage.create | bool | `false` | Whether to create the persistentVolumeClaim for shared storage |
 | sharedStorage.mount | bool | `false` | Whether the persistentVolumeClaim should be mounted (even if not created) |
-| sharedStorage.mountContent | bool | `false` | Whether the persistentVolumeClaim should be mounted to the content pods created by the Launcher |
+| sharedStorage.mountContent | bool | `true` | Whether the persistentVolumeClaim should be mounted to the content pods created by the Launcher |
 | sharedStorage.name | string | `""` | The name of the pvc. By default, computes a value from the release name |
 | sharedStorage.path | string | `"/var/lib/rstudio-connect"` | The path to mount the sharedStorage claim within the Connect pod |
 | sharedStorage.requests.storage | string | `"10Gi"` | The volume of storage to request for this persistent volume claim |

--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -11,8 +11,18 @@ metadata:
     {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
     {{- end }}
     {{- end }}
+    {{- with $templateData.job.annotations }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
   labels:
     {{- with .Job.metadata.job.labels }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
+    {{- with $templateData.job.labels }}
     {{- range $key, $val := . }}
     {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
     {{- end }}
@@ -42,8 +52,18 @@ spec:
         {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
         {{- end }}
         {{- end }}
+        {{- with $templateData.pod.annotations }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- end }}
       labels:
         {{- with .Job.metadata.pod.labels }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- end }}
+        {{- with $templateData.pod.labels }}
         {{- range $key, $val := . }}
         {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
         {{- end }}

--- a/charts/rstudio-connect/files/service.tpl
+++ b/charts/rstudio-connect/files/service.tpl
@@ -12,9 +12,19 @@ metadata:
     {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
     {{- end }}
     {{- end }}
+    {{- with $templateData.service.annotations }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+    {{- end }}
+    {{- end }}
   labels:
     job-name: {{ toYaml .Job.id }}
     {{- with .Job.metadata.service.labels }}
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+    {{- end }}
+    {{- end }}
+    {{- with $templateData.service.labels }}
     {{- range $key, $val := . }}
     {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
     {{- end }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -16,19 +16,11 @@ Please consider removing this configuration value.
 {{- end }}
 
 {{- if hasKey .Values.config "Launcher" }}
-{{- if hasKey .Values.config.Launcher "DataDir" }}
-{{- if contains ":" .Values.config.Launcher.DataDir }}
-
-NOTE: `config.Launcher.DataDir` is configured with a ":". When a ":" character
-is found, Connect treats this configuration as an NFS connection string. Connect then
-uses this information to create NFS volumes when mounting the DataDir to the content
-pods created by the Launcher. This feature will be removed in the next release of Connect.
-  - Please consider setting `sharedStorage.mountContent = true` instead.
-  - When `sharedStorage.mountContent = true`, `config.Launcher.DataDir`
-    should not be set.
-
-{{- end }}
-{{- end }}
+  {{- if hasKey .Values.config.Launcher "DataDir" }}
+    {{- if contains ":" .Values.config.Launcher.DataDir }}
+      {{- fail "NOTE: `config.Launcher.DataDir` is configured with a ':'. This functionality has been removed. Instead, please use a Persistent Volume Claim through the `sharedStorage` values and unset `config.Launcher.DataDir`." -}}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- end }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -63,8 +63,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.launcher.enabled }}
     {{- $namespace := default $.Release.Namespace .Values.launcher.namespace }}
     {{- $launcherSettingsDict := dict "Enabled" ("true") "Kubernetes" ("true") "ClusterDefinition" (list "/etc/rstudio-connect/runtime.yaml") "KubernetesNamespace" ($namespace) "KubernetesProfilesConfig" ("/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf") }}
-    {{- $dataDirPVCName := default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
-    {{- if .Values.sharedStorage.mountContent }}
+    {{- if and (or .Values.sharedStorage.create .Values.sharedStorage.mount) .Values.sharedStorage.mountContent }}
+      {{- $dataDirPVCName := default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
       {{- $_ := set $launcherSettingsDict "DataDirPVCName" $dataDirPVCName }}
     {{- end }}
     {{- if .Values.launcher.useTemplates }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -16,7 +16,7 @@ sharedStorage:
   # -- The path to mount the sharedStorage claim within the Connect pod
   path: /var/lib/rstudio-connect
   # -- Whether the persistentVolumeClaim should be mounted to the content pods created by the Launcher
-  mountContent: false
+  mountContent: true
   # -- The type of storage to use. Must allow ReadWriteMany
   storageClassName: false
   # -- A list of accessModes that are defined for the storage PVC (represented as YAML)


### PR DESCRIPTION
- switch `mountContent` default to `true` so that initial deployment is easier
- fix up missing labels/annotations in the template
- make the existing check for `:` fatal