### PR TITLE
Pvc options for RSC and RSPM

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.10
+version: 0.3.11
 apiVersion: v2
 appVersion: 2022.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,8 @@
+# 0.3.11
+
+- Add `sharedStorage.volumeName` for PVCs that reference a PV
+- Add `sharedStorage.selector` as well
+
 # 0.3.10
 
 - Deprecate `pod.serviceAccountName` in favor of `rbac.serviceAccount.name` ([#267](https://github.com/rstudio/helm/issues/267))

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![AppVersion: 2022.11.0](https://img.shields.io/badge/AppVersion-2022.11.0-informational?style=flat-square)
+![Version: 0.3.11](https://img.shields.io/badge/Version-0.3.11-informational?style=flat-square) ![AppVersion: 2022.11.0](https://img.shields.io/badge/AppVersion-2022.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.10:
+To install the chart with the release name `my-release` at version 0.3.11:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.10
+helm install my-release rstudio/rstudio-connect --version=0.3.11
 ```
 
 ### NOTE
@@ -154,7 +154,9 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | sharedStorage.name | string | `""` | The name of the pvc. By default, computes a value from the release name |
 | sharedStorage.path | string | `"/var/lib/rstudio-connect"` | The path to mount the sharedStorage claim within the Connect pod |
 | sharedStorage.requests.storage | string | `"10Gi"` | The volume of storage to request for this persistent volume claim |
+| sharedStorage.selector | object | `{}` | selector for PVC definition |
 | sharedStorage.storageClassName | bool | `false` | The type of storage to use. Must allow ReadWriteMany |
+| sharedStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | Used to configure the container's startupProbe. Only included if enabled = true |
 | startupProbe.failureThreshold | int | `30` | failureThreshold * periodSeconds should be strictly > worst case startup time |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"100%","maxUnavailable":0},"type":"RollingUpdate"}` | Defines the update strategy for a deployment |

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -2,6 +2,7 @@ sharedStorage:
   create: true
   path: /var/lib/rstudio-connect
   storageClassName: test-class
+  volumeName: test-volume
   requests:
     storage: "10Gi"
 strategy:

--- a/charts/rstudio-connect/templates/pvc.yaml
+++ b/charts/rstudio-connect/templates/pvc.yaml
@@ -8,13 +8,20 @@ metadata:
     {{- .Values.sharedStorage.annotations | toYaml | nindent 4 }}
 spec:
   accessModes:
-{{ .Values.sharedStorage.accessModes | toYaml | indent 4 }}
+    {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}
   volumeMode: Filesystem
   {{- if .Values.sharedStorage.storageClassName }}
   storageClassName: {{ .Values.sharedStorage.storageClassName }}
   {{- end }}
+  {{- with .Values.sharedStorage.volumeName }}
+  volumeName: {{ . }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.sharedStorage.requests.storage }}
+  {{- with .Values.sharedStorage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 {{- end }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -28,6 +28,10 @@ sharedStorage:
   # -- Annotations for the Persistent Volume Claim
   annotations:
     helm.sh/resource-policy: keep
+  # -- selector for PVC definition
+  selector: {}
+  # -- the volumeName passed along to the persistentVolumeClaim. Optional
+  volumeName: ""
 
 rbac:
   # -- Whether to create rbac. (also depends on launcher.enabled = true)

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.1
+version: 0.5.2
 apiVersion: v2
 appVersion: 2022.11.2-18
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,8 @@
+# 0.5.2
+
+- Add `sharedStorage.volumeName` for PVCs that reference a PV
+- Add `sharedStorage.selector` as well
+
 # 0.5.1
 
 - Fix a bug in the image reference. Images now have an operating system reference

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 2022.11.2-18](https://img.shields.io/badge/AppVersion-2022.11.2--18-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 2022.11.2-18](https://img.shields.io/badge/AppVersion-2022.11.2--18-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.1:
+To install the chart with the release name `my-release` at version 0.5.2:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.5.1
+helm install my-release rstudio/rstudio-pm --version=0.5.2
 ```
 
 ## Upgrade Guidance
@@ -180,7 +180,9 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | sharedStorage.name | string | `""` | The name of the pvc. By default, computes a value from the release name |
 | sharedStorage.path | string | `"/var/lib/rstudio-pm"` | the path to mount the sharedStorage claim within the pod |
 | sharedStorage.requests.storage | string | `"10Gi"` | the volume of storage to request for this persistent volume claim |
+| sharedStorage.selector | object | `{}` | selector for PVC definition |
 | sharedStorage.storageClassName | bool | `false` | storageClassName - the type of storage to use. Must allow ReadWriteMany |
+| sharedStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/__ping__","port":4242},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | startupProbe is used to configure the container's startupProbe |
 | startupProbe.failureThreshold | int | `30` | failureThreshold * periodSeconds should be strictly > worst case startup time |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"100%","maxUnavailable":0},"type":"RollingUpdate"}` | The update strategy used by the main service pod. |

--- a/charts/rstudio-pm/ci/all-values.yaml
+++ b/charts/rstudio-pm/ci/all-values.yaml
@@ -4,6 +4,11 @@ image:
   imagePullPolicy: Always
   imagePullSecrets:
     - name: "some-secret"
+
+sharedStorage:
+  create: true
+  storageClassName: test-class
+  volumeName: test-volume
 license:
   key: test
 service:

--- a/charts/rstudio-pm/templates/pvc.yaml
+++ b/charts/rstudio-pm/templates/pvc.yaml
@@ -5,16 +5,23 @@ metadata:
   name: {{default (print (include "rstudio-pm.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
   namespace: {{ $.Release.Namespace }}
   annotations:
-{{ .Values.sharedStorage.annotations | toYaml | indent 4}}
+    {{- .Values.sharedStorage.annotations | toYaml | nindent 4}}
 spec:
   accessModes:
-{{ .Values.sharedStorage.accessModes | toYaml | indent 4 }}
+    {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}
   volumeMode: Filesystem
   {{- if .Values.sharedStorage.storageClassName }}
   storageClassName: {{ .Values.sharedStorage.storageClassName }}
   {{- end }}
+  {{- with .Values.sharedStorage.volumeName }}
+  volumeName: {{ . }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.sharedStorage.requests.storage }}
+  {{- with .Values.sharedStorage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 {{- end }}

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -26,6 +26,10 @@ sharedStorage:
   # -- Define the annotations for the Persistent Volume Claim resource
   annotations:
     helm.sh/resource-policy: keep
+  # -- selector for PVC definition
+  selector: {}
+  # -- the volumeName passed along to the persistentVolumeClaim. Optional
+  volumeName: ""
 
 image:
   # -- the repository to use for the main pod image


### PR DESCRIPTION
add volumeName and selector options for sharedStorage on both the Connect and RSPM charts

This is particularly useful for mapping PVCs to a particular PV