### PR TITLE
Fix: 0.5.25 should use 2024.04.0-20 release

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.24
+version: 0.5.25
 apiVersion: v2
 appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.25
+
+- Update default Posit Package Manager version to 2024.04.0-20
+
 ## 0.5.24
 
 - Unset the `[Server].Address` default value as this can cause issues when serving from a domain name.

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.24](https://img.shields.io/badge/Version-0.5.24-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
+![Version: 0.5.25](https://img.shields.io/badge/Version-0.5.25-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Package Manager_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.5.24:
+To install the chart with the release name `my-release` at version 0.5.25:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.24
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.25
 ```
 
 To explore other chart versions, take a look at:


### PR DESCRIPTION
Replaces https://github.com/rstudio/helm/pull/498