### PR TITLE
Add licensing section to READMEs

### DIFF
--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -108,48 +108,20 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-  {{ if eq .Name "rstudio-connect" -}}
-`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
-  {{ else if eq .Name "rstudio-pm" -}}
-`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
-  {{ else if eq .Name "rstudio-workbench" -}}
-`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
-  {{ else -}}
-`kubectl create secret generic license --from-file=licenses/license.lic`
-  {{- end }}
+`kubectl create secret generic {{ .Name }}-license --from-file=licenses/{{ .Name }}.lic`
 
 Second, specify the following values:
 
 ```yaml
 license:
   file:
-    {{- if eq .Name "rstudio-connect" }}
-    secret: connect-license
-    secretKey: connect.lic
-    {{- else if eq .Name "rstudio-pm" }}
-    secret: package-manager-license
-    secretKey: package-manager.lic
-    {{- else if eq .Name "rstudio-workbench" }}
-    secret: workbench-license
-    secretKey: workbench.lic
-    {{- else }}
-    secret: license
-    secretKey: license.lic
-  {{ end }}
+    secret: {{ .Name }}-license
+    secretKey: {{ .Name }}.lic
 ```
-
 
 Alternatively, license files can be set during `helm install` with the following argument:
 
-  {{ if eq .Name "rstudio-connect" -}}
-`--set-file license.file.contents=licenses/connect.lic`
-  {{ else if eq .Name "rstudio-pm" -}}
-`--set-file license.file.contents=licenses/package-manager.lic`
-  {{ else if eq .Name "rstudio-workbench" -}}
-`--set-file license.file.contents=licenses/workbench.lic`
-  {{ else -}}
-`--set-file license.file.contents=licenses/license.lic`
-  {{- end }}
+`--set-file license.file.contents=licenses/{{ .Name }}.lic`
 
 ### License Key
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -106,7 +106,8 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command: 
+First, create the secret declaratively with YAML or imperatively using the following command:
+
   {{- if eq .Name "rstudio-connect" -}}
 `kubectl create secret generic connect-license --from-file=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}
@@ -119,28 +120,35 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 Second, specify the following values:
 
-```yaml
+
   {{- if eq .Name "rstudio-connect" -}}
+```yaml
 license:
   file:
     secret: connect-license
     secretKey: connect.lic
+```
   {{- else if eq .Name "rstudio-pm" -}}
+```yaml
 license:
   file:
     secret: package-manager-license
     secretKey: package-manager.lic
+```
   {{- else if eq .Name "rstudio-workbench" -}}
+```yaml
 license:
   file:
     secret: workbench-license
     secretKey: workbench.lic
+```
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
-```
 
-Alternatively, license files can be set during `helm install` with the following argument: 
+
+Alternatively, license files can be set during `helm install` with the following argument:
+
   {{- if eq .Name "rstudio-connect" -}}
 `--set-file license.file.contents=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -115,7 +115,7 @@ First, create the secret declaratively with YAML or imperatively using the follo
   {{ else if eq .Name "rstudio-workbench" -}}
 `kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
   {{ else -}}
-{{ template "chart.header" . }}
+`kubectl create secret generic license --from-file=licenses/license.lic`
   {{- end }}
 
 Second, specify the following values:
@@ -123,17 +123,18 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-  {{ if eq .Name "rstudio-connect" }}
+    {{- if eq .Name "rstudio-connect" }}
     secret: connect-license
     secretKey: connect.lic
-  {{ else if eq .Name "rstudio-pm" }}
+    {{- else if eq .Name "rstudio-pm" }}
     secret: package-manager-license
     secretKey: package-manager.lic
-  {{ else if eq .Name "rstudio-workbench" }}
+    {{- else if eq .Name "rstudio-workbench" }}
     secret: workbench-license
     secretKey: workbench.lic
-  {{ else }}
-{{ template "chart.header" . }}
+    {{- else }}
+    secret: license
+    secretKey: license.lic
   {{ end }}
 ```
 
@@ -147,7 +148,7 @@ Alternatively, license files can be set during `helm install` with the following
   {{ else if eq .Name "rstudio-workbench" -}}
 `--set-file license.file.contents=licenses/workbench.lic`
   {{ else -}}
-{{ template "chart.header" . }}
+`--set-file license.file.contents=licenses/license.lic`
   {{- end }}
 
 ### License Key

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -110,11 +110,11 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 ```bash
   {{- if eq .Name "rstudio-connect" -}}
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
+  kubectl create secret generic connect-license --from-file=licenses/connect.lic
   {{- else if eq .Name "rstudio-pm" -}}
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+  kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
   {{- else if eq .Name "rstudio-workbench" -}}
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+  kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
@@ -143,11 +143,11 @@ Alternatively, license files can be set directly in your values file or during `
 
 ```bash
   {{- if eq .Name "rstudio-connect" -}}
---set-file license.file.contents=licenses/connect.lic
+  --set-file license.file.contents=licenses/connect.lic
   {{- else if eq .Name "rstudio-pm" -}}
---set-file license.file.contents=licenses/package-manager.lic
+  --set-file license.file.contents=licenses/package-manager.lic
   {{- else if eq .Name "rstudio-workbench" -}}
---set-file license.file.contents=licenses/workbench.lic
+  --set-file license.file.contents=licenses/workbench.lic
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -123,18 +123,18 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-  {{ if eq .Name "rstudio-connect" -}}
+  {{ if eq .Name "rstudio-connect" }}
     secret: connect-license
     secretKey: connect.lic
-  {{ else if eq .Name "rstudio-pm" -}}
+  {{ else if eq .Name "rstudio-pm" }}
     secret: package-manager-license
     secretKey: package-manager.lic
-  {{ else if eq .Name "rstudio-workbench" -}}
+  {{ else if eq .Name "rstudio-workbench" }}
     secret: workbench-license
     secretKey: workbench.lic
-  {{ else -}}
+  {{ else }}
 {{ template "chart.header" . }}
-  {{- end }}
+  {{ end }}
 ```
 
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -106,7 +106,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:
+First, create the secret declaratively with YAML or imperatively using the following command: 
   {{- if eq .Name "rstudio-connect" -}}
 `kubectl create secret generic connect-license --from-file=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}
@@ -120,15 +120,19 @@ First, create the secret declaratively with YAML or imperatively using the follo
 Second, specify the following values:
 
 ```yaml
+  {{- if eq .Name "rstudio-connect" -}}
 license:
   file:
-  {{- if eq .Name "rstudio-connect" -}}
     secret: connect-license
     secretKey: connect.lic
   {{- else if eq .Name "rstudio-pm" -}}
+license:
+  file:
     secret: package-manager-license
     secretKey: package-manager.lic
   {{- else if eq .Name "rstudio-workbench" -}}
+license:
+  file:
     secret: workbench-license
     secretKey: workbench.lic
   {{- else -}}
@@ -136,7 +140,7 @@ license:
   {{- end }}
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:
+Alternatively, license files can be set during `helm install` with the following argument: 
   {{- if eq .Name "rstudio-connect" -}}
 `--set-file license.file.contents=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}
@@ -149,11 +153,11 @@ Alternatively, license files can be set directly in your values file or during `
 
 ### License Key
 
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+Set a license key directly in your values file (`license.key`) or during `helm install` with the argument `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
 
 ### License Server
 
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
 {{- end }}
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -108,17 +108,21 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-```bash
   {{- if eq .Name "rstudio-connect" -}}
-  kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```
   {{- else if eq .Name "rstudio-pm" -}}
-  kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
   {{- else if eq .Name "rstudio-workbench" -}}
-  kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
-```
 
 Second, specify the following values:
 
@@ -141,17 +145,21 @@ license:
 
 Alternatively, license files can be set directly in your values file or during `helm install` with:
 
-```bash
   {{- if eq .Name "rstudio-connect" -}}
-  --set-file license.file.contents=licenses/connect.lic
+```bash
+--set-file license.file.contents=licenses/connect.lic
+```
   {{- else if eq .Name "rstudio-pm" -}}
-  --set-file license.file.contents=licenses/package-manager.lic
+```bash
+--set-file license.file.contents=licenses/package-manager.lic
+```
   {{- else if eq .Name "rstudio-workbench" -}}
-  --set-file license.file.contents=licenses/workbench.lic
+```bash
+--set-file license.file.contents=licenses/workbench.lic
+```
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
-```
 
 ### License Key
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -108,13 +108,13 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-  {{- if eq .Name "rstudio-connect" -}}
+  {{ if eq .Name "rstudio-connect" -}}
 `kubectl create secret generic connect-license --from-file=licenses/connect.lic`
-  {{- else if eq .Name "rstudio-pm" -}}
+  {{ else if eq .Name "rstudio-pm" -}}
 `kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
-  {{- else if eq .Name "rstudio-workbench" -}}
+  {{ else if eq .Name "rstudio-workbench" -}}
 `kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
-  {{- else -}}
+  {{ else -}}
 {{ template "chart.header" . }}
   {{- end }}
 
@@ -123,17 +123,16 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-
-  {{- if eq .Name "rstudio-connect" -}}
+  {{ if eq .Name "rstudio-connect" -}}
     secret: connect-license
     secretKey: connect.lic
-  {{- else if eq .Name "rstudio-pm" -}}
+  {{ else if eq .Name "rstudio-pm" -}}
     secret: package-manager-license
     secretKey: package-manager.lic
-  {{- else if eq .Name "rstudio-workbench" -}}
+  {{ else if eq .Name "rstudio-workbench" -}}
     secret: workbench-license
     secretKey: workbench.lic
-  {{- else -}}
+  {{ else -}}
 {{ template "chart.header" . }}
   {{- end }}
 ```
@@ -141,13 +140,13 @@ license:
 
 Alternatively, license files can be set during `helm install` with the following argument:
 
-  {{- if eq .Name "rstudio-connect" -}}
+  {{ if eq .Name "rstudio-connect" -}}
 `--set-file license.file.contents=licenses/connect.lic`
-  {{- else if eq .Name "rstudio-pm" -}}
+  {{ else if eq .Name "rstudio-pm" -}}
 `--set-file license.file.contents=licenses/package-manager.lic`
-  {{- else if eq .Name "rstudio-workbench" -}}
+  {{ else if eq .Name "rstudio-workbench" -}}
 `--set-file license.file.contents=licenses/workbench.lic`
-  {{- else -}}
+  {{ else -}}
 {{ template "chart.header" . }}
   {{- end }}
 

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -120,31 +120,23 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 Second, specify the following values:
 
+```yaml
+license:
+  file:
 
   {{- if eq .Name "rstudio-connect" -}}
-```yaml
-license:
-  file:
     secret: connect-license
     secretKey: connect.lic
-```
   {{- else if eq .Name "rstudio-pm" -}}
-```yaml
-license:
-  file:
     secret: package-manager-license
     secretKey: package-manager.lic
-```
   {{- else if eq .Name "rstudio-workbench" -}}
-```yaml
-license:
-  file:
     secret: workbench-license
     secretKey: workbench.lic
-```
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
+```
 
 
 Alternatively, license files can be set during `helm install` with the following argument:

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -96,6 +96,73 @@ helm search repo {{ if $isDev }}--devel {{ end }}rstudio/{{ template "chart.name
 
 {{- end }}
 
+{{- define "rstudio.licensing" }}
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command:
+
+```bash
+  {{- if eq .Name "rstudio-connect" -}}
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+  {{- else if eq .Name "rstudio-pm" -}}
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+  {{- else if eq .Name "rstudio-workbench" -}}
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+  {{- else -}}
+{{ template "chart.header" . }}
+  {{- end }}
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+  {{- if eq .Name "rstudio-connect" -}}
+    secret: connect-license
+    secretKey: connect.lic
+  {{- else if eq .Name "rstudio-pm" -}}
+    secret: package-manager-license
+    secretKey: package-manager.lic
+  {{- else if eq .Name "rstudio-workbench" -}}
+    secret: workbench-license
+    secretKey: workbench.lic
+  {{- else -}}
+{{ template "chart.header" . }}
+  {{- end }}
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with:
+
+```bash
+  {{- if eq .Name "rstudio-connect" -}}
+--set-file license.file.contents=licenses/connect.lic
+  {{- else if eq .Name "rstudio-pm" -}}
+--set-file license.file.contents=licenses/package-manager.lic
+  {{- else if eq .Name "rstudio-workbench" -}}
+--set-file license.file.contents=licenses/workbench.lic
+  {{- else -}}
+{{ template "chart.header" . }}
+  {{- end }}
+```
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+
+{{- end }}
+
 {{ define "rstudio.examples1" -}}
   {{ . }}
   {{ kindOf . }}

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -107,19 +107,12 @@ This chart supports activating the product using a license file, license key, or
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
-
   {{- if eq .Name "rstudio-connect" -}}
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
+`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
+`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
   {{- else if eq .Name "rstudio-workbench" -}}
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
+`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}
@@ -143,20 +136,13 @@ license:
   {{- end }}
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:
-
+Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:
   {{- if eq .Name "rstudio-connect" -}}
-```bash
---set-file license.file.contents=licenses/connect.lic
-```
+`--set-file license.file.contents=licenses/connect.lic`
   {{- else if eq .Name "rstudio-pm" -}}
-```bash
---set-file license.file.contents=licenses/package-manager.lic
-```
+`--set-file license.file.contents=licenses/package-manager.lic`
   {{- else if eq .Name "rstudio-workbench" -}}
-```bash
---set-file license.file.contents=licenses/workbench.lic
-```
+`--set-file license.file.contents=licenses/workbench.lic`
   {{- else -}}
 {{ template "chart.header" . }}
   {{- end }}

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.8
+version: 0.5.9
 apiVersion: v2
 appVersion: 2023.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.9
+
+- Add licensing section to the README to provide guidance on using a license file, license key or license server.
+
 # 0.5.8
 
 - Bump rstudio-library to `0.1.27`

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![AppVersion: 2023.10.0](https://img.shields.io/badge/AppVersion-2023.10.0-informational?style=flat-square)
+![Version: 0.5.10](https://img.shields.io/badge/Version-0.5.10-informational?style=flat-square) ![AppVersion: 2023.10.0](https://img.shields.io/badge/AppVersion-2023.10.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.9:
+To install the chart with the release name `my-release` at version 0.5.10:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.9
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.10
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -71,9 +71,8 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:
-
-```bashkubectl create secret generic connect-license --from-file=licenses/connect.lic
+First, create the secret declaratively with YAML or imperatively using the following command:```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
 ```
 
 Second, specify the following values:
@@ -84,9 +83,8 @@ license:
     secretKey: connect.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:
-
-```bash--set-file license.file.contents=licenses/connect.lic
+Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
+--set-file license.file.contents=licenses/connect.lic
 ```
 
 ### License Key

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,6 +62,39 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: connect-license
+    secretKey: connect.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -73,9 +73,8 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
 
-Second, specify the following values:
-
-```yamllicense:
+Second, specify the following values:```yaml
+license:
   file:
     secret: connect-license
     secretKey: connect.lic

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -75,21 +75,21 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 Second, specify the following values:
 
-```yaml
-license:
-  file:secret: connect-license
+```yamllicense:
+  file:
+    secret: connect-license
     secretKey: connect.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/connect.lic`
+Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/connect.lic`
 
 ### License Key
 
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+Set a license key directly in your values file (`license.key`) or during `helm install` with the argument `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
 
 ### License Server
 
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -71,22 +71,23 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command:
 
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```bashkubectl create secret generic connect-license --from-file=licenses/connect.lic
 ```
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:
-    secret: connect-license
+  file:secret: connect-license
     secretKey: connect.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
+Alternatively, license files can be set directly in your values file or during `helm install` with:
+
+```bash--set-file license.file.contents=licenses/connect.lic
+```
 
 ### License Key
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -81,10 +81,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
- 
     secret: connect-license
     secretKey: connect.lic
- 
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -73,22 +73,20 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-  `kubectl create secret generic connect-license --from-file=licenses/connect.lic`
- 
+`kubectl create secret generic rstudio-connect-license --from-file=licenses/rstudio-connect.lic`
 
 Second, specify the following values:
 
 ```yaml
 license:
   file:
-    secret: connect-license
-    secretKey: connect.lic
+    secret: rstudio-connect-license
+    secretKey: rstudio-connect.lic
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:
 
-  `--set-file license.file.contents=licenses/connect.lic`
- 
+`--set-file license.file.contents=licenses/rstudio-connect.lic`
 
 ### License Key
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
+![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![AppVersion: 2023.09.0](https://img.shields.io/badge/AppVersion-2023.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,39 +62,6 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: connect-license
-    secretKey: connect.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -71,17 +71,25 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
+First, create the secret declaratively with YAML or imperatively using the following command:
+
+  `kubectl create secret generic connect-license --from-file=licenses/connect.lic`
+ 
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:secret: connect-license
+  file:
+  secret: connect-license
     secretKey: connect.lic
+ 
 ```
 
-Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/connect.lic`
+Alternatively, license files can be set during `helm install` with the following argument:
+
+  `--set-file license.file.contents=licenses/connect.lic`
+ 
 
 ### License Key
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -73,10 +73,11 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
 
-Second, specify the following values:```yaml
+Second, specify the following values:
+
+```yaml
 license:
-  file:
-    secret: connect-license
+  file:secret: connect-license
     secretKey: connect.lic
 ```
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -71,9 +71,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
+First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic connect-license --from-file=licenses/connect.lic`
 
 Second, specify the following values:
 
@@ -83,9 +81,7 @@ license:
     secretKey: connect.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
---set-file license.file.contents=licenses/connect.lic
-```
+Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/connect.lic`
 
 ### License Key
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -81,7 +81,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-  secret: connect-license
+ 
+    secret: connect-license
     secretKey: connect.lic
  
 ```

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -71,7 +71,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret using YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
 
 ```bash
 kubectl create secret generic connect-license --from-file=licenses/connect.lic

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.8:
+To install the chart with the release name `my-release` at version 0.5.9:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.8
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.9
 ```
 
 To explore other chart versions, take a look at:
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,6 +62,39 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: connect-license
+    secretKey: connect.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -54,7 +54,7 @@ helm search repo rstudio/rstudio-connect -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -62,39 +62,6 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: connect-license
-    secretKey: connect.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -33,38 +33,7 @@ This chart requires the following in order to function:
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
 
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic connect-license --from-file=licenses/connect.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: connect-license
-    secretKey: connect.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+{{ template "rstudio.licensing" . }}
 
 ## General Principles
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -24,7 +24,7 @@
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for Connect.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -32,6 +32,39 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/connect.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic connect-license --from-file=licenses/connect.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: connect-license
+    secretKey: connect.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/connect.lic` (replace `licenses/connect.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.15
+version: 0.5.16
 apiVersion: v2
 appVersion: 2023.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.16
+
+- Add licensing section to the README to provide guidance on using a license file, license key or license server.
+
 # 0.5.15
 
 - Bump rstudio-library to `0.1.27`
@@ -6,6 +10,7 @@
 # 0.5.14
 
 - Update default Posit Package Manager version to 2023.08.0-16
+
 # 0.5.13 
 
 - Change default operating system from `bionic` to `ubuntu2204` (`jammy`)

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -73,10 +73,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
- 
     secret: package-manager-license
     secretKey: package-manager.lic
- 
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -65,22 +65,20 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-  `kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
- 
+`kubectl create secret generic rstudio-pm-license --from-file=licenses/rstudio-pm.lic`
 
 Second, specify the following values:
 
 ```yaml
 license:
   file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
+    secret: rstudio-pm-license
+    secretKey: rstudio-pm.lic
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:
 
-  `--set-file license.file.contents=licenses/package-manager.lic`
- 
+`--set-file license.file.contents=licenses/rstudio-pm.lic`
 
 ### License Key
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.15](https://img.shields.io/badge/Version-0.5.15-informational?style=flat-square) ![AppVersion: 2023.08.0](https://img.shields.io/badge/AppVersion-2023.08.0-informational?style=flat-square)
+![Version: 0.5.16](https://img.shields.io/badge/Version-0.5.16-informational?style=flat-square) ![AppVersion: 2023.08.0](https://img.shields.io/badge/AppVersion-2023.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,40 +53,7 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+  * Alternatively, S3 storage can be used. See the next section for details.
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -67,21 +67,21 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 Second, specify the following values:
 
-```yaml
-license:
-  file:secret: package-manager-license
+```yamllicense:
+  file:
+    secret: package-manager-license
     secretKey: package-manager.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/package-manager.lic`
+Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/package-manager.lic`
 
 ### License Key
 
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+Set a license key directly in your values file (`license.key`) or during `helm install` with the argument `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
 
 ### License Server
 
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -73,7 +73,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-  secret: package-manager-license
+ 
+    secret: package-manager-license
     secretKey: package-manager.lic
  
 ```

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -63,22 +63,23 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command:
 
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```bashkubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
 ```
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:
-    secret: package-manager-license
+  file:secret: package-manager-license
     secretKey: package-manager.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
+Alternatively, license files can be set directly in your values file or during `helm install` with:
+
+```bash--set-file license.file.contents=licenses/package-manager.lic
+```
 
 ### License Key
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -63,17 +63,25 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
+First, create the secret declaratively with YAML or imperatively using the following command:
+
+  `kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
+ 
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:secret: package-manager-license
+  file:
+  secret: package-manager-license
     secretKey: package-manager.lic
+ 
 ```
 
-Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/package-manager.lic`
+Alternatively, license files can be set during `helm install` with the following argument:
+
+  `--set-file license.file.contents=licenses/package-manager.lic`
+ 
 
 ### License Key
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -63,9 +63,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
+First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
 
 Second, specify the following values:
 
@@ -75,9 +73,7 @@ license:
     secretKey: package-manager.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
---set-file license.file.contents=licenses/package-manager.lic
-```
+Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/package-manager.lic`
 
 ### License Key
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.15:
+To install the chart with the release name `my-release` at version 0.5.16:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.15
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.16
 ```
 
 To explore other chart versions, take a look at:
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,7 +53,40 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the next section for details.
+  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -63,7 +63,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret using YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
 
 ```bash
 kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,40 +53,7 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+  * Alternatively, S3 storage can be used. See the next section for details.
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -63,9 +63,8 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:
-
-```bashkubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+First, create the secret declaratively with YAML or imperatively using the following command:```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
 ```
 
 Second, specify the following values:
@@ -76,9 +75,8 @@ license:
     secretKey: package-manager.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:
-
-```bash--set-file license.file.contents=licenses/package-manager.lic
+Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
+--set-file license.file.contents=licenses/package-manager.lic
 ```
 
 ### License Key

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -65,10 +65,11 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
 
-Second, specify the following values:```yaml
+Second, specify the following values:
+
+```yaml
 license:
-  file:
-    secret: package-manager-license
+  file:secret: package-manager-license
     secretKey: package-manager.lic
 ```
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # RStudio Package Manager
 
-![Version: 0.5.16](https://img.shields.io/badge/Version-0.5.16-informational?style=flat-square) ![AppVersion: 2023.08.4](https://img.shields.io/badge/AppVersion-2023.08.4-informational?style=flat-square)
+![Version: 0.5.17](https://img.shields.io/badge/Version-0.5.17-informational?style=flat-square) ![AppVersion: 2023.08.4](https://img.shields.io/badge/AppVersion-2023.08.4-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.16:
+To install the chart with the release name `my-release` at version 0.5.17:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.16
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.17
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -45,7 +45,7 @@ helm search repo rstudio/rstudio-pm -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume.
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box.
@@ -53,7 +53,40 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the next section for details.
+  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -65,9 +65,8 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic`
 
-Second, specify the following values:
-
-```yamllicense:
+Second, specify the following values:```yaml
+license:
   file:
     secret: package-manager-license
     secretKey: package-manager.lic

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -20,7 +20,7 @@
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the data directory for RSPM.
   * If `sharedStorage.create` is set, a PVC that relies on the default storage class will be created to generate the PersistentVolume. 
     Most Kubernetes environments do not have a default storage class that you can use with `ReadWriteMany` access mode out-of-the-box. 
@@ -28,7 +28,40 @@ This chart requires the following in order to function:
     mount them into the container by specifying the `pod.volumes` and `pod.volumeMounts` parameters, or by specifying your `PersistentVolumeClaim` using `sharedStorage.name` and `sharedStorage.mount`.
   * If you cannot use a `PersistentVolume` to properly mount your data directory, you'll need to mount your data in the container
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
-  * Alternatively, S3 storage can be used. See the next section for details.
+  * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: package-manager-license
+    secretKey: package-manager.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## S3 Configuration
 

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -30,38 +30,7 @@ This chart requires the following in order to function:
     by using a regular [Kubernetes Volume](https://kubernetes.io/docs/concepts/storage/volumes), specified in `pod.volumes` and `pod.volumeMounts`.
   * Alternatively, S3 storage can be used. See the [S3 Configuration](#s3-configuration) section for details.
 
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/package-manager.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic package-manager-license --from-file=licenses/package-manager.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: package-manager-license
-    secretKey: package-manager.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/package-manager.lic` (replace `licenses/package-manager.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+{{ template "rstudio.licensing" . }}
 
 ## S3 Configuration
 

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.10
+version: 0.6.11
 apiVersion: v2
 appVersion: 2023.09.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,7 @@
+# 0.6.11
+
+- Add licensing section to the README to provide guidance on using a license file, license key or license server.
+
 # 0.6.10
 
 - Bump rstudio-library to `0.1.27`

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -97,9 +97,8 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:
-
-```bashkubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+First, create the secret declaratively with YAML or imperatively using the following command:```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
 ```
 
 Second, specify the following values:
@@ -110,9 +109,8 @@ license:
     secretKey: workbench.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:
-
-```bash--set-file license.file.contents=licenses/workbench.lic
+Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
+--set-file license.file.contents=licenses/workbench.lic
 ```
 
 ### License Key

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -107,10 +107,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
- 
     secret: workbench-license
     secretKey: workbench.lic
- 
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -97,17 +97,25 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
+First, create the secret declaratively with YAML or imperatively using the following command:
+
+  `kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
+ 
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:secret: workbench-license
+  file:
+  secret: workbench-license
     secretKey: workbench.lic
+ 
 ```
 
-Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/workbench.lic`
+Alternatively, license files can be set during `helm install` with the following argument:
+
+  `--set-file license.file.contents=licenses/workbench.lic`
+ 
 
 ### License Key
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,6 +88,39 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: workbench-license
+    secretKey: workbench.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -27,11 +27,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.6.10:
+To install the chart with the release name `my-release` at version 0.6.11:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.10
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.6.11
 ```
 
 To explore other chart versions, take a look at:
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,6 +88,39 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret using YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: workbench-license
+    secretKey: workbench.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -97,9 +97,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command:```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
+First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
 
 Second, specify the following values:
 
@@ -109,9 +107,7 @@ license:
     secretKey: workbench.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with:```bash
---set-file license.file.contents=licenses/workbench.lic
-```
+Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/workbench.lic`
 
 ### License Key
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -97,22 +97,23 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command:
 
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```bashkubectl create secret generic workbench-license --from-file=licenses/workbench.lic
 ```
 
 Second, specify the following values:
 
 ```yaml
 license:
-  file:
-    secret: workbench-license
+  file:secret: workbench-license
     secretKey: workbench.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
+Alternatively, license files can be set directly in your values file or during `helm install` with:
+
+```bash--set-file license.file.contents=licenses/workbench.lic
+```
 
 ### License Key
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -107,7 +107,8 @@ Second, specify the following values:
 ```yaml
 license:
   file:
-  secret: workbench-license
+ 
+    secret: workbench-license
     secretKey: workbench.lic
  
 ```

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,39 +88,6 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: workbench-license
-    secretKey: workbench.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -101,21 +101,21 @@ First, create the secret declaratively with YAML or imperatively using the follo
 
 Second, specify the following values:
 
-```yaml
-license:
-  file:secret: workbench-license
+```yamllicense:
+  file:
+    secret: workbench-license
     secretKey: workbench.lic
 ```
 
-Alternatively, license files can be set directly in your values file or during `helm install` with the following arguement:`--set-file license.file.contents=licenses/workbench.lic`
+Alternatively, license files can be set during `helm install` with the following argument:`--set-file license.file.contents=licenses/workbench.lic`
 
 ### License Key
 
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+Set a license key directly in your values file (`license.key`) or during `helm install` with the argument `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
 
 ### License Server
 
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -99,10 +99,11 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
 
-Second, specify the following values:```yaml
+Second, specify the following values:
+
+```yaml
 license:
-  file:
-    secret: workbench-license
+  file:secret: workbench-license
     secretKey: workbench.lic
 ```
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -97,7 +97,7 @@ This chart supports activating the product using a license file, license key, or
 
 We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
 
-First, create the secret using YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
 
 ```bash
 kubectl create secret generic workbench-license --from-file=licenses/workbench.lic

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -99,9 +99,8 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:`kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
 
-Second, specify the following values:
-
-```yamllicense:
+Second, specify the following values:```yaml
+license:
   file:
     secret: workbench-license
     secretKey: workbench.lic

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # RStudio Workbench
 
-![Version: 0.6.10](https://img.shields.io/badge/Version-0.6.10-informational?style=flat-square) ![AppVersion: 2023.09.1](https://img.shields.io/badge/AppVersion-2023.09.1-informational?style=flat-square)
+![Version: 0.6.11](https://img.shields.io/badge/Version-0.6.11-informational?style=flat-square) ![AppVersion: 2023.09.1](https://img.shields.io/badge/AppVersion-2023.09.1-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -43,7 +43,7 @@ helm search repo rstudio/rstudio-workbench -l
 
 This chart requires the following in order to function:
 
-* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
+* A license key, license file, or address of a running license server. See the `license` configuration below.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -88,39 +88,6 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
-
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: workbench-license
-    secretKey: workbench.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -99,22 +99,20 @@ We recommend storing a license file as a `Secret` and setting the `license.file.
 
 First, create the secret declaratively with YAML or imperatively using the following command:
 
-  `kubectl create secret generic workbench-license --from-file=licenses/workbench.lic`
- 
+`kubectl create secret generic rstudio-workbench-license --from-file=licenses/rstudio-workbench.lic`
 
 Second, specify the following values:
 
 ```yaml
 license:
   file:
-    secret: workbench-license
-    secretKey: workbench.lic
+    secret: rstudio-workbench-license
+    secretKey: rstudio-workbench.lic
 ```
 
 Alternatively, license files can be set during `helm install` with the following argument:
 
-  `--set-file license.file.contents=licenses/workbench.lic`
- 
+`--set-file license.file.contents=licenses/rstudio-workbench.lic`
 
 ### License Key
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -64,38 +64,7 @@ In addition to the above required configuration, we recommend setting the follow
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
 
-## Licensing
-
-This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
-
-### License File
-
-We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
-
-First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
-
-```bash
-kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
-```
-
-Second, specify the following values:
-
-```yaml
-license:
-  file:
-    secret: workbench-license
-    secretKey: workbench.lic
-```
-
-Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
-
-### License Key
-
-Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
-
-### License Server
-
-Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
+{{ template "rstudio.licensing" . }}
 
 ## General Principles
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -18,7 +18,7 @@
 
 This chart requires the following in order to function:
 
-* A license key, license file, or address of a running license server. See the `license` configuration below.
+* A license file, license key, or address of a running license server. See the [Licensing](#licensing) section below for more details.
 * A Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that contains the
   home directory for users.
   * If `homeStorage.create` is set, a PVC that relies on the default storage class will be created to generate the
@@ -63,6 +63,39 @@ In addition to the above required configuration, we recommend setting the follow
   by simply running the `uuid` command.
 * Some use-cases may require special PAM profiles to run. By default, no PAM profiles other than the basic `auth` profile will be used to authenticate users.
   If this is not sufficient then you will need to add your PAM profiles into the container using a volume and volumeMount.
+
+## Licensing
+
+This chart supports activating the product using a license file, license key, or license server. In the case of a license file or key, we recommend against placing it in your values file directly.
+
+### License File
+
+We recommend storing a license file as a `Secret` and setting the `license.file.secret` and `license.file.secretKey` values accordingly.
+
+First, create the secret declaratively with YAML or imperatively using the following command (replace `licenses/workbench.lic` with the path and name of your license file):
+
+```bash
+kubectl create secret generic workbench-license --from-file=licenses/workbench.lic
+```
+
+Second, specify the following values:
+
+```yaml
+license:
+  file:
+    secret: workbench-license
+    secretKey: workbench.lic
+```
+
+Alternatively, license files can be set directly in your values file or during `helm install` with `--set-file license.file.contents=licenses/workbench.lic` (replace `licenses/workbench.lic` with the path and name of your license file).
+
+### License Key
+
+Set a license key directly in your values file (`license.key`) or during `helm install` with `--set license.key=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+
+### License Server
+
+Set a license server directly in your values file (`license.server`) or during `helm install` with `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>` (replace `<LICENSE_SERVER_HOST_ADDRESS>` with your actual server address).
 
 ## General Principles
 


### PR DESCRIPTION
This PR adds a "Licensing" section to the Workbench, Connect, and Package Manager READMEs, showing consumers of the charts different ways to use license files, keys, and servers with our helm charts. This is one point that customers struggle with, especially license files (which is soon to be our default).

Closes https://github.com/rstudio/helm/issues/426