### PR TITLE
Connect release 2023.07.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.3
+version: 0.5.4
 apiVersion: v2
-appVersion: 2023.06.0
+appVersion: 2023.07.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:ubuntu2204-2023.06.0
+      image: rstudio/rstudio-connect:ubuntu2204-2023.07.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,12 @@
+# 0.5.4
+
+- Bump Connect version to 2023.07.0
+
+# 0.5.3
+
+- Added ability to assign labels in service accounts in rstudio-workbench and
+  rstudio-connect charts.
+
 # 0.5.2
 
 - Add support for `pod.command` and `pod.env` for Connect off-host execution sessions


### PR DESCRIPTION
Included a blurb from this PR https://github.com/rstudio/helm/commit/dc60d55fa344c21155f56e4e38a317a7e6b61948 that was missing NEWS patch version bump.