### PR TITLE
Change Workbench default service.type and other service generation items

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.6.16
+version: 0.6.17
 apiVersion: v2
 appVersion: 2023.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,3 +1,10 @@
+# 0.6.17
+
+- BREAKING: The generated service will now have type `ClusterIP` by default.
+- Add support for setting the `loadBalancerIP` or `clusterIP`.
+- Ignore `nodePort` settings when the service is not a `NodePort`.
+- Improve the documentation for some service-related settings.
+
 # 0.6.16
 
 - Update default package manager repo in `config.session.repos.conf`

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -479,12 +479,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ print $myvar }}
 {{ end }}
 
-{{- define "rstudio-workbench.annotations" -}}
-{{- range $key,$value := .Values.service.annotations -}}
-{{ $key }}: {{ $value | quote }}
-{{ end }}
-{{- end -}}
-
 {{- define "rstudio-workbench.pod.annotations" -}}
 {{- range $key,$value := $.Values.pod.annotations -}}
 {{ $key }}: {{ $value | quote }}

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -10,6 +10,12 @@ metadata:
 {{ include "rstudio-workbench.annotations" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   selector:
     {{- include "rstudio-workbench.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -22,9 +22,9 @@ spec:
   - protocol: TCP
     name: http
     port: {{ .Values.service.port }}
-    {{- if .Values.service.nodePort }}
+{{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+{{- end }}
     targetPort: 8787
   {{- if .Values.prometheusExporter.enabled }}
   - name: metrics

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "rstudio-workbench.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
   annotations:
-{{ include "rstudio-workbench.annotations" . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
 {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -173,7 +173,7 @@ sealedSecret:
   annotations: {}
 
 service:
-  # -- annotations for the service definition
+  # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -178,6 +178,11 @@ service:
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)
   type: ClusterIP
+  # -- The cluster-internal IP to use with `service.type` ClusterIP
+  clusterIP: ""
+  # -- The external IP to use with `service.type` LoadBalancer, when supported
+  # by the cloud provider
+  loadBalancerIP: ""
   # -- The explicit nodePort to use for `service.type` NodePort. If not
   # provided, Kubernetes will choose one automatically
   nodePort: false

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -178,7 +178,8 @@ service:
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)
   type: ClusterIP
-  # -- the nodePort to use when using service type NodePort. If not defined, Kubernetes will provide one automatically
+  # -- The explicit nodePort to use for `service.type` NodePort. If not
+  # provided, Kubernetes will choose one automatically
   nodePort: false
   # -- The Service port. This is the port your service will run under.
   port: 80

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -175,8 +175,9 @@ sealedSecret:
 service:
   # -- annotations for the service definition
   annotations: {}
-  # -- the service type (i.e. NodePort, LoadBalancer, etc.)
-  type: NodePort
+  # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
+  # expose the service using your cloud provider's load balancer)
+  type: ClusterIP
   # -- the nodePort to use when using service type NodePort. If not defined, Kubernetes will provide one automatically
   nodePort: false
   # -- The Service port. This is the port your service will run under.


### PR DESCRIPTION
This PR contains the following changes, following the changes made to RSPM by @atheriel in 2021 (PR here: https://github.com/rstudio/helm/pull/122) This change to RSPM was made over 2 years ago and went pretty smoothly, now bringing it to Workbench.

- Use a `ClusterIP` service by default instead of a `NodePort`.
- Add support for controlling [`loadBalancerIP`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) and [`clusterIP`](https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address), which are commonly-used service features.
- Ignore nodePort settings when the service type is not `NodePort`. Otherwise, this will generate server-side validation errors.
- Simplify handling of Service annotations by removing the existing YAML helper is not actually necessary and has a confusing name.
- Tweak documentation for `service.nodePort` and `service.annotations`.

Since the first of these is a breaking change, I bumped the minor version for the chart.

## Moving to ClusterIP

`ClusterIP` is the Kubernetes default, exposing the service in-cluster only. This is a secure, well-understood default. For external users, there are a few options:

* Use an `Ingress`. We support this already and it works with `ClusterIP`.

* Use a `LoadBalancer`. This can be expensive so it makes a poor default.

* Use a `NodePort` and some kind of external load balancing solution.

It seems like the last route (which is the current default) is much more uncommon than the first two, so I'd advocate for this change.

In addition:

* `NodePorts` are a very limited cluster resource, so we should avoid consuming them if we can avoid it.

* Defaulting to `NodePort` is a poor security choice, especially if we have users that don't understand the consequences.

