### PR TITLE
enable the new prometheus endpoint for Connect

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.6.7
+version: 0.7.0
 apiVersion: v2
 appVersion: 2024.04.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -6,8 +6,8 @@
   - We are now using an internal prometheus endpoint with all new metrics
   - As a result, the `graphiteExporter` sidecar has been removed
   - Some metrics from the `graphiteExporter` will no longer be present
-  - There is also a new "off-switch" for prometheus at `prometheus.enabled=true`
-  - To revert to old behavior, set `legacyPrometheus=true` (and please reach out to let us know why!)
+  - The parent / main "off-switch" for prometheus is at `prometheus.enabled`
+  - To revert to the old exporter, set `prometheus.legacy=true` (and please reach out to let us know why!)
 
 ## 0.6.7
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.0
+
+- BREAKING: the prometheus endpoint has changed from port `9108` to `3232` by default
+  - We are now using an internal prometheus endpoint with all new metrics
+  - As a result, the `graphiteExporter` sidecar has been removed
+  - Some metrics from the `graphiteExporter` will no longer be present
+  - There is also a new "off-switch" for prometheus at `prometheus.enabled=true`
+  - To revert to old behavior, set `legacyPrometheus=true` (and please reach out to let us know why!)
+
 ## 0.6.7
 
 - Documentation site updates

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![AppVersion: 2024.04.1](https://img.shields.io/badge/AppVersion-2024.04.1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 2024.04.1](https://img.shields.io/badge/AppVersion-2024.04.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.6.7:
+To install the chart with the release name `my-release` at version 0.7.0:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.6.7
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.0
 ```
 
 To explore other chart versions, look at:
@@ -142,6 +142,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"command":[],"containerSecurityContext":{},"defaultSecurityContext":{},"env":[],"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"priorityClassName":"","securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the Posit Connect session templating process |
 | launcher.templateValues.pod.command | list | `[]` | command for all pods. This is really not something we should expose and will be removed once we have a better option |
 | launcher.useTemplates | bool | `true` | Whether to use launcher templates when launching sessions. Defaults to true |
+| legacyPrometheus | bool | `false` | Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. Takes precedence over    prometheusExporter.enabled |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
 | license.file.contents | bool | `false` | contents is an in-line license file |
 | license.file.mountPath | string | `"/etc/rstudio-licensing"` | mountPath is the place the license file will be mounted into the container |
@@ -166,6 +167,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.volumes | list | `[]` | An array of maps that is injected as-is into the "volumes:" component of the pod spec |
 | podDisruptionBudget | object | `{}` | Pod disruption budget |
 | priorityClassName | string | `""` | The pod's priorityClassName |
+| prometheus | object | `{"enabled":true,"port":3232}` | Whether to enable prometheus metrics in the product |
 | prometheusExporter.enabled | bool | `true` | Whether the  prometheus exporter sidecar should be enabled |
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -142,7 +142,6 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"command":[],"containerSecurityContext":{},"defaultSecurityContext":{},"env":[],"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"priorityClassName":"","securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the Posit Connect session templating process |
 | launcher.templateValues.pod.command | list | `[]` | command for all pods. This is really not something we should expose and will be removed once we have a better option |
 | launcher.useTemplates | bool | `true` | Whether to use launcher templates when launching sessions. Defaults to true |
-| legacyPrometheus | bool | `false` | Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. Takes precedence over    prometheusExporter.enabled |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
 | license.file.contents | bool | `false` | contents is an in-line license file |
 | license.file.mountPath | string | `"/etc/rstudio-licensing"` | mountPath is the place the license file will be mounted into the container |
@@ -167,8 +166,10 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.volumes | list | `[]` | An array of maps that is injected as-is into the "volumes:" component of the pod spec |
 | podDisruptionBudget | object | `{}` | Pod disruption budget |
 | priorityClassName | string | `""` | The pod's priorityClassName |
-| prometheus | object | `{"enabled":true,"port":3232}` | Whether to enable prometheus metrics in the product |
-| prometheusExporter.enabled | bool | `true` | Whether the  prometheus exporter sidecar should be enabled |
+| prometheus.enabled | bool | `true` | The parent setting for whether to enable prometheus metrics. Default is to use the built-in product exporter |
+| prometheus.legacy | bool | `false` | Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. If you change this to `true`, please let us know why! Requires prometheusExporter.enabled=true too |
+| prometheus.port | int | `3232` | The port that prometheus will listen on. If legacy=true, then this will be hard-coded to 9108 |
+| prometheusExporter.enabled | bool | `true` | DEPRECATED. Whether the  prometheus exporter sidecar should be enabled. See prometheus.enabled instead. |
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -62,8 +62,8 @@ Please consider removing this configuration value.
 
 {{- end }}
 
-{{- if and (hasKey .Values.config.Metrics "GraphiteEnabled") (not .Values.legacyPrometheus) }}
+{{- if and (hasKey .Values.config.Metrics "GraphiteEnabled") (not .Values.prometheus.legacy) }}
 
-{{- print "\n\n`config.Metrics.GraphiteEnabled` is overwritten by `legacyPrometheus=false`. Internal Connect Prometheus will be used instead." }}
+{{- print "\n\n`config.Metrics.GraphiteEnabled` is overwritten by `prometheus.legacy=false`. Internal Connect Prometheus will be used instead." }}
 
 {{- end }}

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -61,3 +61,9 @@ Please consider removing this configuration value.
 {{- fail "\n\n`pod.nodeSelector` is no longer used. Use `nodeSelector` instead!\nThis is more consistent with other charts and the community." }}
 
 {{- end }}
+
+{{- if and (hasKey .Values.config.Metrics "GraphiteEnabled") (not .Values.legacyPrometheus) }}
+
+{{- print "\n\n`config.Metrics.GraphiteEnabled` is overwritten by `legacyPrometheus=false`. Internal Connect Prometheus will be used instead." }}
+
+{{- end }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -85,8 +85,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.prometheus.enabled }}
     {{- if .Values.prometheus.legacy }}
       {{- /* we set the graphite values as a default, to hide from values.yaml */ -}}
-      {{- $graphiteDict := dict ("Metrics" (dict "Enabled" true "GraphiteClientId" "rsconnect" "GraphiteEnabled" true))}}
-      {{- $graphiteDict = merge $graphiteDict (dict ("Metrics" ("GraphiteHost" "127.0.0.1" "GraphitePort" "9109")))}}
+      {{- $graphiteDict := dict "Metrics" (dict "Enabled" true "GraphiteClientId" "rsconnect" "GraphiteEnabled" true) }}
+      {{- $graphiteDict = merge $graphiteDict (dict "Metrics" (dict "GraphiteHost" "127.0.0.1" "GraphitePort" "9109")) }}
       {{- $defaultConfig = merge $defaultConfig $graphiteDict }}
     {{- else }}
       {{- if hasKey $configCopy "Metrics" }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -83,7 +83,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end }}
   {{- /* default metrics / prometheus configuration */}}
   {{- if .Values.prometheus.enabled }}
-    {{- if .Values.legacyPrometheus }}
+    {{- if .Values.prometheus.legacy }}
       {{- /* we set the graphite values as a default, to hide from values.yaml */ -}}
       {{- $graphiteDict := dict ("Metrics" (dict "Enabled" true "GraphiteClientId" "rsconnect" "GraphiteEnabled" true))}}
       {{- $graphiteDict = merge $graphiteDict (dict ("Metrics" ("GraphiteHost" "127.0.0.1" "GraphitePort" "9109")))}}

--- a/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
+++ b/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
+{{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
+++ b/charts/rstudio-connect/templates/configmap-graphite-exporter.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusExporter.enabled }}
+{{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -20,14 +20,20 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
         checksum/config-graphite: {{ include (print $.Template.BasePath "/configmap-graphite-exporter.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.launcher.enabled }}
         checksum/config-prestart: {{ include (print $.Template.BasePath "/configmap-prestart.yaml") . | sha256sum }}
         {{- end }}
-      {{- if .Values.prometheusExporter.enabled }}
+      {{- if .Values.prometheus }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
+        {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
         prometheus.io/port: "9108"
+        {{- else }}
+        prometheus.io/port: {{ .Values.prometheus.port | quote }}
+        {{- end }}
       {{- end }}
 {{ include "rstudio-connect.pod.annotations" . | indent 8 }}
       labels:
@@ -118,6 +124,11 @@ spec:
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         ports:
         - containerPort: {{ .Values.pod.port }}
+          name: http
+        {{- if and .Values.prometheus.enabled (not .Values.legacyPrometheus) }}
+        - containerPort: {{ .Values.prometheus.port }}
+          name: metrics
+        {{- end}}
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -187,7 +198,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- if .Values.prometheusExporter.enabled }}
+      {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
       - name: exporter
         image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
         imagePullPolicy: "{{ .Values.prometheusExporter.image.imagePullPolicy }}"
@@ -220,7 +231,7 @@ spec:
           claimName: {{default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
       {{- end }}
       {{ include "rstudio-library.license-volume" (dict "license" ( .Values.license ) "fullName" (include "rstudio-connect.fullname" .)) | indent 6 }}
-      {{- if .Values.prometheusExporter.enabled }}
+      {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
       - name: graphite-exporter-config
         configMap:
           name: {{ include "rstudio-connect.fullname" . }}-graphite

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
+        {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
         checksum/config-graphite: {{ include (print $.Template.BasePath "/configmap-graphite-exporter.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.launcher.enabled }}
@@ -29,7 +29,7 @@ spec:
       {{- if .Values.prometheus }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
+        {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
         prometheus.io/port: "9108"
         {{- else }}
         prometheus.io/port: {{ .Values.prometheus.port | quote }}
@@ -125,7 +125,7 @@ spec:
         ports:
         - containerPort: {{ .Values.pod.port }}
           name: http
-        {{- if and .Values.prometheus.enabled (not .Values.legacyPrometheus) }}
+        {{- if and .Values.prometheus.enabled (not .Values.prometheus.legacy) }}
         - containerPort: {{ .Values.prometheus.port }}
           name: metrics
         {{- end}}
@@ -198,7 +198,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
+      {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
       - name: exporter
         image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
         imagePullPolicy: "{{ .Values.prometheusExporter.image.imagePullPolicy }}"
@@ -231,7 +231,7 @@ spec:
           claimName: {{default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
       {{- end }}
       {{ include "rstudio-library.license-volume" (dict "license" ( .Values.license ) "fullName" (include "rstudio-connect.fullname" .)) | indent 6 }}
-      {{- if and .Values.legacyPrometheus .Values.prometheusExporter.enabled }}
+      {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
       - name: graphite-exporter-config
         configMap:
           name: {{ include "rstudio-connect.fullname" . }}-graphite

--- a/charts/rstudio-connect/templates/service-monitor.yaml
+++ b/charts/rstudio-connect/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheusExporter.enabled .Values.serviceMonitor.enabled -}}
+{{- if and .Values.prometheus.enabled .Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -30,5 +30,11 @@ spec:
     targetPort: {{ .Values.service.targetPort }}
   {{- if .Values.prometheus.enabled }}
   - name: metrics
+    targetPort: metrics
+    {{- if .Values.prometheus.legacy }}
+    port: 9108
+    {{- else }}
+    port: {{ .Values.prometheus.port }}
+    {{- end }}
   {{- end }}
 ---

--- a/charts/rstudio-connect/templates/svc.yaml
+++ b/charts/rstudio-connect/templates/svc.yaml
@@ -17,7 +17,7 @@ spec:
 {{- end }}
 {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-{{- end }}  
+{{- end }}
   selector:
     {{- include "rstudio-connect.selectorLabels" . | nindent 4 }}
   ports:
@@ -28,8 +28,7 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
     targetPort: {{ .Values.service.targetPort }}
-  {{- if .Values.prometheusExporter.enabled }}
+  {{- if .Values.prometheus.enabled }}
   - name: metrics
-    port: 9108
   {{- end }}
 ---

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -159,6 +159,14 @@ license:
 securityContext:
   privileged: true
 
+# -- Whether to enable prometheus metrics in the product
+prometheus:
+  enabled: true
+  port: 3232
+
+# -- Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. Takes precedence over
+#    prometheusExporter.enabled
+legacyPrometheus: false
 prometheusExporter:
   # -- Whether the  prometheus exporter sidecar should be enabled
   enabled: true
@@ -357,7 +365,3 @@ config:
     AccessLogFormat: COMMON  # COMMON, COMBINED, or JSON
   Metrics:
     Enabled: true
-    GraphiteEnabled: true
-    GraphiteHost: 127.0.0.1
-    GraphitePort: 9109
-    GraphiteClientId: rsconnect

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -159,16 +159,17 @@ license:
 securityContext:
   privileged: true
 
-# -- Whether to enable prometheus metrics in the product
 prometheus:
+  # -- The parent setting for whether to enable prometheus metrics. Default is to use the built-in product exporter
   enabled: true
+  # -- The port that prometheus will listen on. If legacy=true, then this will be hard-coded to 9108
   port: 3232
+  # -- Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. If you change this to
+  # `true`, please let us know why! Requires prometheusExporter.enabled=true too
+  legacy: false
 
-# -- Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. Takes precedence over
-#    prometheusExporter.enabled
-legacyPrometheus: false
 prometheusExporter:
-  # -- Whether the  prometheus exporter sidecar should be enabled
+  # -- DEPRECATED. Whether the  prometheus exporter sidecar should be enabled. See prometheus.enabled instead.
   enabled: true
   # -- Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
   mappingYaml: null


### PR DESCRIPTION
Add a new .prometheus.enabled flag (defaults true) and a .legacyPrometheus flag (defaults false) to revert to old behavior. A simple `legacyPrometheus=true` should revert back to backwards-compatible behavior, but we want folks to switch to the new endpoint, so that is the new default!

Also removed the default / graphite values from the `values.yaml` file for simplicity. As per usual, settings that a user sets in our `.Values.config` will take precedence over convenience helpers like `prometheus.port`