### PR TITLE
Add template for mounting DB passwords from secrets

### DIFF
--- a/charts/rstudio-library/Chart.yaml
+++ b/charts/rstudio-library/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-library
 description: Helm library helpers for use by official RStudio charts
 type: library
-version: 0.1.29
-appVersion: 0.1.29
+version: 0.1.30
+appVersion: 0.1.30
 
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com

--- a/charts/rstudio-library/NEWS.md
+++ b/charts/rstudio-library/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.30
+
+- Add a `_database-env.tpl` helper to set an environment variable from secret to pass a database password
+
 ## 0.1.29
 
 - Updates to support standalone documentation site

--- a/charts/rstudio-library/NEWS.md
+++ b/charts/rstudio-library/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.1.30
 
-- Add a `_database-env.tpl` helper to set an environment variable from secret to pass a database password
+- Add a `_database-env.tpl` helper to set an environment variable from a secret to pass a database password to a product
 
 ## 0.1.29
 

--- a/charts/rstudio-library/README.md
+++ b/charts/rstudio-library/README.md
@@ -1,6 +1,6 @@
 # rstudio-library
 
-![Version: 0.1.29](https://img.shields.io/badge/Version-0.1.29-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.29](https://img.shields.io/badge/AppVersion-0.1.29-informational?style=flat-square)
+![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.30](https://img.shields.io/badge/AppVersion-0.1.30-informational?style=flat-square)
 
 #### _Helm library helpers for use by official RStudio charts_
 

--- a/charts/rstudio-library/templates/_database-env.tpl
+++ b/charts/rstudio-library/templates/_database-env.tpl
@@ -1,0 +1,15 @@
+{{- /*
+  Define environment variables for database password configuration
+  Takes a dict:
+    "envVarPrefix": "the env var prefix, e.g., WORKBENCH"
+    "database": "the database configuration values"
+*/ -}}
+{{- define "rstudio-library.database-env" -}}
+{{- if .database.password.secret }}
+- name: {{ .envVarPrefix }}_POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .database.password.secret }}
+      key: {{ .database.password.secretKey }}
+{{- end }}
+{{- end -}}{{- /* end define template */ -}}


### PR DESCRIPTION
Adding a template to the `rstudio-library` chart, which will be used in future PRs to automatically mount PostgreSQL database passwords as environment variables from a secret.

This is to work on https://github.com/rstudio/helm/issues/422 (now that Workbench supports env variables) and https://github.com/rstudio/helm/issues/420.

Once this is in, will add to each product these values:
```
database:
  password:
    secretKey: "password"
    secret: ""
```