### PR TITLE
add securityContext to the Connect default initContainer

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.12
+version: 0.3.13
 apiVersion: v2
 appVersion: 2022.12.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,8 @@
+# 0.3.13
+
+- add `launcher.defaultInitContainer.securityContext` to configure the `securityContext` on the default `initContainer`
+  ([#319](https://github.com/rstudio/helm/issues/319))
+
 # 0.3.12
 
 - Bump Connect version to 2022.12.0

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,6 +2,8 @@
 
 - add `launcher.defaultInitContainer.securityContext` to configure the `securityContext` on the default `initContainer`
   ([#319](https://github.com/rstudio/helm/issues/319))
+- add `serviceMonitor` section for defining a ServiceMonitor object [(#126)[https://github.com/rstudio/helm/issues/126]]
+- improve consistency in the `prometheusExporter` configuration section (as compared to the `rstudio-workbench` chart)
 
 # 0.3.12
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.12](https://img.shields.io/badge/Version-0.3.12-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
+![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.12:
+To install the chart with the release name `my-release` at version 0.3.13:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.12
+helm install my-release rstudio/rstudio-connect --version=0.3.13
 ```
 
 ### NOTE
@@ -94,10 +94,11 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
 | launcher.additionalRuntimeImages | list | `[]` | Optional. Additional images to append to the end of the "launcher.customRuntimeYaml" (in the "images" key). If `customRuntimeYaml` is a "map", then "additionalRuntimeImages" will only be used if it is a "list". |
 | launcher.customRuntimeYaml | string | `"base"` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "base", which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. If set to "pro", will pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the cost of a larger image). |
-| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","tag":"","tagPrefix":"bionic-"}` | Image definition for the default RStudio Connect Content InitContainer |
+| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","securityContext":{},"tag":"","tagPrefix":"bionic-"}` | Image definition for the default RStudio Connect Content InitContainer |
 | launcher.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. |
 | launcher.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |
 | launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init"` | The repository to use for the Content InitContainer image |
+| launcher.defaultInitContainer.securityContext | object | `{}` | The securityContext for the default initContainer |
 | launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.defaultInitContainer.tagPrefix | string | `"bionic-"` | A tag prefix for the Content InitContainer image (common selections: bionic-, ubuntu2204-). Only used if tag is not defined |
 | launcher.enabled | bool | `false` | Whether to enable the launcher |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -134,7 +134,9 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |
-| prometheusExporter.resources | object | `{}` |  |
+| prometheusExporter.mappingYaml | string | `nil` | Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file |
+| prometheusExporter.resources | object | `{}` | resource specification for the prometheus exporter sidecar |
+| prometheusExporter.securityContext | object | `{}` | securityContext for the prometheus exporter sidecar |
 | rbac.clusterRoleCreate | bool | `false` | Whether to create the ClusterRole that grants access to the Kubernetes nodes API. This is used by the Launcher to get all of the IP addresses associated with the node that is running a particular job. In most cases, this can be disabled as the node's internal address is sufficient to allow proper functionality. |
 | rbac.create | bool | `true` | Whether to create rbac. (also depends on launcher.enabled = true) |
 | rbac.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | The serviceAccount to be associated with rbac (also depends on launcher.enabled = true) |
@@ -147,6 +149,9 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | service.port | int | `80` | The port to use for the Connect service |
 | service.targetPort | int | `3939` | The port to forward to on the Connect pod. Also see pod.port |
 | service.type | string | `"NodePort"` | The service type (LoadBalancer, NodePort, etc.) |
+| serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
+| serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
+| serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Prometheus Operator is running). Defaults to the release namespace |
 | sharedStorage.accessModes | list | `["ReadWriteMany"]` | A list of accessModes that are defined for the storage PVC (represented as YAML) |
 | sharedStorage.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Annotations for the Persistent Volume Claim |
 | sharedStorage.create | bool | `false` | Whether to create the persistentVolumeClaim for shared storage |

--- a/charts/rstudio-connect/ci/launcher-advanced2-values.yaml
+++ b/charts/rstudio-connect/ci/launcher-advanced2-values.yaml
@@ -7,6 +7,10 @@ sharedStorage:
   create: true
 launcher:
   enabled: true
+  defaultInitContainer:
+    enabled: true
+    securityContext:
+      allowPrivilegedEscalation: false
   additionalRuntimeImages: |
     - name: ghcr.io/rstudio/content-base:r4.1.0-py3.9.2-bionic
       python:

--- a/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
+++ b/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
@@ -7,6 +7,13 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 data:
   graphite-mapping.yaml: |-
+  {{- if .Values.prometheusExporter.mappingYaml }}
+    {{- if kindIs "string" .Values.prometheusExporter.mappingYaml }}
+      {{- .Values.prometheusExporter.mappingYaml | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.prometheusExporter.mappingYaml | nindent 4 }}
+    {{- end }}
+  {{- else }}
     mappings:
       - match: "rsconnect\\.([\\w-]+)\\.content-(\\d+)\\.(.*)"
         match_type: regex
@@ -57,4 +64,5 @@ data:
         name: "rsconnect_$2"
         labels:
           host: "$1"
+  {{- end }}
 {{- end }}

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -23,8 +23,9 @@ data:
       {{- $initContainerImageTag := .Values.launcher.defaultInitContainer.tag | default (printf "%s%s" .Values.launcher.defaultInitContainer.tagPrefix $defaultVersion )}}
       {{- $initContainerImage := print .Values.launcher.defaultInitContainer.repository ":" ( $initContainerImageTag ) }}
       {{- $initContainerPullPolicy := default "IfNotPresent" .Values.launcher.defaultInitContainer.imagePullPolicy }}
+      {{- $initContainerSecurityContext := .Values.launcher.defaultInitContainer.securityContext }}
       {{- $initContainerVolumeMount := dict "name" ("rsc-volume") "mountPath" ("/mnt/rstudio-connect-runtime/") }}
-      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "imagePullPolicy" ($initContainerPullPolicy) "volumeMounts" ( list  $initContainerVolumeMount ) }}
+      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "imagePullPolicy" ($initContainerPullPolicy) "volumeMounts" ( list  $initContainerVolumeMount ) "securityContext" $initContainerSecurityContext }}
       {{- $jobJsonInitContainer := dict "target" ("/spec/template/spec/initContainers/0") "name" ("defaultInitContainer") "json" $initContainerJson }}
     {{- /* set up job-json defaults */ -}}
       {{- $jobJsonDefaults := list }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -177,10 +177,15 @@ spec:
         volumeMounts:
           - name: graphite-exporter-config
             mountPath: "/mnt/graphite"
+        ports:
+          - containerPort: 9108
+            name: metrics
         {{- with .Values.prometheusExporter.resources }}
         resources:
           {{ toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.prometheusExporter.securityContext | nindent 10 }}
       {{- end }}
       {{- if .Values.pod.sidecar }}
 {{ toYaml .Values.pod.sidecar | indent 6 }}

--- a/charts/rstudio-connect/templates/service-monitor.yaml
+++ b/charts/rstudio-connect/templates/service-monitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.prometheusExporter.enabled .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rstudio-connect.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "rstudio-connect.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "rstudio-connect.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -139,11 +139,27 @@ securityContext:
 prometheusExporter:
   # -- Whether the  prometheus exporter sidecar should be enabled
   enabled: true
+  # -- Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
+  mappingYaml: null
+  # -- securityContext for the prometheus exporter sidecar
+  securityContext: {}
+  # -- resource specification for the prometheus exporter sidecar
+  resources: {}
   image:
     repository: "prom/graphite-exporter"
     tag: "v0.9.0"
     imagePullPolicy: IfNotPresent
-  resources: {}
+
+serviceMonitor:
+  # -- Whether to create a ServiceMonitor CRD for use with a Prometheus Operator
+  enabled: false
+  # -- Namespace to create the ServiceMonitor in (usually the same as the one in
+  # which the Prometheus Operator is running). Defaults to the release namespace
+  namespace: ""
+  # -- additionalLabels normally includes the release name of the Prometheus
+  # Operator
+  additionalLabels: {}
+  #   release: kube-prometheus-stack
 
 # -- Defines resources for the rstudio-connect container
 resources: {}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -269,6 +269,8 @@ launcher:
     tag: ""
     # -- The imagePullPolicy for the default initContainer
     imagePullPolicy: ""
+    # -- The securityContext for the default initContainer
+    securityContext: {}
 
 # -- A nested map of maps that generates the rstudio-connect.gcfg file
 # @default -- [RStudio Connect Configuration Reference](https://docs.rstudio.com/connect/admin/appendix/configuration/)


### PR DESCRIPTION
In some environments, it is important to allow customizing securityContext in order to run containers. This PR allows customizing the securityContext on the default initContainer. Close #319