### PR TITLE
change launcher-mounts default

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.0-rc05
+version: 0.6.0-rc06
 apiVersion: v2
 appVersion: 2023.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,16 +1,27 @@
 # 0.6.0
 
-- Update documentation and README for a bit more clarity
 - BREAKING: Change default OS / OS prefix to `ubuntu2204-`.
   [Bionic support is EOL as of 2023-04-30](https://posit.co/about/platform-support/)
   - If you want to revert this change, set `session.image.tagPrefix=bionic-` (sessions) and `image.tagPrefix=bionic-` (
     server)
+- BREAKING: change the "home volume mount" for sessions to happen automatically, regardless of whether you define other
+  values in `config.serverDcf.launcher-mounts`
+  - Previously, if you specify anything in `launcher-mounts`, then we did not mount the home volume onto the session
+  - Now, we continue to mount the home volume onto the session, unless:
+    - You set `session.defaultHomeMount=false`
+    - You have the same (or a parent) `mountPath` defined in an existing `launcher-mounts` volume
+    - You have the same PVC `ClaimName` defined in an existing `launcher-mounts` volume
+  - If you mount the volume yourself and want to keep doing so, you can set `session.defaultHomeMount=false`
+  - If you mount the volume yourself and would like to stop doing so, you can now unset the home mount
+    in `launcher-mounts`
+- Update documentation and README for a bit more clarity
 - Update product to version `2023.03.0`
 - Allow customizing the `pod.command` associated with sessions for some highly custom startup cases. This should
   not be necessary in most cases and will be removed at a later date, once the product supports startup customization.
   Please reach out if you have questions about this functionality!
 - Add `podDisruptionBudget` values
 - Add `topologySpreadConstraints` values
+- Start to utilize the `pod.securityContext` values for pod `securityContext` values
 
 # 0.5.32
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.6.0-rc05](https://img.shields.io/badge/Version-0.6.0--rc05-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
+![Version: 0.6.0-rc06](https://img.shields.io/badge/Version-0.6.0--rc06-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -27,7 +27,7 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.6.0-rc05:
+To install the chart with the release name `my-release` at version 0.6.0-rc06:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
@@ -35,7 +35,7 @@ helm repo add rstudio https://helm.rstudio.com
 helm upgrade --install my-release rstudio/rstudio-workbench
 
 # WARNING: to install devel version / release candidate / etc.
-helm upgrade --install --devel my-release rstudio/rstudio-workbench --version=0.6.0-rc05
+helm upgrade --install --devel my-release rstudio/rstudio-workbench --version=0.6.0-rc06
 ```
 
 To explore other chart versions, take a look at:
@@ -368,7 +368,7 @@ config:
 | config.secret | object | `{"database.conf":{}}` | a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |
 | config.server | object | [RStudio Workbench Configuration Reference](https://docs.rstudio.com/ide/server-pro/rstudio_server_configuration/rstudio_server_configuration.html). See defaults with `helm show values` | a map of server config files. Mounted to `/mnt/configmap/rstudio/` |
 | config.serverDcf | object | `{"launcher-mounts":[]}` | a map of server-scoped config files (akin to `config.server`), but with .dcf file formatting (i.e. `launcher-mounts`, `launcher-env`, etc.) |
-| config.session | object | `{"notifications.conf":{},"repos.conf":{"CRAN":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest","RSPM":"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"},"rsession.conf":{},"rstudio-prefs.json":{}}` | a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default. |
+| config.session | object | `{"notifications.conf":{},"repos.conf":{"RSPM":"https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"},"rsession.conf":{},"rstudio-prefs.json":{}}` | a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default. |
 | config.sessionSecret | object | `{}` | a map of secret, session-scoped config files (odbc.ini, etc.). Mounted to `/mnt/session-secret/` on both server and session, by default |
 | config.startupCustom | object | `{}` | a map of supervisord .conf files to define custom services. Mounted into the container at /startup/custom/ |
 | config.startupUserProvisioning | object | `{"sssd.conf":"[program:sssd]\ncommand=/usr/sbin/sssd -i -c /etc/sssd/sssd.conf --logger=stderr\nautorestart=false\nnumprocs=1\nstdout_logfile=/dev/stdout\nstdout_logfile_maxbytes=0\nstdout_logfile_backups=0\nstderr_logfile=/dev/stderr\nstderr_logfile_maxbytes=0\nstderr_logfile_backups=0\n"}` | a map of supervisord .conf files to define user provisioning services. Mounted into the container at /startup/user-provisioning/ |
@@ -457,6 +457,7 @@ config:
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
 | serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Prometheus Operator is running). Defaults to the release namespace |
 | session.defaultConfigMount | bool | `true` | Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this |
+| session.defaultHomeMount | bool | `true` | Whether to automatically add the homeStorage PVC to the session (i.e. via the `launcher-mounts` file) |
 | session.defaultSecretMountPath | string | `"/mnt/session-secret/"` | The path to mount the sessionSecret (from `config.sessionSecret`) onto the server and session pods |
 | session.image.repository | string | `"rstudio/r-session-complete"` | The repository to use for the session image |
 | session.image.tag | string | `""` | A tag override for the session image. Overrides the "tagPrefix" above, if set. Default tag is `{{ tagPrefix }}{{ version }}` |

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -177,7 +177,7 @@ config:
   serverDcf:
     launcher-mounts:
       - MountType: KubernetesPersistentVolumeClaim
-        MountPath: /home
+        MountPath: /mnt/home
         ClaimName: rstudio-server-home-storage
       - MountType: KubernetesPersistentVolumeClaim
         MountPath: /shared

--- a/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
@@ -1,4 +1,22 @@
 ---
+# Source: rstudio-workbench/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-rstudio-workbench
+  labels:
+    helm.sh/chart: rstudio-workbench-VERSION
+    app.kubernetes.io/name: rstudio-workbench
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "2023.03.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rstudio-workbench
+      app.kubernetes.io/instance: release-name
+  minAvailable: 30%
+---
 # Source: rstudio-workbench/templates/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -146,8 +164,8 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json","/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionSecretVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionSecretVolumeMount.json"
   
   
@@ -167,10 +185,9 @@ data:
   
   
   
-  
   launcher-mounts: |
     ClaimName: rstudio-server-home-storage
-    MountPath: /home
+    MountPath: /mnt/home
     MountType: KubernetesPersistentVolumeClaim
   
     ClaimName: rstudio-shared-data
@@ -665,7 +682,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     key: "value"
@@ -705,7 +722,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: fa80f6d192389899f72f96b4559ffc8c2cf4f59c80a776e5e5e1627243986a31
+        checksum/config-general: d525c9dbb98c8df7406b93b60bc63a5471e68ab8f42eb3be2bbd26015dfbb65e
         checksum/config-graphite: 69dd73685cb821ebf5bcec3155d92801f31d72b031a4d681700bded2ff5700c2
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: fc06992d38b807a70a6f5722d670969573e2ee3f82293197a2bd0d840ca3a7d4
@@ -900,7 +917,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     kubernetes.io/ingress.class: traefik

--- a/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
@@ -105,10 +105,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -328,8 +327,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -482,7 +480,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -520,11 +518,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -538,7 +536,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -657,7 +655,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/default.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default.yaml.lock
@@ -112,10 +112,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -335,8 +334,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -489,7 +487,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -527,11 +525,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -545,7 +543,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -664,7 +662,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
@@ -112,10 +112,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -335,8 +334,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -489,7 +487,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -527,11 +525,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -545,7 +543,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -664,7 +662,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
@@ -112,10 +112,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -335,8 +334,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -489,7 +487,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -527,11 +525,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -545,7 +543,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -658,7 +656,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     kubernetes.io/ingress.class: traefik
@@ -691,7 +689,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
@@ -112,10 +112,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -335,8 +334,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -489,7 +487,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -527,11 +525,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -545,7 +543,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -658,7 +656,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     kubernetes.io/ingress.class: traefik
@@ -691,7 +689,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
@@ -124,9 +124,8 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
-  
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
   
   
   
@@ -144,29 +143,40 @@ metadata:
 data:
   rstudio-library-templates-data.tpl: |
     {{- define "rstudio-library.templates.data" -}}
-    {"job":{"annotations":{"seven":"eight"},"labels":{"nine":"ten"}},"pod":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.azure.com/scalesetpriority","operator":"In","values":["spot"]}]}]}}},"annotations":{"one":"two"},"containerSecurityContext":{"privileged":false},"defaultSecurityContext":{"fsGroupChangePolicy":"Always","runAsGroup":999},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{"three":"four"},"nodeSelector":{},"securityContext":{"runAsUser":999},"serviceAccountName":"test","tolerations":[{"effect":"NoSchedule","key":"kubernetes.azure.com/scalesetpriority","operator":"Equal","value":"spot"}],"volumeMounts":[{"mountPath":"/tmp/mnt","name":"test"},{"mountPath":"/mnt/session-configmap/rstudio","name":"session-config"},{"mountPath":"/mnt/session-secret/","name":"session-secret"}],"volumes":[{"emptyDir":{},"name":"test"},{"configMap":{"defaultMode":420,"name":"release-name-rstudio-workbench-session"},"name":"session-config"},{"name":"session-secret","secret":{"defaultMode":272,"secretName":"release-name-rstudio-workbench-session-secret"}}]},"service":{"annotations":{"five":"six"},"labels":{},"type":"ClusterIP"}}
+    {"job":{"annotations":{"seven":"eight"},"labels":{"nine":"ten"}},"pod":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.azure.com/scalesetpriority","operator":"In","values":["spot"]}]}]}}},"annotations":{"one":"two"},"command":[],"containerSecurityContext":{"privileged":false},"defaultSecurityContext":{"fsGroupChangePolicy":"Always","runAsGroup":999},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{"three":"four"},"nodeSelector":{},"securityContext":{"runAsUser":999},"serviceAccountName":"test","tolerations":[{"effect":"NoSchedule","key":"kubernetes.azure.com/scalesetpriority","operator":"Equal","value":"spot"}],"volumeMounts":[{"mountPath":"/tmp/mnt","name":"test"},{"mountPath":"/mnt/session-configmap/rstudio","name":"session-config"},{"mountPath":"/mnt/session-secret/","name":"session-secret"}],"volumes":[{"emptyDir":{},"name":"test"},{"configMap":{"defaultMode":420,"name":"release-name-rstudio-workbench-session"},"name":"session-config"},{"name":"session-secret","secret":{"defaultMode":272,"secretName":"release-name-rstudio-workbench-session-secret"}}]},"service":{"annotations":{"five":"six"},"labels":{},"type":"ClusterIP"}}
     {{- end }}
   job.tpl: |
-    # Version: 2
+    # Version: 2.3.1
     # DO NOT MODIFY the "Version: " key
     # Helm Version: v2
     {{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}
     apiVersion: batch/v1
     kind: Job
     metadata:
-      generateName: {{ toYaml .Job.generateName }}
       annotations:
+        {{- with .Job.metadata.job.annotations }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+        {{- end }}
+        {{- end }}
         {{- with $templateData.job.annotations }}
         {{- range $key, $val := . }}
         {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
         {{- end }}
         {{- end }}
       labels:
+        app.kubernetes.io/managed-by: "launcher"
+        {{- with .Job.metadata.job.labels }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+        {{- end }}
+        {{- end }}
         {{- with $templateData.job.labels }}
         {{- range $key, $val := . }}
         {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
         {{- end }}
         {{- end }}
+      generateName: {{ toYaml .Job.generateName }}
     spec:
       backoffLimit: 0
       template:
@@ -183,12 +193,25 @@ data:
             user: {{ toYaml .Job.user }}
             name: {{ toYaml .Job.name }}
             service_ports: {{ toYaml .Job.servicePortsJson }}
+            {{- if .Job.metadata }}
+            user_metadata: {{ toJson .Job.metadata | toYaml | indent 8 | trimPrefix (repeat 8 " ") }}
+            {{- end }}
+            {{- with .Job.metadata.pod.annotations }}
+            {{- range $key, $val := . }}
+            {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+            {{- end }}
+            {{- end }}
             {{- with $templateData.pod.annotations }}
             {{- range $key, $val := . }}
             {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
             {{- end }}
             {{- end }}
           labels:
+            {{- with .Job.metadata.pod.labels }}
+            {{- range $key, $val := . }}
+            {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+            {{- end }}
+            {{- end }}
             {{- with $templateData.pod.labels }}
             {{- range $key, $val := . }}
             {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
@@ -200,8 +223,8 @@ data:
           nodeName: {{ toYaml .Job.host }}
           {{- end }}
           restartPolicy: Never
-          {{- with $templateData.pod.serviceAccountName }}
-          serviceAccountName: {{ . }}
+          {{- if or $templateData.pod.serviceAccountName .Job.serviceAccountName }}
+          serviceAccountName: {{ .Job.serviceAccountName | default $templateData.pod.serviceAccountName | quote }}
           {{- end }}
           shareProcessNamespace: {{ .Job.shareProcessNamespace }}
           {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumes) 0) }}
@@ -221,8 +244,17 @@ data:
           affinity:
             {{- toYaml . | nindent 8 }}
           {{- end }}
-          {{- with $templateData.pod.nodeSelector }}
+          {{- if or (ne (len .Job.placementConstraints) 0) (ne (len $templateData.pod.nodeSelector) 0) }}
           nodeSelector:
+            {{- range .Job.placementConstraints }}
+            {{ .name }}: {{ toYaml .value }}
+            {{- end }}
+            {{- range $key,$val := $templateData.pod.nodeSelector }}
+            {{ $key }}: {{- toYaml $val | nindent 10 }}
+            {{- end }}
+          {{- end }}
+          {{- with $templateData.pod.priorityClassName }}
+          priorityClassName:
             {{- toYaml . | nindent 8 }}
           {{- end }}
           {{- $securityContext := $templateData.pod.defaultSecurityContext }}
@@ -250,6 +282,11 @@ data:
           imagePullSecrets: {{ toYaml . | nindent 12 }}
           {{- end }}
           initContainers:
+            {{- with .Job.metadata.pod.initContainers }}
+            {{- range . }}
+            - {{ toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
+            {{- end }}
+            {{- end }}
             {{- with $templateData.pod.initContainers }}
               {{- range . }}
             - {{ toYaml . | indent 10 | trimPrefix (repeat 10 " ") }}
@@ -262,7 +299,10 @@ data:
               imagePullPolicy: {{- . | nindent 12 }}
               {{- end }}
               {{- $isShell := false }}
-              {{- if .Job.command }}
+              {{- if $templateData.pod.command }}
+              command: {{- toYaml $templateData.pod.command | nindent 12 }}
+                {{- if .Job.command }}{{- $isShell = true }}{{- end }}
+              {{- else if .Job.command }}
               command: ['/bin/sh']
               {{- $isShell = true }}
               {{- else }}
@@ -304,7 +344,7 @@ data:
                   {{- $secrets = append $secrets $secret }}
                 {{- end }}
               {{- end }}
-              {{- if or (ne (len .Job.environment) 0) (ne (len $secrets) 0) }}
+              {{- if or (ne (len .Job.environment) 0) (ne (len $secrets) 0) (ne (len $templateData.pod.env) 0) }}
               env:
                 {{- range .Job.environment }}
                 - name: {{ toYaml .name | indent 14 | trimPrefix (repeat 14 " ") }}
@@ -317,16 +357,19 @@ data:
                       name: {{ get . "secret" }}
                       key: {{ get . "key" }}
                 {{- end }}
+                {{- if .Values.pod.env }}
+                  {{- toYaml $templateData.pod.env | nindent 12 }}
+                {{- end }}
+              {{- end }}
+              {{- with $templateData.pod.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 12 }}
               {{- end }}
               {{- $exposedPorts := list }}
               {{- range .Job.exposedPorts }}
                 {{- if .publishedPort }}
                   {{- $exposedPorts = append $exposedPorts . }}
                 {{- end }}
-              {{- end }}
-              {{- with $templateData.pod.containerSecurityContext }}
-              securityContext:
-                {{- toYaml . | nindent 12 }}
               {{- end }}
               {{- if ne (len $exposedPorts) 0 }}
               ports:
@@ -340,16 +383,12 @@ data:
               {{- range .Job.resourceLimits }}
                 {{- if eq .type "cpuCount" }}
                   {{- $_ := set $limits "cpu" .value }}
-                  {{- if ne $.Job.cpuRequestRatio 1.0 }}
-                    {{- $val := mulf .value $.Job.cpuRequestRatio | toString }}
-                    {{- $_ := set $requests "cpu" $val }}
-                  {{- end }}
+                {{- else if eq .type "CPU Request" }}
+                  {{- $_ := set $requests "cpu" .value }}
                 {{- else if eq .type "memory" }}
                   {{- $_ := set $limits "memory" (printf "%s%s" .value "M") }}
-                  {{- if ne $.Job.memoryRequestRatio 1.0 }}
-                    {{- $val := mulf .value $.Job.memoryRequestRatio }}
-                    {{- $_ := set $requests "memory" (printf "%.2f%s" $val "M") }}
-                  {{- end }}
+                {{- else if eq .type "Memory Request" }}
+                  {{- $_ := set $requests "memory" (printf "%s%s" .value "M") }}
                 {{- else if eq .type "NVIDIA GPUs" }}
                   {{- $val := float64 .value }}
                   {{- if ne $val 0.0 }}
@@ -391,7 +430,7 @@ data:
             {{- end }}
     
   service.tpl: |
-    # Version: 2
+    # Version: 2.3.1
     # DO NOT MODIFY the "Version: " key
     # Helm Version: v2
     {{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}
@@ -400,13 +439,24 @@ data:
     metadata:
       name: {{ .Job.serviceName }}
       annotations:
+        {{- with .Job.metadata.service.annotations }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
+        {{- end }}
+        {{- end }}
         {{- with $templateData.service.annotations }}
         {{- range $key, $val := . }}
         {{ $key }}: {{ toYaml $val | indent 4 | trimPrefix (repeat 4 " ") }}
         {{- end }}
         {{- end }}
       labels:
+        app.kubernetes.io/managed-by: "launcher"
         job-name: {{ toYaml .Job.id }}
+        {{- with .Job.metadata.service.labels }}
+        {{- range $key, $val := . }}
+        {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
+        {{- end }}
+        {{- end }}
         {{- with $templateData.service.labels }}
         {{- range $key, $val := . }}
         {{ $key }}: {{ toYaml $val | indent 8 | trimPrefix (repeat 8 " ") }}
@@ -619,8 +669,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -773,7 +822,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -811,11 +860,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 9761d98140194f7d02c9c8d9a719e6b8b6d788a0f8d135f64cd44488261c67c7
+        checksum/config-general: 604aeeee586a28238b9ac79cd2988e62decaf1323bf6de929c9d4d11ae13ba91
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 89e1a6a82a51c83763653a4c034f7f41623f16b840369caf5189b759e6495b85
+        checksum/config-session: 50517ed3e09bf63cb4784fedfc7350ea1bd8a730a5f8302b3b2a9d96e950435a
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -829,7 +878,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -962,7 +1011,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
@@ -112,10 +112,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -335,8 +334,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -489,7 +487,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -527,11 +525,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -545,7 +543,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -672,7 +670,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
@@ -123,10 +123,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -346,8 +345,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -500,7 +498,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -538,11 +536,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -556,7 +554,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -682,7 +680,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
@@ -113,10 +113,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -336,8 +335,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -490,7 +488,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -528,11 +526,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 59a6ae1ab6e21e9f77a08ef95163a9b6478b01c687a17047e7ddbb171de6eaf0
+        checksum/config-general: 804c28aee07c4382d475017e84cfaaf266decdcfb03b27bc6a991b09b340e367
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -546,7 +544,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -667,7 +665,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/license-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-values.yaml.lock
@@ -122,10 +122,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -345,8 +344,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -499,7 +497,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -537,11 +535,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 93d2a2abf9f46dd92c77f36d279c51a99a9f454bfc27b063d8aafd5ff6a82332
+        checksum/config-general: 88e73249fd81f87b3d1e9244d366c115c2c3bee235f382758e87eda33e3cfec2
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -555,7 +553,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -679,7 +677,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
@@ -122,8 +122,8 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
   
   
@@ -143,10 +143,13 @@ data:
   
   
   
-  
   launcher-mounts: |
     ClaimName: rstudio-server-home-storage
     MountPath: /home
+    MountType: KubernetesPersistentVolumeClaim
+  
+    ClaimName: release-name-rstudio-workbench-home-storage
+    MountPath: /mnt/home
     MountType: KubernetesPersistentVolumeClaim
 ---
 # Source: rstudio-workbench/templates/configmap-general.yaml
@@ -580,7 +583,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     key: "value"
@@ -620,7 +623,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 4a0088f21da5f79b8f94867379080104f0d32d2ad6f0729c217e18846be52c1b
+        checksum/config-general: 3e92870779cedc094a84bad280fa894262150c19363837d9811c4eb9adbc8e99
         checksum/config-graphite: ab090aebd9b73a011de2ba8d98eb62398fa39a4fdd7d137281ada8306c3909d8
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4

--- a/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
@@ -123,9 +123,8 @@ data:
     [*]
     allow-unknown-images=1
     container-images=some-image:tag,another-image:tag
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json","/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/volumes.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/volumeMounts.json","/spec/template/spec/containers/0/command/0":"/mnt/job-json-overrides-new/entrypoint.json"
-  
   
   
   
@@ -371,8 +370,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -541,7 +539,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -579,11 +577,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: e389260988e1676cec88446c2db81aebd330f78ef459189b9a016cd7be6b31f4
+        checksum/config-general: 493395b368a78d8f8eebae0fb49fe99226f182fabb71aaaabc47caaa4930ee1b
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -597,7 +595,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -730,7 +728,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
@@ -123,7 +123,6 @@ data:
   
   
   
-  
   launcher-mounts: |
     ClaimName: release-name-rstudio-workbench-home-storage
     MountPath: /home
@@ -349,8 +348,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -519,7 +517,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -557,11 +555,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 449277943a00ad0428fe7e97545b2d8498f24e2b6c2ba49c2dc70a1f4893df7d
+        checksum/config-general: 396300dbd430b7ca84d1368634036ea8009427e60d80a53b96837102ee327a29
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -575,7 +573,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -708,7 +706,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
@@ -122,13 +122,12 @@ data:
   
     [*]
     allow-unknown-images=0
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
   
     [cole]
     allow-unknown-images=1
-  
   
   
   
@@ -351,8 +350,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -521,7 +519,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -559,11 +557,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 780aca3eb488a2ef40ea587e8e45ca7b386880ee6a28e6bb85f0fab9c52909b9
+        checksum/config-general: 75dcd19536484012555597376ce81425e63e04c2fd85404f54c953de397a2981
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -577,7 +575,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -710,7 +708,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
@@ -122,10 +122,9 @@ data:
   
     [*]
     allow-unknown-images=1
-    container-images=rstudio/r-session-complete:bionic-2022.12.0
-    default-container-image=rstudio/r-session-complete:bionic-2022.12.0
+    container-images=rstudio/r-session-complete:ubuntu2204-2023.03.0
+    default-container-image=rstudio/r-session-complete:ubuntu2204-2023.03.0
     job-json-overrides="/spec/template/spec/volumes/-":"/mnt/job-json-overrides-new/defaultSessionVolume.json","/spec/template/spec/containers/0/volumeMounts/-":"/mnt/job-json-overrides-new/defaultSessionVolumeMount.json"
-  
   
   
   
@@ -348,8 +347,7 @@ data:
   
   notifications.conf: |
   repos.conf: |
-    CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-    RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    RSPM=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   rsession.conf: |
   rstudio-prefs.json: |
 ---
@@ -518,7 +516,7 @@ metadata:
     helm.sh/chart: rstudio-workbench-VERSION
     app.kubernetes.io/name: rstudio-workbench
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2022.12.0"
+    app.kubernetes.io/version: "2023.03.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     
@@ -556,11 +554,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 231c509d2879202c327c0f55813d085a1d566645c09ead31199aa611880d45c0
+        checksum/config-general: a2f52eedf957ea7fd7133abed57baed3f8d13b6422e293a9bf525dc68837bc1b
         checksum/config-graphite: 9e9249a6820fceccee72ec5c0811fe22cc8a91eabd085164826ff92b3d693b36
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: ad52e25359a651886a989483098b1d6a177e1a5871803e5992bdd591dd82ebc4
-        checksum/config-session: 8b9522bfc3b63d4206fc26da24bb36f66abed04014e732a9d3448b5a67531755
+        checksum/config-session: dec54acfb2c889c81f4e3fe30eeefa38dd28126194d584d801f56774527442e7
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: "9108"
@@ -574,7 +572,7 @@ spec:
       shareProcessNamespace: false      
       containers:
       - name: rstudio
-        image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+        image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
         env:
         - name: RSTUDIO_LAUNCHER_STARTUP_HEALTH_CHECK_ARGS
           value: "-fsSL"
@@ -707,7 +705,7 @@ spec:
   
   containers:
   - name: rstudio
-    image: "rstudio/rstudio-workbench:bionic-2022.12.0"
+    image: "rstudio/rstudio-workbench:ubuntu2204-2023.03.0"
     env:
     - name: DIAGNOSTIC_DIR
       value: "/var/log/rstudio"

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -349,7 +349,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
     Defines the default launcherMounts (if not defined)
         Precedence:
-            - If .Values.config.serverDcf.launcher-mounts is defined, use that verbatim
+            - If homeStorage.create or homeStorage.mount, then:
+                - If config.serverDcf.launcher-mounts is a string, use that
+                -
             - If not, and if homestorage.create is true, provision home storage and launcher-mounts automatically
             - Otherwise use .Values.config.serverDcf.launcher-mounts
 */}}
@@ -377,6 +379,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- /* TODO: implement a helper that does this lookup for us... key on MountPath? Or ClaimName? */ }}
         {{- /* TODO: also need an escape hatch to turn this magic off */ -}}
         {{- $mountAlreadyDefined := false }}
+        {{- $elt := range $tmpMounts }}
+            {{- if hasKey $elt "MountPath" }}
+            {{- end }}
+            {{- if hasKey $elt "ClaimName" }}
+            {{- end }}
+        {{- end }}
 
         {{- /* only alter $tmpMounts if claim is not provided by the user */ -}}
         {{- if not $mountAlreadyDefined }}

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName:
         {{- toYaml . | nindent 8 }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -12,8 +12,12 @@ diagnostics:
   directory: /var/log/rstudio
 
 session:
-  # -- Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this
+  # -- Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is
+  # different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to
+  # facilitate this
   defaultConfigMount: true
+  # -- Whether to automatically add the homeStorage PVC to the session (i.e. via the `launcher-mounts` file)
+  defaultHomeMount: true
   # -- The path to mount the sessionSecret (from `config.sessionSecret`) onto the server and session pods
   defaultSecretMountPath: /mnt/session-secret/
   image:
@@ -387,8 +391,7 @@ config:
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.
   session:
     repos.conf:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-      CRAN: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
     rsession.conf: {}
     notifications.conf: {}
     rstudio-prefs.json: {}


### PR DESCRIPTION
Before, we turned off the default `launcher-mounts` the second you put anything in the config.

We now:
- have a toggle to disable the default
- when enabled, only inject the default when missing the needed `claim` or mount path