### PR TITLE
Bump Package Manager version to 2022.11.4

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.3
+version: 0.5.4
 apiVersion: v2
-appVersion: 2022.11.2
+appVersion: 2022.11.4
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:bionic-2022.11.2
+      image: rstudio/rstudio-package-manager:bionic-2022.11.4
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.4
+
+- Update default Posit Package Manager version to 2022.11.4-20
+
 # 0.5.3
 
 - Fix Package Manager default image reference

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 2022.11.2](https://img.shields.io/badge/AppVersion-2022.11.2-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 2022.11.4](https://img.shields.io/badge/AppVersion-2022.11.4-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -23,11 +23,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.3:
+To install the chart with the release name `my-release` at version 0.5.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.5.3
+helm install my-release rstudio/rstudio-pm --version=0.5.4
 ```
 
 ## Upgrade Guidance


### PR DESCRIPTION
Bump PPM to 2022.11.4, following image version bump at https://github.com/rstudio/rstudio-docker-products/pull/442