### PR TITLE
bump package manager to a released chart version

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.4.0-rc01
+version: 0.4.0
 apiVersion: v2
 appVersion: 2022.07.2-11
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.4.0-rc01](https://img.shields.io/badge/Version-0.4.0--rc01-informational?style=flat-square) ![AppVersion: 2022.07.2-11](https://img.shields.io/badge/AppVersion-2022.07.2--11-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 2022.07.2-11](https://img.shields.io/badge/AppVersion-2022.07.2--11-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.4.0-rc01:
+To install the chart with the release name `my-release` at version 0.4.0:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install --devel my-release rstudio/rstudio-pm --version=0.4.0-rc01
+helm install my-release rstudio/rstudio-pm --version=0.4.0
 ```
 
 ## Upgrade Guidance


### PR DESCRIPTION
We have had a handful of customers run into issues not picking up the `--devel` flag 😅 I think we've had sufficient testing at this point - we can fix forward if anything troubling shows up