### PR TITLE
fix(connect): ensure tolerations are used in deployment

### DIFF
--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
       priorityClassName:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{/**
          * NOTE: In the case where a service account was in use and
          * then later removed, the behavior of kubernetes is to


### PR DESCRIPTION
This already exists in the [values.yaml](https://github.com/rstudio/helm/blob/main/charts/rstudio-connect/values.yaml#L62C1-L62C12) file but is not currently being used in the deployment