### PR TITLE
update actions

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -16,19 +16,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 
       - name: install Just
         uses: extractions/setup-just@v2
 
-      - name: Install helm-docs
-        env:
-          HELM_DOCS_VERSION: 1.13.1
-        run: |
-          just setup
-      
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
@@ -36,6 +30,8 @@ jobs:
 
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2
+        env:
+          HELM_DOCS_VERSION: 1.13.1
 
       - name: Commit results
         run: |
@@ -54,14 +50,14 @@ jobs:
     needs: document
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 

--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 

--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: 'gh-pages'
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Rebuild index.yaml
           title: Rebuild index.yaml

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,14 +25,14 @@ jobs:
           version: v3.6.3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_repo_url: https://helm.rstudio.com
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser (other)
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: other-charts
           charts_repo_url: https://helm.rstudio.com

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -20,19 +20,19 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.2.0
         with:
           charts_repo_url: https://helm.rstudio.com
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser (other)
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.2.0
         with:
           charts_dir: other-charts
           charts_repo_url: https://helm.rstudio.com

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -54,9 +54,9 @@ jobs:
         with:
           version: v3.6.3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
@@ -89,12 +89,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.6.3
 

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0


### PR DESCRIPTION
- silence some node version warnings
- update some unsupported versions of python

FYI: chart-releaser no longer supports the `charts-repo` parameter.
It wasn't clear to me how to update that in a manner consistent with
releasing charts to helm.rstudio.com so for now I've left that in place.
