### PR TITLE
add container lifecycle hooks to workbench

### DIFF
--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -31,6 +31,10 @@ containers:
   {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
   {{- $imageTag := .Values.image.tag | default (printf "%s%s" .Values.image.tagPrefix $defaultVersion )}}
   image: "{{ .Values.image.repository }}:{{ $imageTag }}"
+  {{- with .Values.pod.lifecycle }}
+  lifecycle:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   env:
   {{- if .Values.diagnostics.enabled }}
   - name: DIAGNOSTIC_DIR

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -282,6 +282,8 @@ pod:
   sidecar: false
   # -- A map used verbatim as the pod's "affinity" definition
   affinity: {}
+  # -- container lifecycle hooks
+  lifecycle: {}
 
 prometheusExporter:
   # -- whether the  prometheus exporter sidecar should be enabled


### PR DESCRIPTION
Adds an option to set [container lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) on the Workbench container. The motivation behind this is a desire to gracefully suspend active user sessions via `rstudio-server force-suspend-all` as part of the pod's `preStop` hook.