### PR TITLE
Upgrade Connect to 2022.11.0 and update chart version to 0.3.7

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.6
+version: 0.3.7
 apiVersion: v2
-appVersion: bionic-2022.10.0
+appVersion: bionic-2022.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:bionic-2022.10.0
+      image: rstudio/rstudio-connect:bionic-2022.11.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.7
+
+- Bump Connect version to 2022.11.0
+
 # 0.3.6
 
 - Bump Connect version to 2022.10.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: bionic-2022.10.0](https://img.shields.io/badge/AppVersion-bionic--2022.10.0-informational?style=flat-square)
+![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![AppVersion: bionic-2022.11.0](https://img.shields.io/badge/AppVersion-bionic--2022.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.6:
+To install the chart with the release name `my-release` at version 0.3.7:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.6
+helm install my-release rstudio/rstudio-connect --version=0.3.7
 ```
 
 ### NOTE

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -268,7 +268,6 @@ config:
   Scheduler:
     InitTimeout: 5m
   Logging:
-    Enabled: true
     ServiceLog: STDOUT
     ServiceLogLevel: INFO    # INFO, WARNING or ERROR
     ServiceLogFormat: TEXT   # TEXT or JSON


### PR DESCRIPTION
- Upgrade Connect version to 2022.11.0
- Bump Connect chart version to 0.3.7
- Fix deprecated setting for logging configuration