### PR TITLE
add a port to the service for metrics

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.4.1
+version: 0.4.2
 apiVersion: v2
 appVersion: 2023.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,11 @@
+# 0.4.2
+
+- Add a `metrics` port to the `service`, which ensures that the `ServiceMonitor` actually works
+
+# 0.4.1
+
+- Fix issue in templates that prevented numeric service accounts from being used.
+
 # 0.4.0
 
 - BREAKING: change `pod.nodeSelector` to `nodeSelector` for consistency with other charts

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 2023.03.0](https://img.shields.io/badge/AppVersion-2023.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.4.1:
+To install the chart with the release name `my-release` at version 0.4.2:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm install my-release rstudio/rstudio-connect --version=0.4.1
+helm install my-release rstudio/rstudio-connect --version=0.4.2
 ```
 
 ### NOTE

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -13,10 +13,15 @@ spec:
   selector:
     {{- include "rstudio-connect.selectorLabels" . | nindent 4 }}
   ports:
-  - protocol: TCP
+  - name: http
+    protocol: TCP
     port: {{ .Values.service.port }}
     {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
     targetPort: {{ .Values.service.targetPort }}
+  {{- if .Values.prometheusExporter.enabled }}
+  - name: metrics
+    port: 9108
+  {{- end }}
 ---


### PR DESCRIPTION
This follows the pattern for other existing charts, and ensures that the ServiceMonitor we produce is actually functional.