### PR TITLE
bump chart version to 0.3.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.2.39-rc01
+version: 0.3.0
 apiVersion: v2
 appVersion: 2022.07.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,8 +1,9 @@
-# Devel
+# 0.3.0
 
 - BETA BREAKING: We moved `launcher.contentInitContainer` customizations to `launcher.defaultInitContainer`
   - This should only affect if you are using `launcher.enabled=true`, which is still in Beta
   - Values are treated the same, so a simple modification to the key should resolve any issues
+- RStudio Connect with off-host execution is now in Public Beta
 - Add support for the `launcher.useTemplates` value
   - This enables greater customization of session creation as well as better labels and annotations out of the box
   - To make use of the default session templates, configure values in `launcher.sessionTemplate`

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.2.39-rc01](https://img.shields.io/badge/Version-0.2.39--rc01-informational?style=flat-square) ![AppVersion: 2022.07.0](https://img.shields.io/badge/AppVersion-2022.07.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: 2022.07.0](https://img.shields.io/badge/AppVersion-2022.07.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -23,12 +23,19 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.39-rc01:
+To install the chart with the release name `my-release` at version 0.3.0:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install --devel my-release rstudio/rstudio-connect --version=0.2.39-rc01
+helm install my-release rstudio/rstudio-connect --version=0.3.0
 ```
+
+### NOTE
+
+> NOTE: Off-Host execution via Kubernetes (a.k.a. running Connect content in
+> their own dedicated pods) is now in Public Beta. Please
+> [see the formal documentation
+> here](https://docs.rstudio.com/helm/rstudio-connect/kubernetes-howto/intro/overview.html).
 
 ## Required Configuration
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -8,6 +8,13 @@
 
 {{ template "rstudio.install" . }}
 
+### NOTE
+
+> NOTE: Off-Host execution via Kubernetes (a.k.a. running Connect content in
+> their own dedicated pods) is now in Public Beta. Please
+> [see the formal documentation
+> here](https://docs.rstudio.com/helm/rstudio-connect/kubernetes-howto/intro/overview.html).
+
 ## Required Configuration
 
 This chart requires the following in order to function:


### PR DESCRIPTION
This finalizes / formalizes the arc to move launcher into public beta
along with the helm chart functionality to make this work well.

Minor version bump because we had a handful of subtly breaking changes in 0.3.0 (mostly for beta customers), and this represents a biggish jump in featureset/functionality.