### PR TITLE
Replace connect team with individuals codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 /charts/rstudio-pm/* @rstudio/rspm-dev
 
 # connect resources
-/charts/rstudio-connect/* @rstudio/connect
-/examples/connect/* @rstudio/connect
+/charts/rstudio-connect/* @aronatkins @dbkegley @christierney @zackverham
+/examples/connect/* @aronatkins @dbkegley @christierney @zackverham


### PR DESCRIPTION
These teammembers are also being added as admins to reduce the review/approve burden on Cole for simple changes (e.g. bumping release versions). Cole or Aaron should still be involved for more complicated changes.

@aronatkins @dbkegley @zackverham FYI: this came out of discussions on Trebuchet and work week. We want to be able to make small, well-understood updates, like bumping the Connect version, with less of a dependency outside the team. Please still be careful about approving other types of changes, like updating base images or other things that may break stuff.