### PR TITLE
Bump connect version to 2024.04.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.6.4
+version: 0.6.5
 apiVersion: v2
-appVersion: 2024.03.0
+appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:ubuntu2204-2024.03.0
+      image: rstudio/rstudio-connect:ubuntu2204-2024.04.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.5
+
+- Bump Connect version to 2024.04.0
+
 ## 0.6.4
 
 - Update the default content images in `default-runtime.yaml` and `default-runtime-pro.yaml` to include newer R, Python and Quarto versions.

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -335,16 +335,18 @@ config:
     DataDir: /var/lib/rstudio-connect
   Python:
     Enabled: true
-    # Note: The `Executable` listed below are only used for Local Execution. For Off-Host Execution, Python versions are defined by the set of Execution Environments
+    # Note: The `Executable` listed below are only used for Local Execution.
+    # For Off-Host Execution, Python versions are defined by the set of Execution Environments
     # https://docs.posit.co/connect/admin/python/
     Executable:
       - /opt/python/3.9.17/bin/python
       - /opt/python/3.8.17/bin/python
   Quarto:
     Enabled: true
-    # Note: The `Executable` listed below is only used for Local Execution. For Off-Host Execution, Quarto versions are defined by the set of Execution Environments
+    # Note: The `Executable` listed below is only used for Local Execution.
+    # For Off-Host Execution, Quarto versions are defined by the set of Execution Environments
     # https://docs.posit.co/connect/admin/quarto/
-    Executable: "/opt/quarto/1.3.340/bin/quarto"
+    Executable: "/opt/quarto/1.4.552/bin/quarto"
   Scheduler:
     InitTimeout: 5m
   Logging:


### PR DESCRIPTION
Bumps connect to 2024.04
Upgrades the default quarto version to 1.4.552