### PR TITLE
remove warnings related to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Supporting and miscellaneous charts with varying levels of maintenance, usefulne
 
 **IMPORTANT:**
 
-These charts are provided as a convenience to RStudio customers and are not formally supported by RStudio. If you
-have questions about these charts, you can ask them in the [issues](https://github.com/rstudio/helm/issues/new/choose)
-in the repository or to your support representative, who will route them appropriately.
+These charts are provided as a convenience to RStudio customers. If you have
+questions about these charts, you can ask them in the
+[issues](https://github.com/rstudio/helm/issues/new/choose) in the repository
+or to your support representative, who will route them appropriately.
 
 Bugs or feature requests should be opened in an [issue](https://github.com/rstudio/helm/issues/new/choose).
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -34,15 +34,13 @@ products using R and Python.
 
 {{- define "rstudio.disclaimer" }}
 
-## Disclaimer
+## For Production
 
-> This chart is "beta" quality. It will likely undergo
-> breaking changes without warning as it moves towards stability.
+To ensure a stable production deployment, please:
 
-As a result, please:
 * Ensure you "pin" the version of the Helm chart that you are using. You can do
   this using the `helm dependency` command and the associated "Chart.lock" files
-  or the `--version` flag. IMPORTANT: This protects you from breaking changes
+  or the `--version` flag. **IMPORTANT: This protects you from breaking changes**
 * Before upgrading, to avoid breaking changes, use `helm diff upgrade` to check
   for breaking changes
 * Pay close attention to [`NEWS.md`](./NEWS.md) for updates on breaking

--- a/charts/rstudio-connect/Chart.lock
+++ b/charts/rstudio-connect/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: rstudio-library
   repository: file://../rstudio-library
-  version: 0.1.24
-digest: sha256:06633b91dc8294ecb96bf57c3192162e15be11b837f4fa911b32ef81bcbc042c
-generated: "2023-01-13T15:28:24.135109-05:00"
+  version: 0.1.25
+digest: sha256:08346f2e681bf03d2dea6d8f9538f15f2396d2bd09da95543ab788bed98e52db
+generated: "2023-03-17T14:57:23.683599-04:00"

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.3.18
+version: 0.3.19
 apiVersion: v2
 appVersion: 2023.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/sol-eng
 dependencies:
   - name: rstudio-library
-    version: 0.1.24
+    version: 0.1.25
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.19
+
+- Update documentation to remove "beta" label and explain production recommendations
+
 # 0.3.18
 
 - Bump Connect version to 2023.03.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.3.18](https://img.shields.io/badge/Version-0.3.18-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
+![Version: 0.3.19](https://img.shields.io/badge/Version-0.3.19-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.18:
+To install the chart with the release name `my-release` at version 0.3.19:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.3.18
+helm install my-release rstudio/rstudio-connect --version=0.3.19
 ```
 
 ### NOTE

--- a/charts/rstudio-launcher-rbac/Chart.lock
+++ b/charts/rstudio-launcher-rbac/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: rstudio-library
   repository: file://../rstudio-library
-  version: 0.1.24
-digest: sha256:06633b91dc8294ecb96bf57c3192162e15be11b837f4fa911b32ef81bcbc042c
-generated: "2023-01-13T15:28:54.05124-05:00"
+  version: 0.1.25
+digest: sha256:08346f2e681bf03d2dea6d8f9538f15f2396d2bd09da95543ab788bed98e52db
+generated: "2023-03-17T14:57:25.394196-04:00"

--- a/charts/rstudio-launcher-rbac/Chart.yaml
+++ b/charts/rstudio-launcher-rbac/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-launcher-rbac
 description: RBAC definition for the RStudio Job Launcher
 type: application
-version: 0.2.14
-appVersion: 0.2.14
+version: 0.2.15
+appVersion: 0.2.15
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 sources:
   - https://github.com/rstudio/helm
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/sol-eng
 dependencies:
   - name: rstudio-library
-    version: 0.1.24
+    version: 0.1.25
     repository: file://../rstudio-library
 keywords:
   - "data science"

--- a/charts/rstudio-launcher-rbac/NEWS.md
+++ b/charts/rstudio-launcher-rbac/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.15
+
+- Update documentation to remove "beta" label and explain production recommendations
+
 # 0.2.13+
 
 - Update `rstudio-library` chart dependency

--- a/charts/rstudio-launcher-rbac/README.md
+++ b/charts/rstudio-launcher-rbac/README.md
@@ -1,18 +1,16 @@
 # rstudio-launcher-rbac
 
-![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.14](https://img.shields.io/badge/AppVersion-0.2.14-informational?style=flat-square)
+![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.15](https://img.shields.io/badge/AppVersion-0.2.15-informational?style=flat-square)
 
 #### _RBAC definition for the RStudio Job Launcher_
 
-## Disclaimer
+## For Production
 
-> This chart is "beta" quality. It will likely undergo
-> breaking changes without warning as it moves towards stability.
+To ensure a stable production deployment, please:
 
-As a result, please:
 * Ensure you "pin" the version of the Helm chart that you are using. You can do
   this using the `helm dependency` command and the associated "Chart.lock" files
-  or the `--version` flag. IMPORTANT: This protects you from breaking changes
+  or the `--version` flag. **IMPORTANT: This protects you from breaking changes**
 * Before upgrading, to avoid breaking changes, use `helm diff upgrade` to check
   for breaking changes
 * Pay close attention to [`NEWS.md`](./NEWS.md) for updates on breaking
@@ -20,11 +18,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.14:
+To install the chart with the release name `my-release` at version 0.2.15:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-launcher-rbac --version=0.2.14
+helm install my-release rstudio/rstudio-launcher-rbac --version=0.2.15
 ```
 
 ## Common Usage

--- a/charts/rstudio-library/Chart.yaml
+++ b/charts/rstudio-library/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-library
 description: Helm library helpers for use by Official RStudio charts
 type: library
-version: 0.1.24
-appVersion: 0.1.24
+version: 0.1.25
+appVersion: 0.1.25
 
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com

--- a/charts/rstudio-library/NEWS.md
+++ b/charts/rstudio-library/NEWS.md
@@ -1,3 +1,7 @@
+# 0.1.25
+
+- Update documentation to remove "beta" label and explain production recommendations
+
 # 0.1.24
 
 - Update RBAC to support listing of service accounts

--- a/charts/rstudio-library/README.md
+++ b/charts/rstudio-library/README.md
@@ -1,18 +1,16 @@
 # rstudio-library
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.24](https://img.shields.io/badge/AppVersion-0.1.24-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.25](https://img.shields.io/badge/AppVersion-0.1.25-informational?style=flat-square)
 
 #### _Helm library helpers for use by Official RStudio charts_
 
-## Disclaimer
+## For Production
 
-> This chart is "beta" quality. It will likely undergo
-> breaking changes without warning as it moves towards stability.
+To ensure a stable production deployment, please:
 
-As a result, please:
 * Ensure you "pin" the version of the Helm chart that you are using. You can do
   this using the `helm dependency` command and the associated "Chart.lock" files
-  or the `--version` flag. IMPORTANT: This protects you from breaking changes
+  or the `--version` flag. **IMPORTANT: This protects you from breaking changes**
 * Before upgrading, to avoid breaking changes, use `helm diff upgrade` to check
   for breaking changes
 * Pay close attention to [`NEWS.md`](./NEWS.md) for updates on breaking

--- a/charts/rstudio-pm/Chart.lock
+++ b/charts/rstudio-pm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: rstudio-library
   repository: file://../rstudio-library
-  version: 0.1.24
-digest: sha256:06633b91dc8294ecb96bf57c3192162e15be11b837f4fa911b32ef81bcbc042c
-generated: "2023-02-09T08:18:05.697629-05:00"
+  version: 0.1.25
+digest: sha256:08346f2e681bf03d2dea6d8f9538f15f2396d2bd09da95543ab788bed98e52db
+generated: "2023-03-17T14:57:27.445424-04:00"

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.5
+version: 0.5.6
 apiVersion: v2
 appVersion: 2022.11.4
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
@@ -14,7 +14,7 @@ maintainers:
     url: https://github.com/rstudio/helm
 dependencies:
   - name: rstudio-library
-    version: 0.1.24
+    version: 0.1.25
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.6
+
+- Update documentation to remove "beta" label and explain production recommendations
+
 # 0.5.5
 
 - Bump rstudio-library to `0.1.24`

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,21 +1,19 @@
 # RStudio Package Manager
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 2022.11.4](https://img.shields.io/badge/AppVersion-2022.11.4-informational?style=flat-square)
+![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 2022.11.4](https://img.shields.io/badge/AppVersion-2022.11.4-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
 IT Administrators use [RStudio Package Manager](https://www.rstudio.com/products/package-manager/) to control and manage
 R and Python packages that Data Scientists need to create and share data products.
 
-## Disclaimer
+## For Production
 
-> This chart is "beta" quality. It will likely undergo
-> breaking changes without warning as it moves towards stability.
+To ensure a stable production deployment, please:
 
-As a result, please:
 * Ensure you "pin" the version of the Helm chart that you are using. You can do
   this using the `helm dependency` command and the associated "Chart.lock" files
-  or the `--version` flag. IMPORTANT: This protects you from breaking changes
+  or the `--version` flag. **IMPORTANT: This protects you from breaking changes**
 * Before upgrading, to avoid breaking changes, use `helm diff upgrade` to check
   for breaking changes
 * Pay close attention to [`NEWS.md`](./NEWS.md) for updates on breaking
@@ -23,11 +21,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.5:
+To install the chart with the release name `my-release` at version 0.5.6:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-pm --version=0.5.5
+helm install my-release rstudio/rstudio-pm --version=0.5.6
 ```
 
 ## Upgrade Guidance

--- a/charts/rstudio-workbench/Chart.lock
+++ b/charts/rstudio-workbench/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: rstudio-library
   repository: file://../rstudio-library
-  version: 0.1.24
-digest: sha256:06633b91dc8294ecb96bf57c3192162e15be11b837f4fa911b32ef81bcbc042c
-generated: "2023-02-09T08:18:19.024454-05:00"
+  version: 0.1.25
+digest: sha256:08346f2e681bf03d2dea6d8f9538f15f2396d2bd09da95543ab788bed98e52db
+generated: "2023-03-17T14:57:29.304822-04:00"

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.28
+version: 0.5.29
 apiVersion: v2
 appVersion: 2022.12.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/sol-eng
 dependencies:
   - name: rstudio-library
-    version: 0.1.24
+    version: 0.1.25
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.29
+
+- Update documentation to remove "beta" label and explain production recommendations
+
 # 0.5.28
 
 - Bump rstudio-library to `0.1.24`

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,21 +1,19 @@
 # RStudio Workbench
 
-![Version: 0.5.28](https://img.shields.io/badge/Version-0.5.28-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
+![Version: 0.5.29](https://img.shields.io/badge/Version-0.5.29-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
 Data Scientists use [RStudio Workbench](https://www.rstudio.com/products/workbench/) to analyze data and create data
 products using R and Python.
 
-## Disclaimer
+## For Production
 
-> This chart is "beta" quality. It will likely undergo
-> breaking changes without warning as it moves towards stability.
+To ensure a stable production deployment, please:
 
-As a result, please:
 * Ensure you "pin" the version of the Helm chart that you are using. You can do
   this using the `helm dependency` command and the associated "Chart.lock" files
-  or the `--version` flag. IMPORTANT: This protects you from breaking changes
+  or the `--version` flag. **IMPORTANT: This protects you from breaking changes**
 * Before upgrading, to avoid breaking changes, use `helm diff upgrade` to check
   for breaking changes
 * Pay close attention to [`NEWS.md`](./NEWS.md) for updates on breaking
@@ -23,11 +21,11 @@ As a result, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.28:
+To install the chart with the release name `my-release` at version 0.5.29:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.28
+helm install my-release rstudio/rstudio-workbench --version=0.5.29
 ```
 
 ## Required Configuration

--- a/examples/rbac/rstudio-launcher-rbac-0.2.15.yaml
+++ b/examples/rbac/rstudio-launcher-rbac-0.2.15.yaml
@@ -1,0 +1,88 @@
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rstudio-launcher-rbac
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rstudio-launcher-rbac
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts"
+    verbs:
+    - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "pods/attach"
+      - "pods/exec"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+    verbs:
+      - "create"
+      - "get"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - "batch"
+    resources:
+      - "jobs"
+    verbs:
+      - "create"
+      - "update"
+      - "patch"
+      - "get"
+      - "watch"
+      - "list"
+      - "delete"
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+---
+# Source: rstudio-launcher-rbac/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rstudio-launcher-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rstudio-launcher-rbac
+subjects:
+  - kind: ServiceAccount
+    name: rstudio-launcher-rbac


### PR DESCRIPTION
Remove wording that is confusing to customers, and ensure folks understand how to make their production deployments reliable and reproducible.