### PR TITLE
add an adhoc implementation of command for the workbench job template

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.5.32
+version: 0.5.33-rc01
 apiVersion: v2
 appVersion: 2022.12.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.5.32](https://img.shields.io/badge/Version-0.5.32-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
+![Version: 0.5.33-rc01](https://img.shields.io/badge/Version-0.5.33--rc01-informational?style=flat-square) ![AppVersion: 2022.12.0](https://img.shields.io/badge/AppVersion-2022.12.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.32:
+To install the chart with the release name `my-release` at version 0.5.33-rc01:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-workbench --version=0.5.32
+helm install --devel my-release rstudio/rstudio-workbench --version=0.5.33-rc01
 ```
 
 ## Required Configuration
@@ -390,7 +390,8 @@ config:
 | launcher.includeTemplateValues | bool | `true` | whether to include the templateValues rendering process |
 | launcher.kubernetesHealthCheck | object | `{"enabled":true,"extraCurlArgs":["-fsSL"]}` | configuration for the "Kubernetes Health Check" that the launcher entrypoint runs at startup |
 | launcher.namespace | string | `""` | allow customizing the namespace that sessions are launched into. Note RBAC and some config issues today |
-| launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"containerSecurityContext":{},"defaultSecurityContext":{},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | values that are passed along to the launcher job rendering process as a data object (in JSON). These values are then used within session templates. |
+| launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"command":[],"containerSecurityContext":{},"defaultSecurityContext":{},"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | values that are passed along to the launcher job rendering process as a data object (in JSON). These values are then used within session templates. |
+| launcher.templateValues.pod.command | list | `[]` | command for all pods. This is really not something we should expose and will be removed once we have a better option |
 | launcher.useTemplates | bool | `false` | whether to render and use templates in the job launching process |
 | launcherPem | string | `""` | An inline launcher.pem key. If not provided, one will be auto-generated. See README for more details. |
 | launcherPub | bool | `false` | An inline launcher.pub key to pair with launcher.pem. If `false` (the default), we will try to generate a `launcher.pub` from the provided `launcher.pem` |

--- a/charts/rstudio-workbench/files/job.tpl
+++ b/charts/rstudio-workbench/files/job.tpl
@@ -1,6 +1,6 @@
 # Version: 2
 # DO NOT MODIFY the "Version: " key
-# Helm Version: v2
+# Helm Version: v3
 {{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}
 apiVersion: batch/v1
 kind: Job
@@ -113,7 +113,10 @@ spec:
           imagePullPolicy: {{- . | nindent 12 }}
           {{- end }}
           {{- $isShell := false }}
-          {{- if .Job.command }}
+          {{- if $templateData.pod.command }}
+          command: {{- toYaml $templateData.pod.command | nindent 12 }}
+            {{- if .Job.command }}{{- $isShell = true }}{{- end }}
+          {{- else if .Job.command }}
           command: ['/bin/sh']
           {{- $isShell = true }}
           {{- else }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -96,6 +96,8 @@ launcher:
       tolerations: []
       affinity: {}
       nodeSelector: {}
+      # -- command for all pods. This is really not something we should expose and will be removed once we have a better option
+      command: []
     job:
       annotations: {}
       labels: {}


### PR DESCRIPTION
This is important for a support article about customizing the entrypoint script for Workbench sessions. Ultimately, we probably need to expose this sort of behavior as a product feature, similar to Connect's "supervisor script." In the meantime, this should hopefully suffice as a workaround for what was previously done with `job-json-overrides`.

Example usage:

```
helm template ./charts/rstudio-workbench --set launcher.templateValues.pod.command={'/usr/bin/startup.sh'} --set launcher.useTemplates=true | launcher-template | grep command -A 2
          command:
            - /usr/bin/startup.sh
          stdin: false

```