### PR TITLE
fix package manager image reference to target `bionic-`

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.0
+version: 0.5.1
 apiVersion: v2
 appVersion: 2022.11.2-18
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:2022.11.2-18
+      image: rstudio/rstudio-package-manager:bionic-2022.11.2-18
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,8 @@
+# 0.5.1
+
+- Fix a bug in the image reference. Images now have an operating system reference
+  - Add an `image.tagPrefix` value for configuring the (current) `bionic-` prefix
+
 # 0.5.0
 
 - Update default Post Package Manager version to 2022.11.2-18

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 2022.11.2-18](https://img.shields.io/badge/AppVersion-2022.11.2--18-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 2022.11.2-18](https://img.shields.io/badge/AppVersion-2022.11.2--18-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.0:
+To install the chart with the release name `my-release` at version 0.5.1:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.5.0
+helm install my-release rstudio/rstudio-pm --version=0.5.1
 ```
 
 ## Upgrade Guidance
@@ -128,6 +128,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | image.imagePullSecrets | list | `[]` | an array of kubernetes secrets for pulling the main pod image from private registries |
 | image.repository | string | `"rstudio/rstudio-package-manager"` | the repository to use for the main pod image |
 | image.tag | string | `""` | the tag to use for the main pod image |
+| image.tagPrefix | string | `"bionic-"` | A tag prefix for the server image (common selections: bionic-, jammy-). Only used if tag is not defined |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | string | `nil` |  |

--- a/charts/rstudio-pm/templates/_helpers.tpl
+++ b/charts/rstudio-pm/templates/_helpers.tpl
@@ -24,7 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -69,7 +69,8 @@ spec:
       containers:
       - name: rspm
         {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default $defaultVersion }}"
+        {{- $imageTag := .Values.image.tag | default (printf "%s%s" .Values.image.tagPrefix $defaultVersion )}}
+        image: "{{ .Values.image.repository }}:{{ $imageTag }}"
         env:
         {{- include "rstudio-library.license-env" (dict "license" ( .Values.license ) "product" ("rstudio-pm") "envVarPrefix" ("RSPM") "fullName" (include "rstudio-pm.fullname" .)) | nindent 8 }}
         {{- if .Values.pod.env }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -30,6 +30,8 @@ sharedStorage:
 image:
   # -- the repository to use for the main pod image
   repository: rstudio/rstudio-package-manager
+  # -- A tag prefix for the server image (common selections: bionic-, jammy-). Only used if tag is not defined
+  tagPrefix: bionic-
   # -- the tag to use for the main pod image
   tag: ""
   # -- the imagePullPolicy for the main pod image


### PR DESCRIPTION
Follow up to #304 

I think this is our first change since images started having a `bionic-` prefix. I was tempted to go ahead and take this opportunity to switch to `jammy-`... but with RSPM recently going through the root -> non-root switch, with the change to Posit, and Thanksgiving, I thought maybe we should be more cautious about such a change (i.e. scope it before we make the change).

NOTE: also plucked a newline from #298 to prevent another version bump