### PR TITLE
Connect 2022.09.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.3
+version: 0.3.4
 apiVersion: v2
-appVersion: 2022.08.1
+appVersion: 2022.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:2022.08
+      image: rstudio/rstudio-connect:2022.09
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.4
+
+- Bump Connect version to 2022.09.0
+
 # 0.3.3
 
 - Add a check to provide faster feedback if `launcher.enabed=true` without setting up shared storage

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![AppVersion: 2022.08.1](https://img.shields.io/badge/AppVersion-2022.08.1-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![AppVersion: 2022.09.0](https://img.shields.io/badge/AppVersion-2022.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.3:
+To install the chart with the release name `my-release` at version 0.3.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.3
+helm install my-release rstudio/rstudio-connect --version=0.3.4
 ```
 
 ### NOTE


### PR DESCRIPTION
Hold until 2022.09.0 exists and https://github.com/rstudio/rstudio-docker-products/pull/394 has been merged.