### PR TITLE
Workbench: Make `prestart-launcher.bash` distribution-agnostic

### DIFF
--- a/charts/rstudio-workbench/prestart-launcher.bash
+++ b/charts/rstudio-workbench/prestart-launcher.bash
@@ -38,8 +38,13 @@ main() {
     /usr/local/share/ca-certificates/Kubernetes/cert-Kubernetes.crt 2>&1 | _indent
 
   _logf 'Updating CA certificates'
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  DIST=$(cat /etc/os-release | grep "^ID=" -E -m 1 | cut -c 4-10 | sed 's/"//g')
+  if [[ $DIST == "ubuntu" ]]; then
     update-ca-certificates 2>&1 | _indent
+  elif [[ $DIST == "rhel" || $DIST == "almalinux" ]]; then
+    update-ca-trust 2>&1 | _indent
+  fi
 
   _logf 'Preparing dirs'
   mkdir -p \


### PR DESCRIPTION
(Assuming no other distros are being used yet as a base for WB images.)

Right now, the script is hard-coded for debian-like distros only.
The following patch adds a dynamic solution to also include rhel-like distros.

Should be pretty fail-safe, but feel free to modify to your liking, of course.