### PR TITLE
Use the full PWB version docker tag

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.7.3
+version: 0.7.4
 apiVersion: v2
 appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.04.0
+      image: rstudio/rstudio-workbench:ubuntu2204-2024.04.0-735.pro3
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.04.0
+      image: rstudio/r-session-complete:ubuntu2204-2024.04.0-735.pro3
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.4
+
+- Use the full workbench image tag of ubuntu2204-2024.04.0+735.pro3
+
 ## 0.7.3
 
 - Bump Workbench version to 2024.04.0

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.7.3:
+To install the chart with the release name `my-release` at version 0.7.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.3
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.4
 ```
 
 To explore other chart versions, take a look at:


### PR DESCRIPTION
The tag for PWB image `rstudio/rstudio-workbench:ubuntu2204-2024.04.0` doesn't exist on docker hub for some reason, which causes problems because that's the tag used in PWB's helm chart.

While platform team investigates why that tag wasn't created, we can use `rstudio/rstudio-workbench:ubuntu2204-024.04.0-735.pro3` instead