### PR TITLE
Improve several default settings and add to README for Workbench

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.15
+version: 0.6.16
 apiVersion: v2
 appVersion: 2023.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,15 @@
+# 0.6.16
+
+- Update default package manager repo in `config.session.repos.conf`
+- Remove `--verbose` from args in `config.server.vscode.conf`
+- Add instructions for configuring R and Python repos in the README
+- Add empty JSON to `rstudio-prefs.json` default
+- Add documentation for `databricks.conf`
+- Increase `readinessProbe.initialDelaySeconds` to `10`
+
 # 0.6.15
 
-- Added `ttlSecondsAfterFinished` to `job.tpl` for session jobs.
+- Add `ttlSecondsAfterFinished` to `job.tpl` for session jobs.
 
 # 0.6.14
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -117,7 +117,7 @@ the `XDG_CONFIG_DIRS` environment variable
   - mounted at `/mnt/session-secret/`
 - Secret Configuration
   - These configuration files are mounted into the server with more restrictive permissions (0600)
-  - `database.conf`, `openid-client-secret`, etc.
+  - `database.conf`, `openid-client-secret`, `databricks.conf`
   - They are located in the `config.secret.<< name of file >>` helm values
   - mounted at `/mnt/secret-configmap/rstudio/`
 - Server Configuration
@@ -161,6 +161,37 @@ config:
   - `pam` configuration files
   - Located at `config.pam.<< name of file >>` helm values
   - Will be mounted verbatim as individual files (using `subPath` mounts) at `/etc/pam.d/<< name of file >>`
+
+### Configuring R and Python repositories
+
+#### R repositories
+
+R package repositories can be configured with `config.session.repos.conf`.
+
+```
+config:
+  session:
+    repos.conf:
+      CRAN: https://packagemanager.posit.co/cran/__linux__/jammy/latest
+```
+
+For more information about configuring CRAN repositories in Workbench refer to the [Admin Guide](https://docs.posit.co/ide/server-pro/rstudio_pro_sessions/package_installation.html#cran-repositories).
+
+#### Python repositories
+
+pip can be configured with `config.session.pip.conf`. To ensure `pip.conf` is mounted into the session pods it is important that `launcher.useTemplates: true` is set and `pip.conf` settings are listed under `config.session` like in the example below for adding Posit Public Package Manager's PyPI.
+
+```
+launcher:
+  useTemplates: true
+
+config:
+  session:
+    pip.conf:
+      "global":
+        index-url: https://packagemanager.posit.co/pypi/latest/simple
+        trusted-host: packagemanager.posit.co
+```
 
 ## User Provisioning
 

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -222,7 +222,7 @@ readinessProbe:
   httpGet:
     path: /health-check
     port: 8787
-  initialDelaySeconds: 3
+  initialDelaySeconds: 10
   periodSeconds: 3
   timeoutSeconds: 1
   successThreshold: 1
@@ -404,15 +404,15 @@ config:
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.
   session:
     repos.conf:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
+      CRAN: https://packagemanager.posit.co/cran/__linux__/jammy/latest
     rsession.conf: {}
     notifications.conf: {}
-    rstudio-prefs.json: {}
+    rstudio-prefs.json: |
+      {}
   # -- a map of secret, session-scoped config files (odbc.ini, etc.). Mounted to `/mnt/session-secret/` on both server and session, by default
   sessionSecret: {}
-  # -- a map of secret, server-scoped config files. Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions
+  # -- a map of secret, server-scoped config files (database.conf, databricks.conf, openid-client-secret). Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions
   secret:
-    # "database.conf": {}
   # -- a map of sssd config files, used for user provisioning. Mounted to `/etc/sssd/conf.d/` with 0600 permissions
   userProvisioning: {}
   # -- a map of server config files. Mounted to `/mnt/configmap/rstudio/`
@@ -452,7 +452,7 @@ config:
     vscode.conf:
       enabled: 1
       exe: /opt/code-server/bin/code-server
-      args: --verbose --host=0.0.0.0
+      args: --host=0.0.0.0
     vscode-user-settings.json: |
       {
             "terminal.integrated.shell.linux": "/bin/bash",


### PR DESCRIPTION
This PR fixes/improves several rough edges in the Workbench chart. @SamEdwardes and I went through them together and each tested the changes.

- Update default package manager repo in `config.session.repos.conf`
  - Closes https://github.com/rstudio/helm/issues/418 and changes to CRAN so the default gets picked up in RStudio Pro sessions
- Remove `--verbose` from args in `config.server.vscode.conf`
  - Closes https://github.com/rstudio/helm/issues/461 as this was removed in Workbench default config at some point but not in the helm values
- Add instructions for configuring R and Python repos in the README
  - Documents how to set repos and mount pip.conf to close https://github.com/rstudio/helm/issues/423
- Add empty JSON to `rstudio-prefs.json` default
  - Closes https://github.com/rstudio/helm/issues/468
- Add documentation for `databricks.conf`
  - Documents in the README that `databricks.conf` should be put in `config.secret`
- Increase `readinessProbe.initialDelaySeconds` to `10`
  - Closes https://github.com/rstudio/helm/issues/253 as the startup script often takes 7-8 seconds