### PR TITLE
RSW Fix-up and Security Context Issues

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.9
+version: 0.3.10
 apiVersion: v2
 appVersion: 2022.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,8 @@
+# 0.3.10
+
+- BREAKING: Remove `pod.serviceAccountName` in favor of `rbac.serviceAccount.name`
+- Allow un-setting `rbac.serviceAccount.name` ([#294](https://github.com/rstudio/helm/pull/294))
+
 # 0.3.9
 
 - Fix a typo in `launcher.defaultInitContainer.imagePullPolicy` ([#289](https://github.com/rstudio/helm/pull/289))

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,6 +1,6 @@
 # 0.3.10
 
-- BREAKING: Remove `pod.serviceAccountName` in favor of `rbac.serviceAccount.name`
+- Deprecate `pod.serviceAccountName` in favor of `rbac.serviceAccount.name` ([#267](https://github.com/rstudio/helm/issues/267))
 - Allow un-setting `rbac.serviceAccount.name` ([#294](https://github.com/rstudio/helm/pull/294))
 
 # 0.3.9

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![AppVersion: 2022.11.0](https://img.shields.io/badge/AppVersion-2022.11.0-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![AppVersion: 2022.11.0](https://img.shields.io/badge/AppVersion-2022.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.9:
+To install the chart with the release name `my-release` at version 0.3.10:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.9
+helm install my-release rstudio/rstudio-connect --version=0.3.10
 ```
 
 ### NOTE
@@ -125,7 +125,6 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.labels | object | `{}` | Additional labels to add to the rstudio-connect pods |
 | pod.port | int | `3939` | The containerPort used by the main pod container |
 | pod.securityContext | object | `{}` | Values to set the `securityContext` for the connect pod |
-| pod.serviceAccountName | bool | `false` | A string representing the service account of the pod spec |
 | pod.sidecar | bool | `false` | An array of containers that will be run alongside the main pod |
 | pod.volumeMounts | list | `[]` | An array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | An array of maps that is injected as-is into the "volumes:" component of the pod spec |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -125,6 +125,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.labels | object | `{}` | Additional labels to add to the rstudio-connect pods |
 | pod.port | int | `3939` | The containerPort used by the main pod container |
 | pod.securityContext | object | `{}` | Values to set the `securityContext` for the connect pod |
+| pod.serviceAccountName | bool | `false` | Deprecated. Use `rbac.serviceAccount.name` instead |
 | pod.sidecar | bool | `false` | An array of containers that will be run alongside the main pod |
 | pod.volumeMounts | list | `[]` | An array of maps that is injected as-is into the "volumeMounts" component of the pod spec |
 | pod.volumes | list | `[]` | An array of maps that is injected as-is into the "volumes:" component of the pod spec |

--- a/charts/rstudio-connect/ci/deprecated-values.yaml
+++ b/charts/rstudio-connect/ci/deprecated-values.yaml
@@ -1,0 +1,2 @@
+pod:
+  serviceAccountName: test

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -49,3 +49,7 @@ Please consider removing this configuration value.
 {{- if .Values.launcher.contentInitContainer }}
   {{- fail "\n\n`launcher.contentInitContainer` values are now stored at `launcher.defaultInitContainer`" }}
 {{- end }}
+
+{{- if .Values.pod.serviceAccountName }}
+  {{- fail "\n\n `pod.serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead."}}
+{{- end }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -51,5 +51,7 @@ Please consider removing this configuration value.
 {{- end }}
 
 {{- if .Values.pod.serviceAccountName }}
-  {{- fail "\n\n `pod.serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead."}}
+
+WARNING: `pod.serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead.
+
 {{- end }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
          */}}
       {{- if and .Values.rbac.create .Values.launcher.enabled }}
       {{ $serviceAccountName := default .Values.rbac.serviceAccount.name (include "rstudio-connect.fullname" .) }}
-      serviceAccount: {{ $serviceAccountName }}
       serviceAccountName: {{ $serviceAccountName }}
       {{- else }}
-      serviceAccount: {{ .Values.pod.serviceAccountName | toString | quote }}
-      serviceAccountName: {{ .Values.pod.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount.name | toString | quote }}
       {{- end }}
       {{- with .Values.pod.securityContext }}
       securityContext:

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -40,11 +40,23 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{/**
+         * NOTE: In the case where a service account was in use and
+         * then later removed, the behavior of kubernetes is to
+         * leave the `serviceAccount` / `serviceAccountName` value
+         * unchanged unless explicitly overwritten with an empty
+         * string. See linked issues tracing backward from:
+         * https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204
+         * and also the "Note" callout at the end of this section:
+         * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
+         */}}
       {{- if and .Values.rbac.create .Values.launcher.enabled }}
       {{ $serviceAccountName := default .Values.rbac.serviceAccount.name (include "rstudio-connect.fullname" .) }}
+      serviceAccount: {{ $serviceAccountName }}
       serviceAccountName: {{ $serviceAccountName }}
-      {{- else if .Values.pod.serviceAccountName }}
-      serviceAccountName: {{ .Values.pod.serviceAccountName }}
+      {{- else }}
+      serviceAccount: {{ .Values.pod.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.pod.serviceAccountName | toString | quote }}
       {{- end }}
       {{- with .Values.pod.securityContext }}
       securityContext:

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
          * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
          */}}
       {{- if and .Values.rbac.create .Values.launcher.enabled }}
-      {{ $serviceAccountName := default .Values.rbac.serviceAccount.name (include "rstudio-connect.fullname" .) }}
+      {{ $serviceAccountName := default (default .Values.rbac.serviceAccount.name .Values.pod.serviceAccountName) (include "rstudio-connect.fullname" .) }}
       serviceAccountName: {{ $serviceAccountName }}
       {{- else }}
       serviceAccountName: {{ .Values.rbac.serviceAccount.name | toString | quote }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -86,6 +86,8 @@ pod:
   volumes: []
   # -- An array of maps that is injected as-is into the "volumeMounts" component of the pod spec
   volumeMounts: []
+  # -- Deprecated. Use `rbac.serviceAccount.name` instead
+  serviceAccountName: false
   # -- Additional annotations to add to the rstudio-connect pods
   annotations: {}
   # -- Additional labels to add to the rstudio-connect pods

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -86,8 +86,6 @@ pod:
   volumes: []
   # -- An array of maps that is injected as-is into the "volumeMounts" component of the pod spec
   volumeMounts: []
-  # -- A string representing the service account of the pod spec
-  serviceAccountName: false
   # -- Additional annotations to add to the rstudio-connect pods
   annotations: {}
   # -- Additional labels to add to the rstudio-connect pods

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.23
+version: 0.5.24
 apiVersion: v2
 appVersion: 2022.07.2-576.pro12
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,8 @@
 # 0.5.24
 
 - Add `prometheusExporter.securityContext` for the ability to configure the sidecar `securityContext`
+- Add `revisionHistoryLimit` value for the Workbench deployment
+  - This can be helpful particularly when CI systems such as `ArgoCD` leave replicaseits around
 
 # 0.5.23
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,8 +1,11 @@
 # 0.5.24
 
+- BREAKING: remove `serviceAccountName` in favor of `serviceAccount.name`.
+  - Also fix a handful of consistency issues with serviceAccount
+    creation ([#251](https://github.com/rstudio/helm/issues/251))
 - Add `prometheusExporter.securityContext` for the ability to configure the sidecar `securityContext`
 - Add `revisionHistoryLimit` value for the Workbench deployment
-  - This can be helpful particularly when CI systems such as `ArgoCD` leave replicaseits around
+  - This can be helpful particularly when CI systems such as `ArgoCD` leave replicasets around
 
 # 0.5.23
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,8 +1,9 @@
 # 0.5.24
 
-- BREAKING: remove `serviceAccountName` in favor of `serviceAccount.name`.
+- BREAKING: remove `serviceAccountName` in favor of `rbac.serviceAccount.name`.
   - Also fix a handful of consistency issues with serviceAccount
     creation ([#251](https://github.com/rstudio/helm/issues/251))
+  - Allow un-setting `rbac.serviceAccount.name` ([#294](https://github.com/rstudio/helm/pull/294))
 - Add `prometheusExporter.securityContext` for the ability to configure the sidecar `securityContext`
 - Add `revisionHistoryLimit` value for the Workbench deployment
   - This can be helpful particularly when CI systems such as `ArgoCD` leave replicasets around

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.24
+
+- Add `prometheusExporter.securityContext` for the ability to configure the sidecar `securityContext`
+
 # 0.5.23
 
 - Add updated templates for `launcher.templateValues` and session container customization

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.23](https://img.shields.io/badge/Version-0.5.23-informational?style=flat-square) ![AppVersion: 2022.07.2-576.pro12](https://img.shields.io/badge/AppVersion-2022.07.2--576.pro12-informational?style=flat-square)
+![Version: 0.5.24](https://img.shields.io/badge/Version-0.5.24-informational?style=flat-square) ![AppVersion: 2022.07.2-576.pro12](https://img.shields.io/badge/AppVersion-2022.07.2--576.pro12-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.23:
+To install the chart with the release name `my-release` at version 0.5.24:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.23
+helm install my-release rstudio/rstudio-workbench --version=0.5.24
 ```
 
 ## Required Configuration
@@ -337,7 +337,7 @@ config:
 | config.secret | object | `{"database.conf":{}}` | a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |
 | config.server | object | [RStudio Workbench Configuration Reference](https://docs.rstudio.com/ide/server-pro/rstudio_server_configuration/rstudio_server_configuration.html). See defaults with `helm show values` | a map of server config files. Mounted to `/mnt/configmap/rstudio/` |
 | config.serverDcf | object | `{"launcher-mounts":[]}` | a map of server-scoped config files (akin to `config.server`), but with .dcf file formatting (i.e. `launcher-mounts`, `launcher-env`, etc.) |
-| config.session | object | `{"notifications.conf":{},"repos.conf":{"CRAN":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest","RSPM":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"},"rsession.conf":{}}` | a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default. |
+| config.session | object | `{"notifications.conf":{},"repos.conf":{"CRAN":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest","RSPM":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"},"rsession.conf":{},"rstudio-prefs.json":{}}` | a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default. |
 | config.sessionSecret | object | `{}` | a map of secret, session-scoped config files (odbc.ini, etc.). Mounted to `/mnt/session-secret/` on both server and session, by default |
 | config.startupCustom | object | `{}` | a map of supervisord .conf files to define custom services. Mounted into the container at /startup/custom/ |
 | config.startupUserProvisioning | object | `{"sssd.conf":"[program:sssd]\ncommand=/usr/sbin/sssd -i -c /etc/sssd/sssd.conf --logger=stderr\nautorestart=false\nnumprocs=1\nstdout_logfile=/dev/stdout\nstdout_logfile_maxbytes=0\nstdout_logfile_backups=0\nstderr_logfile=/dev/stderr\nstderr_logfile_maxbytes=0\nstderr_logfile_backups=0\n"}` | a map of supervisord .conf files to define user provisioning services. Mounted into the container at /startup/user-provisioning/ |

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -402,12 +402,14 @@ config:
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |
 | prometheusExporter.mappingYaml | string | `nil` | Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file |
+| prometheusExporter.securityContext | object | `{}` | securityContext for the prometheus exporter sidecar |
 | rbac.clusterRoleCreate | bool | `false` | Whether to create the ClusterRole that grants access to the Kubernetes nodes API. This is used by the Launcher to get all of the IP addresses associated with the node that is running a particular job. In most cases, this can be disabled as the node's internal address is sufficient to allow proper functionality. |
 | rbac.create | bool | `true` | Whether to create rbac. (also depends on launcher.enabled = true) |
 | rbac.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | The serviceAccount to be associated with rbac (also depends on launcher.enabled = true) |
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/health-check","port":8787},"initialDelaySeconds":3,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | readinessProbe is used to configure the container's readinessProbe |
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service. Use 2 or more to enable HA |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-server pod |
+| revisionHistoryLimit | int | `10` | The revisionHistoryLimit to use for the pod deployment. Do not set to 0 |
 | secureCookieKey | string | `""` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` | annotations for the service definition |

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -12,6 +12,7 @@ service:
     key: value
 replicas: 2
 
+revisionHistoryLimit: 3
 pod:
   env:
     - name: TEST_ENV_WORKS

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -65,6 +65,8 @@ homeStorage:
     storage: "500Gi"
 
 prometheusExporter:
+  securityContext:
+    privileged: false
   mappingYaml:
     mappings:
       - match: "rstudio\\.([\\w-]+)\\.system\\.load\\.(.*)"

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -48,8 +48,12 @@ xdgConfigDirsExtra:
   - '/tmp/one/'
   - '/tmp/two/'
 
-rbac.create: true
-serviceAccountName: rstudio-server-job-launcher
+rbac:
+  create: true
+  serviceAccount:
+    name: rstudio-server-job-launcher
+    annotations:
+      one-two: three
 
 sharedStorage:
   create: true

--- a/charts/rstudio-workbench/ci/default-sa-values.yaml
+++ b/charts/rstudio-workbench/ci/default-sa-values.yaml
@@ -1,0 +1,5 @@
+rbac:
+  create: true
+  serviceAccount:
+    name: default
+    create: false

--- a/charts/rstudio-workbench/ci/other-complex-values.yaml
+++ b/charts/rstudio-workbench/ci/other-complex-values.yaml
@@ -32,8 +32,10 @@ xdgConfigDirsExtra:
   - '/tmp/one/'
   - '/tmp/two/'
 
-rbac.create: true
-serviceAccountName: rstudio-server-job-launcher
+rbac:
+  create: true
+  serviceAccount:
+    name: rstudio-server-job-launcher
 
 sharedStorage:
   create: true

--- a/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
@@ -3,8 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
+  annotations:
+    one-two: three
 ---
 # Source: rstudio-workbench/templates/configmap-secret.yaml
 apiVersion: v1
@@ -571,7 +573,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
 rules:
   - apiGroups:
@@ -635,15 +637,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
 subjects:
   - kind: ServiceAccount
-    name: release-name-rstudio-workbench
+    name: rstudio-server-job-launcher
     namespace: rstudio
 ---
 # Source: rstudio-workbench/templates/svc.yaml
@@ -692,6 +694,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:
@@ -710,7 +713,8 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/part-of: rstudio-team
     spec:
-      serviceAccountName: release-name-rstudio-workbench
+      
+      serviceAccountName: rstudio-server-job-launcher
       imagePullSecrets:
         - name: some-secret
       shareProcessNamespace: false      
@@ -806,6 +810,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          privileged: false
       - image: busybox
         imagePullPolicy: IfNotPresent
         name: test
@@ -913,7 +919,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
-  serviceAccountName: release-name-rstudio-workbench
+  serviceAccountName: rstudio-server-job-launcher
   imagePullSecrets:
     - name: some-secret
   shareProcessNamespace: false

--- a/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
@@ -453,6 +453,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -655,7 +656,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -702,7 +703,7 @@ spec:
         checksum/config-graphite: 69dd73685cb821ebf5bcec3155d92801f31d72b031a4d681700bded2ff5700c2
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: fc06992d38b807a70a6f5722d670969573e2ee3f82293197a2bd0d840ca3a7d4
-        checksum/config-session: 1e1189618d9113414ca3b1ff32a6d723ccefa7eacb23a20c63c26910fdcca983
+        checksum/config-session: 75e2ce5c7bf075bab77ace7c86c3f9f97706137bec3b54eb0e5b7c022950bd6a
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -890,7 +891,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"

--- a/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
@@ -331,6 +331,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -472,7 +473,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -517,7 +518,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
@@ -526,6 +526,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: default
       shareProcessNamespace: false      
       containers:

--- a/charts/rstudio-workbench/snapshot/default.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default.yaml.lock
@@ -516,6 +516,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -532,6 +533,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -597,6 +599,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/default.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default.yaml.lock
@@ -338,6 +338,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -524,7 +525,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
@@ -516,6 +516,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -532,6 +533,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -597,6 +599,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
@@ -338,6 +338,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -524,7 +525,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
@@ -516,6 +516,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -532,6 +533,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -597,6 +599,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
@@ -338,6 +338,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -524,7 +525,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -648,7 +649,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"

--- a/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
@@ -516,6 +516,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -532,6 +533,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -597,6 +599,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
@@ -338,6 +338,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -524,7 +525,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -648,7 +649,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"

--- a/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
@@ -791,6 +791,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -807,6 +808,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -880,6 +882,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: etc-rstudio
         emptyDir: {}

--- a/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
@@ -613,6 +613,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -754,7 +755,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -799,7 +800,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
@@ -516,6 +516,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -532,6 +533,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -602,6 +604,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
@@ -338,6 +338,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -479,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -524,7 +525,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
@@ -349,6 +349,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -490,7 +491,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -535,7 +536,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
@@ -527,6 +527,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -543,6 +544,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -612,6 +614,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
@@ -517,6 +517,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -533,6 +534,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -600,6 +602,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
@@ -339,6 +339,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -480,7 +481,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -525,7 +526,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/license-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-values.yaml.lock
@@ -526,6 +526,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -542,6 +543,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -612,6 +614,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-job-overrides-new
         configMap:

--- a/charts/rstudio-workbench/snapshot/license-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-values.yaml.lock
@@ -348,6 +348,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -489,7 +490,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -534,7 +535,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
@@ -393,6 +393,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -568,7 +569,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -615,7 +616,7 @@ spec:
         checksum/config-graphite: ab090aebd9b73a011de2ba8d98eb62398fa39a4fdd7d137281ada8306c3909d8
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: b31fcdf8218c2b1feac32f7a9e15b119bb6a4f08c004ffce2c46cb642e22bf63
+        checksum/config-session: 0141a2ffc1025f68704c750899f9abd4e9f82bc284920c6eeea502e4062e61bb
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
 ---
 # Source: rstudio-workbench/templates/configmap-secret.yaml
@@ -486,7 +486,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
 rules:
   - apiGroups:
@@ -550,15 +550,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
   namespace: rstudio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: release-name-rstudio-workbench
+  name: rstudio-server-job-launcher
 subjects:
   - kind: ServiceAccount
-    name: release-name-rstudio-workbench
+    name: rstudio-server-job-launcher
     namespace: rstudio
 ---
 # Source: rstudio-workbench/templates/svc.yaml
@@ -607,6 +607,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -624,7 +625,8 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
-      serviceAccountName: release-name-rstudio-workbench
+      
+      serviceAccountName: rstudio-server-job-launcher
       shareProcessNamespace: false      
       containers:
       - name: rstudio
@@ -706,6 +708,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       - image: busybox
         imagePullPolicy: IfNotPresent
         name: test
@@ -770,7 +774,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
-  serviceAccountName: release-name-rstudio-workbench
+  serviceAccountName: rstudio-server-job-launcher
   shareProcessNamespace: false
   restartPolicy: Never
   

--- a/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
@@ -568,6 +568,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -584,6 +585,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -660,6 +662,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-home-storage
         persistentVolumeClaim:

--- a/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
@@ -374,6 +374,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -531,7 +532,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -576,7 +577,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
@@ -546,6 +546,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -562,6 +563,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -638,6 +640,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-home-storage
         persistentVolumeClaim:

--- a/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
@@ -352,6 +352,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -509,7 +510,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -554,7 +555,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
@@ -548,6 +548,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -564,6 +565,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -640,6 +642,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-home-storage
         persistentVolumeClaim:

--- a/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
@@ -354,6 +354,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -511,7 +512,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -556,7 +557,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
@@ -351,6 +351,7 @@ data:
     CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
     RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   rsession.conf: |
+  rstudio-prefs.json: |
 ---
 # Source: rstudio-workbench/templates/configmap-startup.yaml
 apiVersion: v1
@@ -508,7 +509,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.23
+    helm.sh/chart: rstudio-workbench-0.5.24
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -553,7 +554,7 @@ spec:
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 79990c0cc9486c7c12fe2dcb19cf9989deb5f4bbffcfe26931614a95ada278fe
+        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"

--- a/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
@@ -545,6 +545,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:
@@ -561,6 +562,7 @@ spec:
         app.kubernetes.io/name: rstudio-workbench
         app.kubernetes.io/instance: release-name
     spec:
+      
       serviceAccountName: release-name-rstudio-workbench
       shareProcessNamespace: false      
       containers:
@@ -637,6 +639,8 @@ spec:
         ports:
         - containerPort: 9108
           name: metrics
+        securityContext:
+          {}
       volumes:
       - name: rstudio-home-storage
         persistentVolumeClaim:

--- a/charts/rstudio-workbench/templates/NOTES.txt
+++ b/charts/rstudio-workbench/templates/NOTES.txt
@@ -48,3 +48,7 @@ Please consider removing this configuration value.
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.serviceAccountName }}
+  {{- fail "\n\n`serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead"}}
+{{- end }}

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -206,6 +206,8 @@ containers:
   ports:
   - containerPort: 9108
     name: metrics
+  securityContext:
+    {{- toYaml .Values.prometheusExporter.securityContext | nindent 4 }}
 {{- end }}
 {{- if .Values.pod.sidecar }}
 {{ toYaml .Values.pod.sidecar }}

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "rstudio-workbench.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -40,11 +40,22 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{/**
+         * NOTE: In the case where a service account was in use and
+         * then later removed, the behavior of kubernetes is to
+         * leave the `serviceAccount` / `serviceAccountName` value
+         * unchanged unless explicitly overwritten with an empty
+         * string. See linked issues tracing backward from:
+         * https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204
+         * and also the "Note" callout at the end of this section:
+         * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
+         */}}
       {{- if .Values.rbac.create }}
+      serviceAccount: {{ include "rstudio-workbench.fullname" . }}
       serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
-      {{- end }}
-      {{- if and (not .Values.rbac.create) (.Values.serviceAccountName) }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- else }}
+      serviceAccount: {{ .Values.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.serviceAccountName | toString | quote }}
       {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -51,12 +51,11 @@ spec:
          * and also the "Note" callout at the end of this section:
          * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
          */}}
-      {{- if .Values.rbac.create }}
-      serviceAccount: {{ include "rstudio-workbench.fullname" . }}
-      serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
+      {{- $serviceAccountName := .Values.rbac.serviceAccount.name | default (include "rstudio-workbench.fullname" .)}}
+      {{- if or .Values.rbac.create (.Values.rbac.serviceAccount.name) }}
+      serviceAccountName: {{ $serviceAccountName }}
       {{- else }}
-      serviceAccount: {{ .Values.serviceAccountName | toString | quote }}
-      serviceAccountName: {{ .Values.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount.name | toString | quote }}
       {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/rstudio-workbench/templates/rbac.yaml
+++ b/charts/rstudio-workbench/templates/rbac.yaml
@@ -2,47 +2,13 @@
 {{- $namespace := $.Release.Namespace }}
 {{- $targetNamespace := default $.Release.Namespace .Values.launcher.namespace }}
 {{- $serviceAccountName := default (include "rstudio-workbench.fullname" .) .Values.rbac.serviceAccount.name }}
-{{- $serviceAccountCreate := .Values.rbac.create }}
+{{- $serviceAccountCreate := .Values.rbac.serviceAccount.create }}
 {{- $roleName := $serviceAccountName }}
-{{- $serviceAccountAnnotations := .Values.serviceAccountAnnotations }}
+{{- $serviceAccountAnnotations := .Values.rbac.serviceAccount.annotations }}
 {{- $clusterRoleCreate := .Values.rbac.clusterRoleCreate }}
 {{- $rbacValues1 := dict "namespace" $namespace "serviceAccountName" $serviceAccountName "targetNamespace" $targetNamespace }}
-{{- $rbacValues2 := dict "serviceAccountCreate" $.Values.rbac.create "serviceAccountAnnotations" $serviceAccountAnnotations "roleName" ($roleName) }}
+{{- $rbacValues2 := dict "serviceAccountCreate" $serviceAccountCreate "serviceAccountAnnotations" $serviceAccountAnnotations "roleName" ($roleName) }}
 {{- $rbacValues3 := dict "clusterRoleCreate" $clusterRoleCreate }}
 {{- $rbacValues := merge $rbacValues1 $rbacValues2 $rbacValues3 }}
 {{- include "rstudio-library.rbac" $rbacValues }}
-{{- if ne $namespace $targetNamespace }}
-{{- /*
-  Allow listing pods for the namespace the ServiceAccount is in
-  TODO: can remove this once the load-balancer sidecar is not needed
-*/}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ $roleName }}
-  namespace: {{ $namespace }}
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "pods"
-    verbs:
-      - "get"
-      - "list"
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ $roleName }}
-  namespace: {{ $namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $roleName }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $serviceAccountName }}
-    namespace: {{ $namespace }}
-{{- end }}
 {{- end }}

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -5,9 +5,21 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  {{/**
+     * NOTE: In the case where a service account was in use and
+     * then later removed, the behavior of kubernetes is to
+     * leave the `serviceAccount` / `serviceAccountName` value
+     * unchanged unless explicitly overwritten with an empty
+     * string. See linked issues tracing backward from:
+     * https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204
+     * and also the "Note" callout at the end of this section:
+     * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
+     */}}
   {{- $serviceAccountName := .Values.rbac.serviceAccount.name | default (include "rstudio-workbench.fullname" .)}}
   {{- if or .Values.rbac.create (.Values.rbac.serviceAccount.name) }}
   serviceAccountName: {{ $serviceAccountName }}
+  {{- else }}
+  serviceAccountName: {{ .Values.rbac.serviceAccount.name | toString | quote }}
   {{- end }}
   {{- with .Values.image.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
+++ b/charts/rstudio-workbench/templates/tests/test-verify-installation.yaml
@@ -5,11 +5,9 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
-  {{- if .Values.rbac.create }}
-  serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
-  {{- end }}
-  {{- if and (not .Values.rbac.create) (.Values.serviceAccountName) }}
-  serviceAccountName: {{ .Values.serviceAccountName }}
+  {{- $serviceAccountName := .Values.rbac.serviceAccount.name | default (include "rstudio-workbench.fullname" .)}}
+  {{- if or .Values.rbac.create (.Values.rbac.serviceAccount.name) }}
+  serviceAccountName: {{ $serviceAccountName }}
   {{- end }}
   {{- with .Values.image.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -281,6 +281,8 @@ prometheusExporter:
   enabled: true
   # -- Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
   mappingYaml: null
+  # -- securityContext for the prometheus exporter sidecar
+  securityContext: {}
   image:
     repository: "prom/graphite-exporter"
     tag: "v0.9.0"

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -260,6 +260,9 @@ affinity: {}
 nodeSelector: {}
 tolerations: []
 
+# -- The revisionHistoryLimit to use for the pod deployment. Do not set to 0
+revisionHistoryLimit: 10
+
 pod:
   # -- env is an array of maps that is injected as-is into the "env:" component of the pod.container spec
   env: []


### PR DESCRIPTION
Incorporates #294 
( allow setting Service Account to empty string)

- Allow customizing `prometheusExporter` `securityContext`
- Allow `revisionHistoryLimit` for Workbench and Connect
- Close #251 by resolving inconsistencies in workbench service account definition (which was falsely closed by accident on another PR)
- close #267 