### PR TITLE
Connect: Allow overriding `securityContext` for jobs

### DIFF
--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -94,23 +94,27 @@ spec:
         {{- end }}
       {{- end }}
       {{- $securityContext := dict }}
-      {{- if .Job.container.runAsUserId }}
-        {{- $_ := set $securityContext "runAsUser" .Job.container.runAsUserId }}
-      {{- end }}
-      {{- if .Job.container.runAsGroupId }}
-        {{- $_ := set $securityContext "runAsGroup" .Job.container.runAsGroupId }}
-      {{- end }}
-      {{- if .Job.container.supplementalGroupIds }}
-        {{- $groupIds := list }}
-        {{- range .Job.container.supplementalGroupIds }}
-          {{- $groupIds = append $groupIds . }}
+      {{- if $templateData.job.securityContext }}
+        {{- $_ := set $securityContext $templateData.job.securityContext }}
+      {{- else }}
+        {{- if .Job.container.runAsUserId }}
+          {{- $_ := set $securityContext "runAsUser" .Job.container.runAsUserId }}
         {{- end }}
-        {{- $_ := set $securityContext "supplementalGroups" (cat "[" ($groupIds | join ", ") "]") }}
-      {{- end }}
-      {{- if $securityContext }}
-      securityContext:
-        {{- range $key, $val := $securityContext }}
-        {{ $key }}: {{ $val }}
+        {{- if .Job.container.runAsGroupId }}
+          {{- $_ := set $securityContext "runAsGroup" .Job.container.runAsGroupId }}
+        {{- end }}
+        {{- if .Job.container.supplementalGroupIds }}
+          {{- $groupIds := list }}
+          {{- range .Job.container.supplementalGroupIds }}
+            {{- $groupIds = append $groupIds . }}
+          {{- end }}
+          {{- $_ := set $securityContext "supplementalGroups" (cat "[" ($groupIds | join ", ") "]") }}
+        {{- end }}
+        {{- if $securityContext }}
+        securityContext:
+          {{- range $key, $val := $securityContext }}
+          {{ $key }}: {{ $val }}
+          {{- end }}
         {{- end }}
       {{- end }}
       {{- with $templateData.pod.imagePullSecrets }}


### PR DESCRIPTION
relates #293 

Disclaimer: untested, just a first take on allowing to set `securityContext` for jobs from template data. I don't know if the presented notation will work in practice.

I essentially just added an if clause which sets the `securityContext` if it's defined and otherwise uses the previous definition for the dict.

Please modify and correct as needed :)