### PR TITLE
Bump rstudio-connect version to 2023.09.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.5
+version: 0.5.6
 apiVersion: v2
-appVersion: 2023.07.0
+appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:ubuntu2204-2023.07.0
+      image: rstudio/rstudio-connect:ubuntu2204-2023.09.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.6
+
+- Bump Connect version to 2023.09.0
+
 # 0.5.5
 
 - Add support for `sharedStorage.subPath`

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 2023.07.0](https://img.shields.io/badge/AppVersion-2023.07.0-informational?style=flat-square)
+![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.5:
+To install the chart with the release name `my-release` at version 0.5.6:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.5
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.6
 ```
 
 To explore other chart versions, take a look at:


### PR DESCRIPTION
blocked by https://github.com/rstudio/rstudio-docker-products/pull/636
and https://github.com/rstudio/rstudio-docker-products/pull/638