### PR TITLE
Add pvc options for Workbench

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,11 +42,11 @@ snapshot-rsw:
   #!/bin/bash
   set -xe
 
-  helm template -n rstudio ./charts/rstudio-workbench --set global.secureCookieKey="abc" --set launcherPem="abc" > charts/rstudio-workbench/snapshot/default.yaml
-  
+  helm template -n rstudio ./charts/rstudio-workbench --set global.secureCookieKey="abc" --set launcherPem="abc" | sed -e 's|\(helm\.sh/chart\:\ [a-zA-Z\-]*\).*|\1VERSION|g' > charts/rstudio-workbench/snapshot/default.yaml
+
   for file in `ls ./charts/rstudio-workbench/ci/*.yaml`; do
     filename=$(basename $file)
-    helm template -n rstudio ./charts/rstudio-workbench --set global.secureCookieKey="abc" --set launcherPem="abc" -f $file > charts/rstudio-workbench/snapshot/$filename
+    helm template -n rstudio ./charts/rstudio-workbench --set global.secureCookieKey="abc" --set launcherPem="abc" -f $file | sed -e 's|\(helm\.sh/chart\:\ [a-zA-Z\-]*\).*|\1VERSION|g' > charts/rstudio-workbench/snapshot/$filename
   done
 
 snapshot-rsw-lock:

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.24
+version: 0.5.25
 apiVersion: v2
 appVersion: 2022.07.2-576.pro12
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,8 @@
+# 0.5.25
+
+- Add `homeStorage.otherArgs` and `sharedStorage.otherArgs` for other PVC arguments
+  - This can be useful for arguments like `volumeName` when using a PVC that references a PV
+
 # 0.5.24
 
 - BREAKING: remove `serviceAccountName` in favor of `rbac.serviceAccount.name`.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.24](https://img.shields.io/badge/Version-0.5.24-informational?style=flat-square) ![AppVersion: 2022.07.2-576.pro12](https://img.shields.io/badge/AppVersion-2022.07.2--576.pro12-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![AppVersion: 2022.07.2-576.pro12](https://img.shields.io/badge/AppVersion-2022.07.2--576.pro12-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.24:
+To install the chart with the release name `my-release` at version 0.5.25:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.24
+helm install my-release rstudio/rstudio-workbench --version=0.5.25
 ```
 
 ## Required Configuration
@@ -355,6 +355,7 @@ config:
 | homeStorage.requests.storage | string | `"10Gi"` | the volume of storage to request for this persistent volume claim |
 | homeStorage.selector | object | `{}` | selector for PVC definition |
 | homeStorage.storageClassName | bool | `false` | storageClassName - the type of storage to use. Must allow ReadWriteMany |
+| homeStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | image.imagePullPolicy | string | `"IfNotPresent"` | the imagePullPolicy for the main pod image |
 | image.imagePullSecrets | list | `[]` | an array of kubernetes secrets for pulling the main pod image from private registries |
 | image.repository | string | `"rstudio/rstudio-workbench"` | the repository to use for the main pod image |
@@ -434,6 +435,7 @@ config:
 | sharedStorage.requests.storage | string | `"10Gi"` | the volume of storage to request for this persistent volume claim |
 | sharedStorage.selector | object | `{}` | selector for PVC definition |
 | sharedStorage.storageClassName | bool | `false` | storageClassName - the type of storage to use. Must allow ReadWriteMany |
+| sharedStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/health-check","port":8787},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | startupProbe is used to configure the container's startupProbe |
 | startupProbe.failureThreshold | int | `30` | failureThreshold * periodSeconds should be strictly > worst case startup time |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"100%","maxUnavailable":0},"type":"RollingUpdate"}` | How to handle updates to the service. RollingUpdate (the default) minimizes downtime, but will not work well if your license only allows a single activation. |

--- a/charts/rstudio-workbench/ci/other-complex-values.yaml
+++ b/charts/rstudio-workbench/ci/other-complex-values.yaml
@@ -42,14 +42,16 @@ sharedStorage:
   path: "/var/lib/awesome"
   storageClassName: nfs
   requests:
-    storage: "200Gi"
+    storage: "20Mi"
+  volumeName: test2-volume
 
 homeStorage:
   create: true
   path: "/mnt/home"
   storageClassName: nfs
   requests:
-    storage: "500Gi"
+    storage: "50Mi"
+  volumeName: test-volume
 
 prometheusExporter:
   mappingYaml: |

--- a/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
@@ -656,7 +656,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -891,7 +891,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -920,6 +920,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: rstudio-server-job-launcher
   imagePullSecrets:
     - name: some-secret
@@ -994,11 +995,11 @@ spec:
       - name: rstudio-custom-startup
         mountPath: "/startup/custom"
       - name: rstudio-pam
-        mountPath: "/etc/pam.d/pam-example"
-        subPath: "pam-example"
-      - name: rstudio-pam
         mountPath: "/etc/pam.d/pam-example-2"
         subPath: "pam-example-2"
+      - name: rstudio-pam
+        mountPath: "/etc/pam.d/pam-example"
+        subPath: "pam-example"
       
       - name: rstudio-job-overrides-old
         mountPath: "/mnt/job-json-overrides"

--- a/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
@@ -473,7 +473,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -644,6 +644,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: default
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/default.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default.yaml.lock
@@ -480,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -651,6 +651,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
@@ -480,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -651,6 +651,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
@@ -480,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -649,7 +649,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -678,6 +678,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
@@ -480,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -649,7 +649,7 @@ kind: Ingress
 metadata:
   name: release-name-rstudio-workbench
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -678,6 +678,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
@@ -755,7 +755,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -934,6 +934,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
@@ -480,7 +480,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -659,6 +659,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
@@ -491,7 +491,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -669,6 +669,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
@@ -481,7 +481,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -654,6 +654,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/license-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-values.yaml.lock
@@ -490,7 +490,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -666,6 +666,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
@@ -462,9 +462,10 @@ spec:
     - ReadWriteMany
   volumeMode: Filesystem
   storageClassName: nfs
+  volumeName: test2-volume
   resources:
     requests:
-      storage: 200Gi
+      storage: 20Mi
 ---
 # Source: rstudio-workbench/templates/pvc.yaml
 kind: PersistentVolumeClaim
@@ -479,9 +480,10 @@ spec:
     - ReadWriteMany
   volumeMode: Filesystem
   storageClassName: nfs
+  volumeName: test-volume
   resources:
     requests:
-      storage: 500Gi
+      storage: 50Mi
 ---
 # Source: rstudio-workbench/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -569,7 +571,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -775,6 +777,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: rstudio-server-job-launcher
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
@@ -532,7 +532,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -717,6 +717,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
@@ -510,7 +510,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -695,6 +695,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
@@ -512,7 +512,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -697,6 +697,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
@@ -509,7 +509,7 @@ metadata:
   name: release-name-rstudio-workbench
   namespace: rstudio
   labels:
-    helm.sh/chart: rstudio-workbench-0.5.24
+    helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2022.07.2-576.pro12"
@@ -694,6 +694,7 @@ metadata:
   annotations:
    "helm.sh/hook": test
 spec:
+  
   serviceAccountName: release-name-rstudio-workbench
   shareProcessNamespace: false
   restartPolicy: Never

--- a/charts/rstudio-workbench/templates/pvc.yaml
+++ b/charts/rstudio-workbench/templates/pvc.yaml
@@ -8,10 +8,13 @@ metadata:
 {{ .Values.sharedStorage.annotations | toYaml | indent 4}}
 spec:
   accessModes:
-{{ .Values.sharedStorage.accessModes | toYaml | indent 4 }}
+    {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}
   volumeMode: Filesystem
   {{- if .Values.sharedStorage.storageClassName }}
   storageClassName: {{ .Values.sharedStorage.storageClassName }}
+  {{- end }}
+  {{- with .Values.sharedStorage.volumeName }}
+  volumeName: {{ . }}
   {{- end }}
   resources:
     requests:
@@ -32,10 +35,13 @@ metadata:
     "helm.sh/resource-policy": keep
 spec:
   accessModes:
-{{ .Values.homeStorage.accessModes | toYaml | indent 4 }}
+    {{- .Values.homeStorage.accessModes | toYaml | nindent 4 }}
   volumeMode: Filesystem
   {{- if .Values.homeStorage.storageClassName }}
   storageClassName: {{ .Values.homeStorage.storageClassName }}
+  {{- end }}
+  {{- with .Values.homeStorage.volumeName }}
+  volumeName: {{ . }}
   {{- end }}
   resources:
     requests:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -43,6 +43,8 @@ sharedStorage:
     storage: "10Gi"
   # -- selector for PVC definition
   selector: {}
+  # -- the volumeName passed along to the persistentVolumeClaim. Optional
+  volumeName: ""
   # -- Define the annotations for the Persistent Volume Claim resource
   annotations:
     helm.sh/resource-policy: keep
@@ -116,6 +118,8 @@ homeStorage:
     storage: "10Gi"
   # -- selector for PVC definition
   selector: {}
+  # -- the volumeName passed along to the persistentVolumeClaim. Optional
+  volumeName: ""
 
 image:
   # -- the repository to use for the main pod image


### PR DESCRIPTION
`volumeName` is the only argument that we actually need to add,
per the API spec here:
https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/
It is also useful when referencing a PV with the created PVC.