### PR TITLE
Add database configuration docs to PWB, PCT and PPM charts

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for RStudio Connect
-version: 0.6.6
+version: 0.6.7
 apiVersion: v2
 appVersion: 2024.04.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.6.7
 
-- Add documentation on database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
 
 # 0.6.6
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.7
+
+- Add documentation on database configuration and mounting passwords from secrets
+
 # 0.6.6
 
 - Bump Connect version to 2024.04.1

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.6.7
 
-- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets as env variables
 
 # 0.6.6
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -84,13 +84,6 @@ Set a license key directly in your values file (`license.key`) or during `helm i
 
 Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
-## General Principles
-
-- In most places, we opt to pass helm values over configmaps. We translate these into the valid `.gcfg` file format
-required by rstudio-connect.
-- rstudio-connect does not export many prometheus metrics on its own. Instead, we run a sidecar graphite exporter
-  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
-
 ## Database
 
 Connect requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/connect/admin/database/postgres/) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
@@ -129,9 +122,7 @@ pod:
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 
-```bash
---set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
-```
+`--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"`
 
 ### Operational metrics database
 
@@ -144,8 +135,8 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
-    InstrumentationURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+    InstrumentationURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>"
 ```
 
 Then specify the `InstrumentationPassword` in the same manner as `Password` by setting the environment variable `CONNECT_POSTGRES_INSTRUMENTATIONPASSWORD` from secret.
@@ -164,6 +155,13 @@ pod:
           name: rstudio-connect-database
           key: password
 ```
+
+## General Principles
+
+- In most places, we opt to pass helm values over configmaps. We translate these into the valid `.gcfg` file format
+required by rstudio-connect.
+- rstudio-connect does not export many prometheus metrics on its own. Instead, we run a sidecar graphite exporter
+  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
 ## Configuration File
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -93,7 +93,7 @@ required by rstudio-connect.
 
 ## Database
 
-Connect requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Connect requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/connect/admin/database/postgres/) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 ### Database configuration
 
@@ -104,14 +104,16 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
 ```
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic rstudio-connect-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic rstudio-connect-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -23,13 +23,6 @@ This chart requires the following in order to function:
 
 {{ template "rstudio.licensing" . }}
 
-## General Principles
-
-- In most places, we opt to pass helm values over configmaps. We translate these into the valid `.gcfg` file format
-required by {{ template "chart.name" . }}.
-- {{ template "chart.name" . }} does not export many prometheus metrics on its own. Instead, we run a sidecar graphite exporter
-  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
-
 ## Database
 
 Connect requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/connect/admin/database/postgres/) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
@@ -68,9 +61,7 @@ pod:
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 
-```bash
---set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
-```
+`--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"`
 
 ### Operational metrics database
 
@@ -83,8 +74,8 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
-    InstrumentationURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+    InstrumentationURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>"
 ```
 
 Then specify the `InstrumentationPassword` in the same manner as `Password` by setting the environment variable `CONNECT_POSTGRES_INSTRUMENTATIONPASSWORD` from secret.
@@ -103,6 +94,13 @@ pod:
           name: {{ .Name }}-database
           key: password
 ```
+
+## General Principles
+
+- In most places, we opt to pass helm values over configmaps. We translate these into the valid `.gcfg` file format
+required by {{ template "chart.name" . }}.
+- {{ template "chart.name" . }} does not export many prometheus metrics on its own. Instead, we run a sidecar graphite exporter
+  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
 ## Configuration File
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -32,7 +32,7 @@ required by {{ template "chart.name" . }}.
 
 ## Database
 
-Connect requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Connect requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/connect/admin/database/postgres/) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 ### Database configuration
 
@@ -43,14 +43,16 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
 ```
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -30,6 +30,78 @@ required by {{ template "chart.name" . }}.
 - {{ template "chart.name" . }} does not export many prometheus metrics on its own. Instead, we run a sidecar graphite exporter
   [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
+## Database
+
+Connect requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `URL` with your database details.
+
+```yaml
+config:
+  Database:
+    Provider: "Postgres"
+  Postgres:
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+### Database password
+
+First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: CONNECT_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+```bash
+--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
+```
+
+### Operational metrics database
+
+Connect by default stores operational metrics in its main database. You may optionally use a seperate [schema or database for your operational metrics storage](https://docs.posit.co/connect/admin/database/postgres/index.html#operational-metrics).
+
+To use a seperate database or schema for these metrics add `InstrumentationURL` in the same section as `URL` in your `values.yaml`.
+
+```yaml
+config:
+  Database:
+    Provider: "Postgres"
+  Postgres:
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    InstrumentationURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+Then specify the `InstrumentationPassword` in the same manner as `Password` by setting the environment variable `CONNECT_POSTGRES_INSTRUMENTATIONPASSWORD` from secret.
+
+```yaml
+pod:
+  env:
+    - name: CONNECT_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+    - name: CONNECT_POSTGRES_INSTRUMENTATIONPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
 ## Configuration File
 
 The configuration values all take the form of usual helm values

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for RStudio Package Manager
-version: 0.5.25
+version: 0.5.26
 apiVersion: v2
 appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.26
+
+- Add documentation on database configuration and mounting passwords from secrets
+
 ## 0.5.25
 
 - Update default Posit Package Manager version to 2024.04.0-20

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.26
 
-- Add documentation on database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
 
 ## 0.5.25
 

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.26
 
-- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets as env variables
 
 ## 0.5.25
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -90,7 +90,7 @@ Set a license server directly in your values file (`license.server`) or during `
 
 ## Database
 
-Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/rspm/admin/database/#database-postgres) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 By default, Package Manager relies on two databases or schemas. The primary database stores information needed to run the service, including the arrangement of repositories, sources, and packages. The secondary database records usage data, such as the number of times a package was downloaded.
 
@@ -103,15 +103,17 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
-    UsageDataURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>&sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+    UsageDataURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>"
 ```
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic rstudio-pm-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic rstudio-pm-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 
@@ -130,7 +132,7 @@ pod:
           key: password
 ```
 
-In this example the same database is being used with two schemas so we use the same database password secret.
+In this example the same database is being used with two schemas so we use the same secret.
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -134,11 +134,10 @@ pod:
 
 In this example the same database is being used with two schemas so we use the same secret.
 
-Alternatively, database passwords may be set during `helm install` with the following argument:
+Alternatively, database passwords may be set during `helm install` with the following arguments:
 
-```bash
---set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
---set config.Postgres.UsageDataPassword="<YOUR_PASSWORD_HERE>"
+```
+--set config.Postgres.Password="<YOUR_PASSWORD_HERE>" --set config.Postgres.UsageDataPassword="<YOUR_PASSWORD_HERE>"
 ```
 
 ## S3 Configuration

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -34,7 +34,7 @@ This chart requires the following in order to function:
 
 ## Database
 
-Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/rspm/admin/database/#database-postgres) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 By default, Package Manager relies on two databases or schemas. The primary database stores information needed to run the service, including the arrangement of repositories, sources, and packages. The secondary database records usage data, such as the number of times a package was downloaded.
 
@@ -47,15 +47,17 @@ config:
   Database:
     Provider: "Postgres"
   Postgres:
-    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
-    UsageDataURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>&sslmode=allow"
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+    UsageDataURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>"
 ```
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 
@@ -74,7 +76,7 @@ pod:
           key: password
 ```
 
-In this example the same database is being used with two schemas so we use the same database password secret.
+In this example the same database is being used with two schemas so we use the same secret.
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -78,11 +78,10 @@ pod:
 
 In this example the same database is being used with two schemas so we use the same secret.
 
-Alternatively, database passwords may be set during `helm install` with the following argument:
+Alternatively, database passwords may be set during `helm install` with the following arguments:
 
-```bash
---set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
---set config.Postgres.UsageDataPassword="<YOUR_PASSWORD_HERE>"
+```
+--set config.Postgres.Password="<YOUR_PASSWORD_HERE>" --set config.Postgres.UsageDataPassword="<YOUR_PASSWORD_HERE>"
 ```
 
 ## S3 Configuration

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -32,6 +32,57 @@ This chart requires the following in order to function:
 
 {{ template "rstudio.licensing" . }}
 
+## Database
+
+Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+
+By default, Package Manager relies on two databases or schemas. The primary database stores information needed to run the service, including the arrangement of repositories, sources, and packages. The secondary database records usage data, such as the number of times a package was downloaded.
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `URL` and `UsageDataURL` with your database details.
+
+```yaml
+config:
+  Database:
+    Provider: "Postgres"
+  Postgres:
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+    UsageDataURL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?options=-csearch_path=<SCHEMA>&sslmode=allow"
+```
+
+### Database password
+
+First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: PACKAGEMANAGER_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+    - name: PACKAGEMANAGER_POSTGRES_USAGEDATAPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
+In this example the same database is being used with two schemas so we use the same database password secret.
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+```bash
+--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"
+--set config.Postgres.UsageDataPassword="<YOUR_PASSWORD_HERE>"
+```
+
 ## S3 Configuration
 
 Package Manager [can be configured to store its data in S3

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for RStudio Workbench
-version: 0.7.3
+version: 0.7.4
 apiVersion: v2
 appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.4
+
+- Add documentation on database configuration and mounting passwords from secrets
+
 ## 0.7.3
 
 - Bump Workbench version to 2024.04.0

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.7.4
 
-- Add documentation on database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
 
 ## 0.7.3
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.7.4
 
-- Add documentation on PostgreSQL database configuration and mounting passwords from secrets
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets as env variables
 
 ## 0.7.3
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -104,19 +104,6 @@ Set a license key directly in your values file (`license.key`) or during `helm i
 
 Set a license server directly in your values file (`license.server`) or during `helm install` with the argument `--set license.server=<LICENSE_SERVER_HOST_ADDRESS>`.
 
-## General Principles
-
-- In most places, we opt to pass Helm values directly into ConfigMaps. We automatically translate these into the
-  valid `.ini` or `.dcf` file formats required by RStudio Workbench. Those config files and their mount locations are
-  below.
-- If you need to modify the jobs launched by RStudio Workbench, you want to use `job-json-overrides`. There is a section on this below
-  and [a support article](https://support.rstudio.com/hc/en-us/articles/360051652094-Using-Job-Json-Overrides-with-RStudio-Server-Pro-and-Kubernetes)
-  on the topic in general.
-- The prestart scripts for RStudio Workbench and RStudio Launcher are highly customized to:
-  - Get the service account information off of the RStudio Workbench pod for use in launching jobs
-- RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
-  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
-
 ## Database
 
 Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
@@ -155,9 +142,20 @@ pod:
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 
-```bash
---set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"
-```
+`--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
+
+## General Principles
+
+- In most places, we opt to pass Helm values directly into ConfigMaps. We automatically translate these into the
+  valid `.ini` or `.dcf` file formats required by RStudio Workbench. Those config files and their mount locations are
+  below.
+- If you need to modify the jobs launched by RStudio Workbench, you want to use `job-json-overrides`. There is a section on this below
+  and [a support article](https://support.rstudio.com/hc/en-us/articles/360051652094-Using-Job-Json-Overrides-with-RStudio-Server-Pro-and-Kubernetes)
+  on the topic in general.
+- The prestart scripts for RStudio Workbench and RStudio Launcher are highly customized to:
+  - Get the service account information off of the RStudio Workbench pod for use in launching jobs
+- RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
+  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
 ## Configuration files
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for RStudio Workbench_
 
@@ -21,11 +21,11 @@ To ensure a stable production deployment, please:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.7.3:
+To install the chart with the release name `my-release` at version 0.7.4:
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.3
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.4
 ```
 
 To explore other chart versions, take a look at:
@@ -116,6 +116,46 @@ Set a license server directly in your values file (`license.server`) or during `
   - Get the service account information off of the RStudio Workbench pod for use in launching jobs
 - RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
   [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
+
+## Database
+
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `connection-uri` with your database details.
+
+```yaml
+config:
+  secret:
+    database.conf:
+      provider: "postgresql"
+      connection-uri: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+### Database password
+
+First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+`kubectl create secret generic rstudio-workbench-database --from-literal=password=YOURPASSWORDHERE`
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: WORKBENCH_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rstudio-workbench-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+```bash
+--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"
+```
 
 ## Configuration files
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -119,7 +119,7 @@ Set a license server directly in your values file (`license.server`) or during `
 
 ## Database
 
-Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 ### Database configuration
 
@@ -135,9 +135,11 @@ config:
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic rstudio-workbench-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic rstudio-workbench-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -63,7 +63,7 @@ config:
 
 ## Database
 
-Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
 
 ### Database configuration
 
@@ -79,9 +79,11 @@ config:
 
 ### Database password
 
-First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
 
-`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+```bash
+kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE
+```
 
 Second, specify the following in your `values.yaml`:
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -61,6 +61,46 @@ config:
 - RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
   [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
+## Database
+
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a valid connection URI and a password for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret,` which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `connection-uri` with your database details.
+
+```yaml
+config:
+  secret:
+    database.conf:
+      provider: "postgresql"
+      connection-uri: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+### Database password
+
+First, create a secret declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+`kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE`
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: WORKBENCH_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+```bash
+--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"
+```
+
 ## Configuration files
 
 These configuration values all take the form of usual helm values

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -48,19 +48,6 @@ config:
 
 {{ template "rstudio.licensing" . }}
 
-## General Principles
-
-- In most places, we opt to pass Helm values directly into ConfigMaps. We automatically translate these into the
-  valid `.ini` or `.dcf` file formats required by RStudio Workbench. Those config files and their mount locations are
-  below.
-- If you need to modify the jobs launched by RStudio Workbench, you want to use `job-json-overrides`. There is a section on this below
-  and [a support article](https://support.rstudio.com/hc/en-us/articles/360051652094-Using-Job-Json-Overrides-with-RStudio-Server-Pro-and-Kubernetes)
-  on the topic in general.
-- The prestart scripts for RStudio Workbench and RStudio Launcher are highly customized to:
-  - Get the service account information off of the RStudio Workbench pod for use in launching jobs
-- RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
-  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
-
 ## Database
 
 Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
@@ -99,9 +86,20 @@ pod:
 
 Alternatively, database passwords may be set during `helm install` with the following argument:
 
-```bash
---set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"
-```
+`--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
+
+## General Principles
+
+- In most places, we opt to pass Helm values directly into ConfigMaps. We automatically translate these into the
+  valid `.ini` or `.dcf` file formats required by RStudio Workbench. Those config files and their mount locations are
+  below.
+- If you need to modify the jobs launched by RStudio Workbench, you want to use `job-json-overrides`. There is a section on this below
+  and [a support article](https://support.rstudio.com/hc/en-us/articles/360051652094-Using-Job-Json-Overrides-with-RStudio-Server-Pro-and-Kubernetes)
+  on the topic in general.
+- The prestart scripts for RStudio Workbench and RStudio Launcher are highly customized to:
+  - Get the service account information off of the RStudio Workbench pod for use in launching jobs
+- RStudio Workbench does not export prometheus metrics on its own. Instead, we run a sidecar graphite exporter
+  [as described here](https://support.rstudio.com/hc/en-us/articles/360044800273-Monitoring-RStudio-Team-Using-Prometheus-and-Graphite)
 
 ## Configuration files
 


### PR DESCRIPTION
This PR closes https://github.com/rstudio/helm/issues/422 by providing customers guidance on how to configure and set database passwords consistently and in a Kubernetes-friendly way across products.

The docs added show how to configure the database and set up PostgreSQL database passwords as env variables from K8s secrets in Workbench, Connect and Package Manager. This is now possible since Workbench supports setting the [database password as an env variable](https://docs.posit.co/ide/server-pro/database/configuration.html#environment-variables) in the 2024.04.0 release (Connect and Package Manager already supported this).

Currently, admins need to either set the password in the values or imperatively during `helm install`. Both are not very k8s native ways of doing things.

After this, I will file PRs to each product's admin guide to make instructions consistent there. With license file and database passwords being pulled from secrets admins no longer need to set any custom values during `helm install` which is very nice!