### PR TITLE
Explicitly setting service account to empty string

### DIFF
--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -40,11 +40,23 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{/**
+         * NOTE: In the case where a service account was in use and
+         * then later removed, the behavior of kubernetes is to
+         * leave the `serviceAccount` / `serviceAccountName` value
+         * unchanged unless explicitly overwritten with an empty
+         * string. See linked issues tracing backward from:
+         * https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204
+         * and also the "Note" callout at the end of this section:
+         * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
+         */}}
       {{- if and .Values.rbac.create .Values.launcher.enabled }}
       {{ $serviceAccountName := default .Values.rbac.serviceAccount.name (include "rstudio-connect.fullname" .) }}
+      serviceAccount: {{ $serviceAccountName }}
       serviceAccountName: {{ $serviceAccountName }}
-      {{- else if .Values.pod.serviceAccountName }}
-      serviceAccountName: {{ .Values.pod.serviceAccountName }}
+      {{- else }}
+      serviceAccount: {{ .Values.pod.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.pod.serviceAccountName | toString | quote }}
       {{- end }}
       {{- with .Values.pod.securityContext }}
       securityContext:

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -40,11 +40,22 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{/**
+         * NOTE: In the case where a service account was in use and
+         * then later removed, the behavior of kubernetes is to
+         * leave the `serviceAccount` / `serviceAccountName` value
+         * unchanged unless explicitly overwritten with an empty
+         * string. See linked issues tracing backward from:
+         * https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204
+         * and also the "Note" callout at the end of this section:
+         * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts
+         */}}
       {{- if .Values.rbac.create }}
+      serviceAccount: {{ include "rstudio-workbench.fullname" . }}
       serviceAccountName: {{ include "rstudio-workbench.fullname" . }}
-      {{- end }}
-      {{- if and (not .Values.rbac.create) (.Values.serviceAccountName) }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- else }}
+      serviceAccount: {{ .Values.serviceAccountName | toString | quote }}
+      serviceAccountName: {{ .Values.serviceAccountName | toString | quote }}
       {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
which *must be done* according to an amazing thread of issues reported by humans bitten by this intentional inconsistency in kubernetes "apply" behavior :tada:

As referenced in the body of this change, one may trace back through this gotcha from this issue comment:

https://github.com/kubernetes/kubernetes/issues/108208#issuecomment-1262269204

and also see this mention in the kubernetes docs in a "Note" callout near the end of this section:

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts