### PR TITLE
Change Connect default service.type and other service generation items

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.5.14
+version: 0.6.0
 apiVersion: v2
 appVersion: 2024.02.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,6 +1,6 @@
 # 0.6.0
 
-- BREAKING: The generated service will now have type `ClusterIP` by default.
+- BREAKING: The generated service will now have type `ClusterIP` set by default.
 - Add support for setting the `loadBalancerIP` or `clusterIP`.
 - Ignore `nodePort` settings when the service is not a `NodePort`.
 - Improve the documentation for some service-related settings.

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,3 +1,10 @@
+# 0.6.0
+
+- BREAKING: The generated service will now have type `ClusterIP` by default.
+- Add support for setting the `loadBalancerIP` or `clusterIP`.
+- Ignore `nodePort` settings when the service is not a `NodePort`.
+- Improve the documentation for some service-related settings.
+
 # 0.5.14
 
 - Bump Connect version to 2024.02.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # RStudio Connect
 
-![Version: 0.5.14](https://img.shields.io/badge/Version-0.5.14-informational?style=flat-square) ![AppVersion: 2024.02.0](https://img.shields.io/badge/AppVersion-2024.02.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 2024.02.0](https://img.shields.io/badge/AppVersion-2024.02.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.14:
+To install the chart with the release name `my-release` at version 0.6.0:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.5.14
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.6.0
 ```
 
 To explore other chart versions, take a look at:
@@ -192,11 +192,13 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | replicas | int | `1` | The number of replica pods to maintain for this service |
 | resources | object | `{}` | Defines resources for the rstudio-connect container |
 | securityContext | object | `{"privileged":true}` | Values to set the `securityContext` for Connect container. It must include "privileged: true" or "CAP_SYS_ADMIN" when launcher is not enabled. If launcher is enabled, this can be removed with `securityContext: null` |
-| service.annotations | object | `{}` | Annotations that will be added onto the service |
-| service.nodePort | bool | `false` | The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically |
+| service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
+| service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |
+| service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |
+| service.nodePort | bool | `false` | The explicit nodePort to use for `service.type` NodePort. If not provided, Kubernetes will choose one automatically |
 | service.port | int | `80` | The port to use for the Connect service |
 | service.targetPort | int | `3939` | The port to forward to on the Connect pod. Also see pod.port |
-| service.type | string | `"NodePort"` | The service type (LoadBalancer, NodePort, etc.) |
+| service.type | string | `"ClusterIP"` | The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to expose the service using your cloud provider's load balancer) |
 | serviceMonitor.additionalLabels | object | `{}` | additionalLabels normally includes the release name of the Prometheus Operator |
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor CRD for use with a Prometheus Operator |
 | serviceMonitor.namespace | string | `""` | Namespace to create the ServiceMonitor in (usually the same as the one in which the Prometheus Operator is running). Defaults to the release namespace |

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -85,12 +85,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- include "rstudio-library.config.gcfg" ( mergeOverwrite $defaultConfig .Values.config ) }}
 {{- end -}}
 
-{{- define "rstudio-connect.annotations" -}}
-{{- range $key,$value := $.Values.service.annotations -}}
-{{ $key }}: {{ $value | quote }}
-{{ end }}
-{{- end -}}
-
 {{/*
   - Define the runtime.yaml file
     - If a string:

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "rstudio-connect.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
   annotations:
-{{ include "rstudio-connect.annotations" . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
 {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -10,6 +10,12 @@ metadata:
 {{ include "rstudio-connect.annotations" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}  
   selector:
     {{- include "rstudio-connect.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -22,9 +22,9 @@ spec:
   - name: http
     protocol: TCP
     port: {{ .Values.service.port }}
-    {{- if .Values.service.nodePort }}
+{{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+{{- end }}
     targetPort: {{ .Values.service.targetPort }}
   {{- if .Values.prometheusExporter.enabled }}
   - name: metrics

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -91,6 +91,11 @@ service:
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)
   type: ClusterIP
+  # -- The cluster-internal IP to use with `service.type` ClusterIP
+  clusterIP: ""
+  # -- The external IP to use with `service.type` LoadBalancer, when supported
+  # by the cloud provider
+  loadBalancerIP: ""
   # -- The explicit nodePort to use for `service.type` NodePort. If not
   # provided, Kubernetes will choose one automatically
   nodePort: false

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -91,7 +91,8 @@ service:
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)
   type: ClusterIP
-  # -- The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically
+  # -- The explicit nodePort to use for `service.type` NodePort. If not
+  # provided, Kubernetes will choose one automatically
   nodePort: false
   # -- The port to use for the Connect service
   port: 80

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -88,8 +88,9 @@ strategy:
 service:
   # -- Annotations that will be added onto the service
   annotations: {}
-  # -- The service type (LoadBalancer, NodePort, etc.)
-  type: NodePort
+  # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
+  # expose the service using your cloud provider's load balancer)
+  type: ClusterIP
   # -- The nodePort to use when using service type NodePort. If not provided, Kubernetes will provide one automatically
   nodePort: false
   # -- The port to use for the Connect service

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -86,7 +86,7 @@ strategy:
     maxUnavailable: 0
 
 service:
-  # -- Annotations that will be added onto the service
+  # -- Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
   annotations: {}
   # -- The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to
   # expose the service using your cloud provider's load balancer)


### PR DESCRIPTION
This PR contains the following changes, following the changes made to RSPM by @atheriel in 2021 (PR here: https://github.com/rstudio/helm/pull/122) This change to RSPM was made over 2 years ago and went pretty smoothly, now bringing it to Connect.

- Use a `ClusterIP` service by default instead of a `NodePort`.
- Add support for controlling [`loadBalancerIP`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) and [`clusterIP`](https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address), which are commonly-used service features.
- Ignore nodePort settings when the service type is not `NodePort`. Otherwise, this will generate server-side validation errors.
- Simplify handling of Service annotations by removing the existing YAML helper is not actually necessary and has a confusing name.
- Tweak documentation for `service.nodePort` and `service.annotations`.

Since the first of these is a breaking change, I bumped the minor version for the chart.

## Moving to ClusterIP

`ClusterIP` is the Kubernetes default, exposing the service in-cluster only. This is a secure, well-understood default. For external users, there are a few options:

- Use an `Ingress`. We support this already and it works with `ClusterIP`.
- Use a `LoadBalancer`. This can be expensive so it makes a poor default.
- Use a `NodePort` and some kind of external load balancing solution.

It seems like the last route (which is the current default) is much more uncommon than the first two, so I'd advocate for this change.

In addition:

- `NodePorts` are a very limited cluster resource, so we should avoid consuming them if we can avoid it.
- Defaulting to `NodePort` is a poor security choice, especially if we have users that don't understand the consequences.

