### PR TITLE
Remove CRAN override from Connect chart value

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.6
+version: 0.5.7
 apiVersion: v2
 appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.7
+
+- Remove `CRAN` as a default repository entry in `session.repos.conf`
+
 # 0.5.6
 
 - Bump Connect version to 2023.09.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.6:
+To install the chart with the release name `my-release` at version 0.5.7:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.6
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.7
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -138,10 +138,8 @@ config:
   Python:
     Enabled: true
     Executable: /opt/python/3.6.5/bin/python
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   'RPackageRepository "RSPM"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   Server:
     Address: http://localhost:3939
     DataDir: /var/lib/rstudio-connect

--- a/charts/rstudio-connect/ci/simple-values.yaml
+++ b/charts/rstudio-connect/ci/simple-values.yaml
@@ -14,10 +14,8 @@ config:
   Python:
     Enabled: true
     Executable: /opt/python/3.6.5/bin/python
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   'RPackageRepository "RSPM"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   Server:
     Address: http://localhost:3939
     DataDir: /var/lib/rstudio-connect

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -317,8 +317,6 @@ config:
     Listen: :3939
   Authentication:
     Provider: password
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   Server:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -52,6 +52,7 @@
 - Add `podDisruptionBudget` values
 - Add `topologySpreadConstraints` values
 - Start to utilize the `pod.securityContext` values for pod `securityContext` values
+- Remove `CRAN` as a default repository entry in `session.repos.conf`
 
 # 0.5.32
 

--- a/examples/connect/beta-migration/values-base.yaml
+++ b/examples/connect/beta-migration/values-base.yaml
@@ -4,11 +4,6 @@ config:
 
   # Overrides the package URLs to use source packages which are required if the list
   # of execution environments contains multiple OS distributions.
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/latest
-
-  # Overrides the package URLs to use source packages which are required if the list
-  # of execution environments contains multiple OS distributions.
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/latest
 

--- a/examples/connect/beta-migration/values-pro.yaml
+++ b/examples/connect/beta-migration/values-pro.yaml
@@ -4,11 +4,6 @@ config:
 
   # Overrides the package URLs to use source packages which are required if the list
   # of execution environments contains multiple OS distributions.
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/latest
-
-  # Overrides the package URLs to use source packages which are required if the list
-  # of execution environments contains multiple OS distributions.
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/latest
 

--- a/examples/connect/standalone/values.yaml
+++ b/examples/connect/standalone/values.yaml
@@ -24,9 +24,7 @@ config:
     Enabled: true
     Executable:
       - /opt/python/3.9.5/bin/python
-  'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   'RPackageRepository "RSPM"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+    URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   Server:
     DefaultContentListView: expanded


### PR DESCRIPTION
Motivation: If a user specifies a non-PPM version of `CRAN` (e.g., `https://cran.r-project.org/`)  when deploying to Connect, the current Helm chart overrides it with the PPM version of CRAN, which may not yet have the latest version of a package.

This change (1) removes this constraint (while still having `RSPM` pointing to PPM as a fall back) and (2) mirrors the `workbench` Helm chart (changed [here](https://github.com/rstudio/helm/commit/19b2d2f86c3b836d767114e633895697b36e5b2f#diff-923d1824addd75f58b6022881e5a99553726a4e1c18c97e03bdf025b5f6ab9a5L391))