### PR TITLE
workbench: Add database config and pass as env variable to README

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.7.4
+version: 0.7.5
 apiVersion: v2
 appVersion: 2024.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.7.5
 
-- Add documentation on PostgreSQL database configuration and mounting passwords from secrets as env variables
+- Add documentation about PostgreSQL database configuration and mounting passwords from secrets as env variables
 
 ## 0.7.4
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.5
+
+- Add documentation on PostgreSQL database configuration and mounting passwords from secrets as env variables
+
 ## 0.7.4
 
 - Documentation site updates

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.4:
+To install the chart with the release name `my-release` at version 0.7.5:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.4
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.5
 ```
 
 To explore other chart versions, look at:
@@ -104,6 +104,46 @@ Alternatively, license files can be set during `helm install` with the following
 ```{.bash}
 --set-file license.file.contents=licenses/rstudio-workbench.lic
 ```
+
+## Database
+
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `connection-uri` with your database details.
+
+```yaml
+config:
+  secret:
+    database.conf:
+      provider: "postgresql"
+      connection-uri: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+### Database password
+
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+```bash
+kubectl create secret generic rstudio-workbench-database --from-literal=password=YOURPASSWORDHERE
+```
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: WORKBENCH_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rstudio-workbench-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+`--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
 
 ## General principles
 

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -50,6 +50,46 @@ To function, this chart requires the following:
     ```
 {{ template "rstudio.licensing" . }}
 
+## Database
+
+Workbench requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/ide/server-pro/database/configuration.html#postgresql) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `connection-uri` with your database details.
+
+```yaml
+config:
+  secret:
+    database.conf:
+      provider: "postgresql"
+      connection-uri: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>?sslmode=allow"
+```
+
+### Database password
+
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+```bash
+kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE
+```
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: WORKBENCH_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+`--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
+
 ## General principles
 
 - In most places, we opt to pass Helm values directly into ConfigMaps. We automatically translate these into the


### PR DESCRIPTION
This PR relates to https://github.com/rstudio/helm/issues/422 by providing customers guidance on how to configure and set database passwords consistently and in a Kubernetes-friendly way across products.

The docs added show how to configure the database and set up PostgreSQL database passwords as env variables from K8s secrets in Workbench. This is now possible since Workbench supports setting the [database password as an env variable](https://docs.posit.co/ide/server-pro/database/configuration.html#environment-variables) in the 2024.04.0 release. Similar changes are being submitted for each of the products.

Currently, admins need to either set the password in the values or imperatively during helm install. Both are not very k8s native ways of doing things.

This PR is already inflight for Admin install doc changes: https://github.com/rstudio/rstudio-pro/pull/6316