### PR TITLE
Add licensing documentation sections to each product and pull in latest rstudio-library

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.7
+version: 0.5.8
 apiVersion: v2
 appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/sol-eng
 dependencies:
   - name: rstudio-library
-    version: 0.1.26
+    version: 0.1.27
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,9 @@
+# 0.5.8
+
+- Update documentation to provide guidance on using license files with `Secrets`.
+- Bump rstudio-library to `0.1.27`
+  - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
+
 # 0.5.7
 
 - Add support for setting `tolerations` for Connect

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,6 +1,6 @@
 # 0.5.8
 
-- Update documentation to provide guidance on using license files with `Secrets`.
+- Add licensing section to the README to provide guidance on using a license file, key or server.
 - Bump rstudio-library to `0.1.27`
   - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,39 +62,6 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret using YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: connect-license
-    secretKey: connect.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/connect.lic`.
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
+![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.7:
+To install the chart with the release name `my-release` at version 0.5.8:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.7
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.8
 ```
 
 To explore other chart versions, take a look at:
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,39 +62,6 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/package-manager.lic`.
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,6 +62,39 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/package-manager.lic`.
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,6 +62,39 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: connect-license
+    secretKey: connect.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/connect.lic`.
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.14
+version: 0.5.15
 apiVersion: v2
 appVersion: 2023.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     url: https://github.com/rstudio/helm
 dependencies:
   - name: rstudio-library
-    version: 0.1.26
+    version: 0.1.27
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,6 +1,13 @@
+# 0.5.15
+
+- Update documentation to provide guidance on using license files with `Secrets`.
+- Bump rstudio-library to `0.1.27`
+  - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
+
 # 0.5.14
 
 - Update default Posit Package Manager version to 2023.08.0-16
+
 # 0.5.13 
 
 - Change default operating system from `bionic` to `ubuntu2204` (`jammy`)

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,6 +1,6 @@
 # 0.5.15
 
-- Update documentation to provide guidance on using license files with `Secrets`.
+- Add licensing section to the README to provide guidance on using a license file, key or server.
 - Bump rstudio-library to `0.1.27`
   - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -54,6 +54,39 @@ This chart requires the following in order to function:
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
   * Alternatively, S3 storage can be used. See the next section for details.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic`.
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,7 +53,40 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the next section for details.
+  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/package-manager.lic`.
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,40 +53,7 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/package-manager.lic`.
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+  * Alternatively, S3 storage can be used. See the next section for details.
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.14](https://img.shields.io/badge/Version-0.5.14-informational?style=flat-square) ![AppVersion: 2023.08.0](https://img.shields.io/badge/AppVersion-2023.08.0-informational?style=flat-square)
+![Version: 0.5.15](https://img.shields.io/badge/Version-0.5.15-informational?style=flat-square) ![AppVersion: 2023.08.0](https://img.shields.io/badge/AppVersion-2023.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.14:
+To install the chart with the release name `my-release` at version 0.5.15:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.14
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.15
 ```
 
 To explore other chart versions, take a look at:
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -54,39 +54,6 @@ This chart requires the following in order to function:
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
   * Alternatively, S3 storage can be used. See the next section for details.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic`.
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.8
+version: 0.6.9
 apiVersion: v2
 appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/sol-eng
 dependencies:
   - name: rstudio-library
-    version: 0.1.26
+    version: 0.1.27
     repository: file://../rstudio-library
 annotations:
   artifacthub.io/images: |

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,6 @@
 # 0.6.10
 
-- Update documentation to provide guidance on using license files with `Secrets`.
+- Add licensing section to the README to provide guidance on using a license file, key or server.
 - Bump rstudio-library to `0.1.27`
   - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,9 @@
+# 0.6.9
+
+- Update documentation to provide guidance on using license files with `Secrets`.
+- Bump rstudio-library to `0.1.27`
+  - Fix an issue with `mountPath` and `subPath` when `license.file.mountSubPath` is `true`
+
 # 0.6.8
 
 - Bump Workbench version to 2023.09.0

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,6 +88,39 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: workbench-license
+    secretKey: workbench.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/workbench.lic`.
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,39 +88,6 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret using YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: workbench-license
-    secretKey: workbench.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=license_files/workbench.lic`.
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 


### PR DESCRIPTION
This PR adds a licensing section for each product in the README. This is especially important as we start to provide license files to all of our customers, as customers are often confused on how to use these files with our charts.

Also brings in `rstudio-library` `0.1.27` which fixes a `subPath` issue related to licensing.