### PR TITLE
Connect: Enable Quarto and Python by default for local execution

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -84,3 +84,22 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: ct install --target-branch main --all --chart-dirs charts --chart-dirs other-charts
         continue-on-error: true
+
+  check-versions-connect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.6.3
+
+      - uses: extractions/setup-just@v2
+
+      - name: Run executable verification for default interpreters
+        run: |
+          just test-connect-interpreter-versions


### PR DESCRIPTION
~~This PR enables Quarto and Python by default for local execution. They were already enabled by default for off-host execution.~~ This change will happen in the [original PR ](https://github.com/rstudio/helm/pull/486) instead. This PR only add the new GHA

Adds a new GHA test that runs on every PR which validates `that` the local defaults defined in the values are actually installed on the default image:
- Enumerates the interpreter versions that are defined in the helm chart's default values for each R, Python, and Quarto.
- Then attempts to run `command -v` against each executable to ensure that it exists in the default chart image.

Related to https://github.com/rstudio/helm/pull/486#issuecomment-2085390506