### PR TITLE
connect: update content images and enable quarto by default

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -84,3 +84,22 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: ct install --target-branch main --all --chart-dirs charts --chart-dirs other-charts
         continue-on-error: true
+
+  check-versions-connect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.6.3
+
+      - uses: extractions/setup-just@v2
+
+      - name: Run executable verification for default interpreters
+        run: |
+          just test-connect-interpreter-versions

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.6.3
+version: 0.6.4
 apiVersion: v2
 appVersion: 2024.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -3,7 +3,7 @@
 ## 0.6.4
 
 - Update the default content images in `default-runtime.yaml` and `default-runtime-pro.yaml` to include newer R, Python and Quarto versions.
-- Enable Quarto by default in the `config` section of `values.yaml`
+- Enable Quarto by default when `launcher.enabled: true`
 
 ## 0.6.3
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.4
+
+- Update the default content images in `default-runtime.yaml` and `default-runtime-pro.yaml` to include newer R, Python and Quarto versions.
+
 ## 0.6.3
 
 - Bump Chronicle Agent to version 2024.03.0

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -3,7 +3,7 @@
 ## 0.6.4
 
 - Update the default content images in `default-runtime.yaml` and `default-runtime-pro.yaml` to include newer R, Python and Quarto versions.
-- Enable Quarto by default when `launcher.enabled: true`
+- Enable Python and Quarto by default in `values.yaml` when running in local or off-host execution mode.
 
 ## 0.6.3
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -3,6 +3,7 @@
 ## 0.6.4
 
 - Update the default content images in `default-runtime.yaml` and `default-runtime-pro.yaml` to include newer R, Python and Quarto versions.
+- Enable Quarto by default in the `config` section of `values.yaml`
 
 ## 0.6.3
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![AppVersion: 2024.03.0](https://img.shields.io/badge/AppVersion-2024.03.0-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![AppVersion: 2024.03.0](https://img.shields.io/badge/AppVersion-2024.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Connect_
 
@@ -26,11 +26,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.6.3:
+To install the chart with the release name `my-release` at version 0.6.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.6.3
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.6.4
 ```
 
 To explore other chart versions, take a look at:

--- a/charts/rstudio-connect/default-runtime-pro.yaml
+++ b/charts/rstudio-connect/default-runtime-pro.yaml
@@ -1,12 +1,12 @@
 name: Kubernetes
 images:
   -
-    name: ghcr.io/rstudio/content-pro:r3.6.3-py3.8.16-ubuntu2204
+    name: ghcr.io/rstudio/content-pro:r3.6.3-py3.8.19-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.8.16/bin/python3
-          version: 3.8.16
+          path: /opt/python/3.8.19/bin/python3
+          version: 3.8.19
     r:
       installations:
         -
@@ -14,15 +14,15 @@ images:
           version: 3.6.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-pro:r4.0.5-py3.9.16-ubuntu2204
+    name: ghcr.io/rstudio/content-pro:r4.0.5-py3.9.19-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.9.16/bin/python3
-          version: 3.9.16
+          path: /opt/python/3.9.19/bin/python3
+          version: 3.9.19
     r:
       installations:
         -
@@ -30,15 +30,15 @@ images:
           version: 4.0.5
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-pro:r4.1.3-py3.10.11-ubuntu2204
+    name: ghcr.io/rstudio/content-pro:r4.1.3-py3.10.14-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.10.11/bin/python3
-          version: 3.10.11
+          path: /opt/python/3.10.14/bin/python3
+          version: 3.10.14
     r:
       installations:
         -
@@ -46,21 +46,53 @@ images:
           version: 4.1.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-pro:r4.2.2-py3.11.3-ubuntu2204
+    name: ghcr.io/rstudio/content-pro:r4.2.3-py3.11.9-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.11.3/bin/python3
-          version: 3.11.3
+          path: /opt/python/3.11.9/bin/python3
+          version: 3.11.9
     r:
       installations:
         -
-          path: /opt/R/4.2.2/bin/R
-          version: 4.2.2
+          path: /opt/R/4.2.3/bin/R
+          version: 4.2.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
+  -
+    name: ghcr.io/rstudio/content-pro:r4.3.3-py3.12.3-ubuntu2204
+    python:
+      installations:
+        -
+          path: /opt/python/3.12.3/bin/python3
+          version: 3.12.3
+    r:
+      installations:
+        -
+          path: /opt/R/4.3.3/bin/R
+          version: 4.3.3
+    quarto:
+      installations:
+        - path: /opt/quarto/1.4.553/bin/quarto
+          version: 1.4.553
+  -
+    name: ghcr.io/rstudio/content-pro:r4.4.0-py3.12.3-ubuntu2204
+    python:
+      installations:
+        -
+          path: /opt/python/3.12.3/bin/python3
+          version: 3.12.3
+    r:
+      installations:
+        -
+          path: /opt/R/4.4.0/bin/R
+          version: 4.4.0
+    quarto:
+      installations:
+        - path: /opt/quarto/1.4.553/bin/quarto
+          version: 1.4.553

--- a/charts/rstudio-connect/default-runtime.yaml
+++ b/charts/rstudio-connect/default-runtime.yaml
@@ -1,12 +1,12 @@
 name: Kubernetes
 images:
   -
-    name: ghcr.io/rstudio/content-base:r3.6.3-py3.8.16-ubuntu2204
+    name: ghcr.io/rstudio/content-base:r3.6.3-py3.8.19-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.8.16/bin/python3
-          version: 3.8.16
+          path: /opt/python/3.8.19/bin/python3
+          version: 3.8.19
     r:
       installations:
         -
@@ -14,15 +14,15 @@ images:
           version: 3.6.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-base:r4.0.5-py3.9.16-ubuntu2204
+    name: ghcr.io/rstudio/content-base:r4.0.5-py3.9.19-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.9.16/bin/python3
-          version: 3.9.16
+          path: /opt/python/3.9.19/bin/python3
+          version: 3.9.19
     r:
       installations:
         -
@@ -30,15 +30,15 @@ images:
           version: 4.0.5
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-base:r4.1.3-py3.10.11-ubuntu2204
+    name: ghcr.io/rstudio/content-base:r4.1.3-py3.10.14-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.10.11/bin/python3
-          version: 3.10.11
+          path: /opt/python/3.10.14/bin/python3
+          version: 3.10.14
     r:
       installations:
         -
@@ -46,21 +46,53 @@ images:
           version: 4.1.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
   -
-    name: ghcr.io/rstudio/content-base:r4.2.2-py3.11.3-ubuntu2204
+    name: ghcr.io/rstudio/content-base:r4.2.3-py3.11.9-ubuntu2204
     python:
       installations:
         -
-          path: /opt/python/3.11.3/bin/python3
-          version: 3.11.3
+          path: /opt/python/3.11.9/bin/python3
+          version: 3.11.9
     r:
       installations:
         -
-          path: /opt/R/4.2.2/bin/R
-          version: 4.2.2
+          path: /opt/R/4.2.3/bin/R
+          version: 4.2.3
     quarto:
       installations:
-        - path: /opt/quarto/1.3.340/bin/quarto
-          version: 1.3.340
+        - path: /opt/quarto/1.3.450/bin/quarto
+          version: 1.3.450
+  -
+    name: ghcr.io/rstudio/content-base:r4.3.3-py3.12.3-ubuntu2204
+    python:
+      installations:
+        -
+          path: /opt/python/3.12.3/bin/python3
+          version: 3.12.3
+    r:
+      installations:
+        -
+          path: /opt/R/4.3.3/bin/R
+          version: 4.3.3
+    quarto:
+      installations:
+        - path: /opt/quarto/1.4.553/bin/quarto
+          version: 1.4.553
+  -
+    name: ghcr.io/rstudio/content-base:r4.4.0-py3.12.3-ubuntu2204
+    python:
+      installations:
+        -
+          path: /opt/python/3.12.3/bin/python3
+          version: 3.12.3
+    r:
+      installations:
+        -
+          path: /opt/R/4.4.0/bin/R
+          version: 4.4.0
+    quarto:
+      installations:
+        - path: /opt/quarto/1.4.553/bin/quarto
+          version: 1.4.553

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -73,12 +73,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{- $_ := set $launcherSettingsDict "KubernetesUseTemplates" "false" }}
     {{- end }}
     {{- $launcherDict := dict "Launcher" ( $launcherSettingsDict ) }}
-    {{- $pythonSettingsDict := dict "Enabled" ("true") }}
-    {{- $pythonDict := dict "Python" ( $pythonSettingsDict ) }}
-    {{- $defaultConfig = merge $defaultConfig $launcherDict $pythonDict }}
-    {{- $quartoSettingsDict := dict "Enabled" ("true") }}
-    {{- $quartoDict := dict "Quarto" ( $quartoSettingsDict ) }}
-    {{- $defaultConfig = merge $defaultConfig $launcherDict $quartoDict }}
+    {{- $defaultConfig = merge $defaultConfig $launcherDict }}
   {{- end }}
   {{- /* default licensing configuration */}}
   {{- if .Values.license.server }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -76,6 +76,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- $pythonSettingsDict := dict "Enabled" ("true") }}
     {{- $pythonDict := dict "Python" ( $pythonSettingsDict ) }}
     {{- $defaultConfig = merge $defaultConfig $launcherDict $pythonDict }}
+    {{- $quartoSettingsDict := dict "Enabled" ("true") }}
+    {{- $quartoDict := dict "Quarto" ( $quartoSettingsDict ) }}
+    {{- $defaultConfig = merge $defaultConfig $launcherDict $quartoDict }}
   {{- end }}
   {{- /* default licensing configuration */}}
   {{- if .Values.license.server }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -335,6 +335,8 @@ config:
     DataDir: /var/lib/rstudio-connect
   Scheduler:
     InitTimeout: 5m
+  Quarto:
+    Enabled: true
   Logging:
     ServiceLog: STDOUT
     ServiceLogLevel: INFO    # INFO, WARNING or ERROR

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -335,8 +335,6 @@ config:
     DataDir: /var/lib/rstudio-connect
   Scheduler:
     InitTimeout: 5m
-  Quarto:
-    Enabled: true
   Logging:
     ServiceLog: STDOUT
     ServiceLogLevel: INFO    # INFO, WARNING or ERROR
@@ -349,3 +347,5 @@ config:
     GraphiteHost: 127.0.0.1
     GraphitePort: 9109
     GraphiteClientId: rsconnect
+  # Note: Quarto and Python are both enabled automatically when launcher.enabled: true
+  # https://github.com/rstudio/helm/blob/main/charts/rstudio-connect/templates/_helpers.tpl

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -333,6 +333,12 @@ config:
   Server:
     Address: http://localhost:3939
     DataDir: /var/lib/rstudio-connect
+  Python:
+    Enabled: true
+    Executable: "/opt/python/3.9.17/bin/python3"
+  Quarto:
+    Enabled: true
+    Executable: "/opt/quarto/1.3.340/bin/quarto"
   Scheduler:
     InitTimeout: 5m
   Logging:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -335,7 +335,9 @@ config:
     DataDir: /var/lib/rstudio-connect
   Python:
     Enabled: true
-    Executable: "/opt/python/3.9.17/bin/python3"
+    Executable:
+      - /opt/python/3.9.17/bin/python
+      - /opt/python/3.8.17/bin/python
   Quarto:
     Enabled: true
     Executable: "/opt/quarto/1.3.340/bin/quarto"

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -335,11 +335,15 @@ config:
     DataDir: /var/lib/rstudio-connect
   Python:
     Enabled: true
+    # Note: The `Executable` listed below are only used for Local Execution. For Off-Host Execution, Python versions are defined by the set of Execution Environments
+    # https://docs.posit.co/connect/admin/python/
     Executable:
       - /opt/python/3.9.17/bin/python
       - /opt/python/3.8.17/bin/python
   Quarto:
     Enabled: true
+    # Note: The `Executable` listed below is only used for Local Execution. For Off-Host Execution, Quarto versions are defined by the set of Execution Environments
+    # https://docs.posit.co/connect/admin/quarto/
     Executable: "/opt/quarto/1.3.340/bin/quarto"
   Scheduler:
     InitTimeout: 5m
@@ -356,4 +360,3 @@ config:
     GraphitePort: 9109
     GraphiteClientId: rsconnect
   # Note: Quarto and Python are both enabled automatically when launcher.enabled: true
-  # https://github.com/rstudio/helm/blob/main/charts/rstudio-connect/templates/_helpers.tpl

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -359,4 +359,3 @@ config:
     GraphiteHost: 127.0.0.1
     GraphitePort: 9109
     GraphiteClientId: rsconnect
-  # Note: Quarto and Python are both enabled automatically when launcher.enabled: true


### PR DESCRIPTION
- Adds in the new content-base and content-pro images in the `default-runtime.yaml` and `default-runtime-pro.yaml` files created via this PR: https://github.com/rstudio/rstudio-docker-products/pull/737
- Enables `Quarto` and `Python` in the default `values.yaml` `config` section so Python and Quarto content will work out of the box for local execution or off-host execution (closes https://github.com/rstudio/helm/issues/463). Previously Python was automatically enabled only when launcher was enabled. This conditional is removed now that its in the values.

## Testing

Deployed Connect into EKS using base and pro, they show up as expected and content can be deployed from R and Python (tested on the content-pro:r4.2.3-py3.11.9-ubuntu2204 image).

Base env list:
![env list base](https://github.com/rstudio/helm/assets/180123/c54c8957-f759-4c58-b25e-284b02661295)

Pro env list:
![env list pro](https://github.com/rstudio/helm/assets/180123/5dfadd64-a71e-4d50-a889-85b08b925a8f)



