### PR TITLE
switch to using a volume instead of an env var for encryption key

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.13
+version: 0.5.14-rc01
 apiVersion: v2
 appVersion: 2023.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.14-rc01
+
+- Switch PM encryption key to use a volume instead of environment variable
+
 # 0.5.13 
 
 - Change default operating system from `bionic` to `ubuntu2204` (`jammy`)

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.13](https://img.shields.io/badge/Version-0.5.13-informational?style=flat-square) ![AppVersion: 2023.04.0](https://img.shields.io/badge/AppVersion-2023.04.0-informational?style=flat-square)
+![Version: 0.5.14-rc01](https://img.shields.io/badge/Version-0.5.14--rc01-informational?style=flat-square) ![AppVersion: 2023.04.0](https://img.shields.io/badge/AppVersion-2023.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -21,16 +21,20 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.13:
+To install the chart with the release name `my-release` at version 0.5.14-rc01:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.13
+# to install latest release (NOTE: `--version` flag still recommended!)
+helm upgrade --install my-release rstudio/rstudio-pm
+
+# WARNING: to install devel version / release candidate / etc.
+helm upgrade --install --devel my-release rstudio/rstudio-pm --version=0.5.14-rc01
 ```
 
 To explore other chart versions, take a look at:
 ```
-helm search repo rstudio/rstudio-pm -l
+helm search repo --devel rstudio/rstudio-pm -l
 ```
 
 ## Upgrade Guidance

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -80,13 +80,6 @@ spec:
         {{- if .Values.pod.env }}
         {{- toYaml .Values.pod.env | nindent 8 }}
         {{- end }}
-        {{- if .Values.rstudioPMKey }}
-        - name: PACKAGEMANAGER_ENCRYPTION_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "rstudio-pm.fullname" . }}-rstudio-pm-key
-              key: rstudio-pm.key
-        {{- end }}
         {{- if (not .Values.enableSandboxing) }}
         - name: PACKAGEMANAGER_GIT_ALLOWUNSANDBOXEDGITBUILDS
           value: "1"
@@ -116,6 +109,11 @@ spec:
           - name: rstudio-pm-config
             mountPath: "/etc/rstudio-pm/rstudio-pm.gcfg"
             subPath: "rstudio-pm.gcfg"
+          {{- if .Values.rstudioPMKey }}
+          - name: key-volume
+            mountPath: /var/lib/rstudio-pm/rstudio-pm.key
+            subPath: rstudio-pm.key
+          {{- end }}
           {{- if .Values.awsAccessKeyId }}
           - name: aws-creds
             readOnly: true
@@ -173,6 +171,12 @@ spec:
           items:
           - key: rstudio-pm.gcfg
             path: "rstudio-pm.gcfg"
+      {{- if .Values.rstudioPMKey }}
+      - name: key-volume
+        secret:
+          secretName: {{ include "rstudio-pm.fullname" . }}-rstudio-pm-key
+          defaultMode: 0600
+      {{- end }}
       {{- if .Values.awsAccessKeyId }}
       - name: aws-creds
         secret:


### PR DESCRIPTION
Switching to draft because this breaks the permissions on the `rstudio-pm.key` file due to mounting weirdness in Kubernetes.