### PR TITLE
add option to set subdir on the PVC volume mount

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.4
+version: 0.5.5
 apiVersion: v2
 appVersion: 2023.07.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.5
+
+- Add support for `sharedStorage.subDir`
+
 # 0.5.4
 
 - Bump Connect version to 2023.07.0

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,6 +1,6 @@
 # 0.5.5
 
-- Add support for `sharedStorage.subDir`
+- Add support for `sharedStorage.subPath`
 
 # 0.5.4
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 2023.07.0](https://img.shields.io/badge/AppVersion-2023.07.0-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 2023.07.0](https://img.shields.io/badge/AppVersion-2023.07.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.4:
+To install the chart with the release name `my-release` at version 0.5.5:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.4
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.5
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if or .Values.sharedStorage.create .Values.sharedStorage.mount }}
           - name: rstudio-connect-data
             mountPath: "{{ .Values.sharedStorage.path }}"
+            {{- if .Values.sharedStorage.subPath }}
+            subPath: "{{ .Values.sharedStorage.subPath }}"
+            {{- end }}
           {{- end }}
           {{ include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | indent 10 }}
       {{- if .Values.pod.volumeMounts }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -32,6 +32,8 @@ sharedStorage:
   selector: {}
   # -- the volumeName passed along to the persistentVolumeClaim. Optional
   volumeName: ""
+  # -- an optional subPath for the volume mount
+  subPath: ""
 
 rbac:
   # -- Whether to create rbac. (also depends on launcher.enabled = true)

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.4
+version: 0.6.5
 apiVersion: v2
 appVersion: 2023.06.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,6 @@
 # 0.6.5
 
-- Add support for `homeStorage.subDir` (and for launcher sessions)
+- Add support for `homeStorage.subPath` (and for launcher sessions)
 
 # 0.6.4
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,11 @@
+# 0.6.5
+
+- Add support for `homeStorage.subDir` (and for launcher sessions)
+
+# 0.6.4
+
+- Add support for serviceAccount labels (`rbac.serviceAccount.labels`)
+
 # 0.6.3
 
 - Fix support for `pod.env` on sessions

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![AppVersion: 2023.06.0](https://img.shields.io/badge/AppVersion-2023.06.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![AppVersion: 2023.06.0](https://img.shields.io/badge/AppVersion-2023.06.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -27,11 +27,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.6.4:
+To install the chart with the release name `my-release` at version 0.6.5:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.4
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.5
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -73,6 +73,7 @@ homeStorage:
   storageClassName: nfs
   requests:
     storage: "500Gi"
+  subPath: "/another"
 
 prometheusExporter:
   securityContext:
@@ -181,9 +182,6 @@ config:
     logging.conf: {}
   serverDcf:
     launcher-mounts:
-      - MountType: KubernetesPersistentVolumeClaim
-        MountPath: /mnt/home
-        ClaimName: rstudio-server-home-storage
       - MountType: KubernetesPersistentVolumeClaim
         MountPath: /shared
         ClaimName: rstudio-shared-data

--- a/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/complex-values.yaml.lock
@@ -149,13 +149,14 @@ data:
   
   
   launcher-mounts: |
-    ClaimName: rstudio-server-home-storage
-    MountPath: /mnt/home
-    MountType: KubernetesPersistentVolumeClaim
-  
     ClaimName: rstudio-shared-data
     MountPath: /shared
     MountType: KubernetesPersistentVolumeClaim
+  
+    ClaimName: release-name-rstudio-workbench-home-storage
+    MountPath: /mnt/home
+    MountType: KubernetesPersistentVolumeClaim
+    SubPath: /another
 ---
 # Source: rstudio-workbench/templates/configmap-general.yaml
 apiVersion: v1
@@ -685,7 +686,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-general: 6e9045d1445aa885f5b80ccb746a0f5bba05fff45baa100c04e509ec48dc8463
+        checksum/config-general: 0641da4c718599b1d351db140258190aae55cd3da97f44f2616140a4dc8980fc
         checksum/config-graphite: 69dd73685cb821ebf5bcec3155d92801f31d72b031a4d681700bded2ff5700c2
         checksum/config-prestart: 88c121990a2291900c2e9e4dda1cecda9614a767ee6c6c05068bcadd0f8e97e9
         checksum/config-secret: cab76a6f9b0e8168201b837f280ddee96f5306cb62d0ac022340cb8c88e40d52
@@ -740,6 +741,7 @@ spec:
             mountPath: "/var/lib/awesome"
           - name: rstudio-home-storage
             mountPath: "/mnt/home"
+            subPath: "/another"
           - name: rstudio-prestart
             mountPath: "/scripts/"
           - name: rstudio-config
@@ -763,11 +765,11 @@ spec:
           - name: rstudio-custom-startup
             mountPath: "/startup/custom"
           - name: rstudio-pam
-            mountPath: "/etc/pam.d/pam-example-2"
-            subPath: "pam-example-2"
-          - name: rstudio-pam
             mountPath: "/etc/pam.d/pam-example"
             subPath: "pam-example"
+          - name: rstudio-pam
+            mountPath: "/etc/pam.d/pam-example-2"
+            subPath: "pam-example-2"
           
           - name: rstudio-job-overrides-old
             mountPath: "/mnt/job-json-overrides"
@@ -1007,6 +1009,7 @@ spec:
         mountPath: "/var/lib/awesome"
       - name: rstudio-home-storage
         mountPath: "/mnt/home"
+        subPath: "/another"
       - name: rstudio-prestart
         mountPath: "/scripts/"
       - name: rstudio-config
@@ -1030,11 +1033,11 @@ spec:
       - name: rstudio-custom-startup
         mountPath: "/startup/custom"
       - name: rstudio-pam
-        mountPath: "/etc/pam.d/pam-example-2"
-        subPath: "pam-example-2"
-      - name: rstudio-pam
         mountPath: "/etc/pam.d/pam-example"
         subPath: "pam-example"
+      - name: rstudio-pam
+        mountPath: "/etc/pam.d/pam-example-2"
+        subPath: "pam-example-2"
       
       - name: rstudio-job-overrides-old
         mountPath: "/mnt/job-json-overrides"

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -99,6 +99,9 @@ containers:
     {{- if or .Values.homeStorage.create .Values.homeStorage.mount }}
     - name: rstudio-home-storage
       mountPath: "{{ .Values.homeStorage.path }}"
+      {{- if .Values.homeStorage.subPath }}
+      subPath: "{{ .Values.homeStorage.subPath }}"
+      {{- end }}
     {{- end }}
     - name: rstudio-prestart
       mountPath: "/scripts/"

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -405,6 +405,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- /* only alter $tmpMounts if claim is not provided by the user */ -}}
         {{- if not $mountAlreadyDefined }}
             {{- $defaultMount := (dict "MountType" "KubernetesPersistentVolumeClaim" "MountPath" $.Values.homeStorage.path "ClaimName" $claimName ) }}
+            {{- if .Values.homeStorage.subPath }}
+              {{- $defaultMount = merge $defaultMount (dict "SubPath" .Values.homeStorage.subPath )}}
+            {{- end }}
             {{- $tmpMounts = append $tmpMounts $defaultMount}}
         {{- end }}
 

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -128,6 +128,8 @@ homeStorage:
   selector: {}
   # -- the volumeName passed along to the persistentVolumeClaim. Optional
   volumeName: ""
+  # -- an optional subPath for the volume mount
+  subPath: ""
 
 image:
   # -- the repository to use for the main pod image


### PR DESCRIPTION
One thing that needs to be vetted: Does Launcher / the job launching process handle this subdir properly (and subdir below it?)... or will we need to pass this sub-directory along somehow?

Also need to:
- bump chart versions
- add NEWS entries