### PR TITLE
fix(rstudio-workbench): don't change ownership of projected volumes

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.19
+version: 0.5.20
 apiVersion: v2
 appVersion: 2022.07.1-554.pro3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -2,7 +2,7 @@ name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
 version: 0.5.20
 apiVersion: v2
-appVersion: 2022.07.1-554.pro3
+appVersion: bionic-2022.07.1-554.pro3
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,8 @@
+# 0.5.20
+
+- Fix an issue where chowning fails in the startup script
+  - This is particularly problematic if ConfigMaps or Secrets are mounted into this directory
+
 # 0.5.19
 
 - Add a simple mechanism for snapshot testing to make stronger backwards compatibility guarantees

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fix an issue where chowning fails in the startup script
   - This is particularly problematic if ConfigMaps or Secrets are mounted into this directory
+- Change appVersion to reflect the new docker image naming convention: `bionic-***` to include the OS in the image name.
 
 # 0.5.19
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.19](https://img.shields.io/badge/Version-0.5.19-informational?style=flat-square) ![AppVersion: 2022.07.1-554.pro3](https://img.shields.io/badge/AppVersion-2022.07.1--554.pro3-informational?style=flat-square)
+![Version: 0.5.20](https://img.shields.io/badge/Version-0.5.20-informational?style=flat-square) ![AppVersion: 2022.07.1-554.pro3](https://img.shields.io/badge/AppVersion-2022.07.1--554.pro3-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.19:
+To install the chart with the release name `my-release` at version 0.5.20:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.19
+helm install my-release rstudio/rstudio-workbench --version=0.5.20
 ```
 
 ## Required Configuration

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.20](https://img.shields.io/badge/Version-0.5.20-informational?style=flat-square) ![AppVersion: 2022.07.1-554.pro3](https://img.shields.io/badge/AppVersion-2022.07.1--554.pro3-informational?style=flat-square)
+![Version: 0.5.20](https://img.shields.io/badge/Version-0.5.20-informational?style=flat-square) ![AppVersion: bionic-2022.07.1-554.pro3](https://img.shields.io/badge/AppVersion-bionic--2022.07.1--554.pro3-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -32,7 +32,7 @@ main() {
     /var/lib/rstudio-server/monitor/log
   chown -v -R \
     rstudio-server:rstudio-server \
-    /var/lib/rstudio-server 2>&1 | _indent
+    /var/lib/rstudio-server/Local 2>&1 | _indent
 
   _writeEtcRstudioReadme
 


### PR DESCRIPTION
The Workbench launcher's startup script currently attempts to assume ownership of all files underneath `/var/lib/rstudio`, which fails when the contents of those directories are read-only projected volumes (i.e. mounted from ConfigMap or Secret resources).

This change backports the prestart-workbench.bash fix from #213 in order to make it available immediately to users who are generating and volume-mounting Job and Service templates, while the larger PR is polished and wrapped up.