### PR TITLE
Posit Package Manager Chart does not reference an existing container at the moment

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:bionic-2022.11.2-18
+      image: rstudio/rstudio-package-manager:bionic-2022.11.2
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -10,7 +10,7 @@
 
 # 0.5.0
 
-- Update default Post Package Manager version to 2022.11.2-18
+- Update default Posit Package Manager version to 2022.11.2-18
 
 # 0.4.0
 


### PR DESCRIPTION
Currently the [Posit Package Manager Chart](https://github.com/rstudio/helm/blob/main/charts/rstudio-pm/Chart.yaml#L22) does not seem to reference any container that exists on dockerhub. We reference `rstudio-package-manager:bionic-2022.11.2-18` but in fact no `-18` exists, only `--{git commit id}` tags. 

This PR is changing the reference to `rstudio-package-manager:bionic-2022.11.2`.

Additionally a typo in the NEWS section where we claim that we changed version of [Post Package Manager](https://github.com/rstudio/helm/blame/main/charts/rstudio-pm/NEWS.md#L13) is part of this PR as well. 

