### PR TITLE
Bump workbench version to 2023.09.0

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.7
+version: 0.6.8
 apiVersion: v2
-appVersion: 2023.06.1
+appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,7 @@
+# 0.6.8
+
+- Bump Workbench version to 2023.09.0
+
 # 0.6.7
 
 - Add native session support for `pip.conf`

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![AppVersion: 2023.06.1](https://img.shields.io/badge/AppVersion-2023.06.1-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![AppVersion: 2023.06.1](https://img.shields.io/badge/AppVersion-2023.06.1-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![AppVersion: 2023.06.1](https://img.shields.io/badge/AppVersion-2023.06.1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -27,11 +27,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.6.7:
+To install the chart with the release name `my-release` at version 0.6.8:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.7
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.8
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-workbench/prestart-workbench.bash
+++ b/charts/rstudio-workbench/prestart-workbench.bash
@@ -24,7 +24,7 @@ main() {
   if [[ -n "$RSW_LOAD_BALANCING" ]]; then
     _logf "Enabling load-balancing by making sure that the /mnt/load-balancer/rstudio/load-balancer file exists"
     mkdir -p /mnt/load-balancer/rstudio/
-    echo -e "balancer=sessions\nwww-host-name=$(hostname -i)" > /mnt/load-balancer/rstudio/load-balancer
+    echo -e "delete-node-on-exit=1\nwww-host-name=$(hostname -i)" > /mnt/load-balancer/rstudio/load-balancer
   fi
 
   _logf 'Preparing dirs'


### PR DESCRIPTION
- bump workbench version
- Reconfigure load-balancing so balancer is not explicitly set to `sessions`, as this is now the default behavior, and to set `delete-node-exit` so that Workbench manages the nodes in the database.