### PR TITLE
Bump Connect version to 2024.05.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.7.1
+version: 0.7.2
 apiVersion: v2
-appVersion: 2024.04.1
+appVersion: 2024.05.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:ubuntu2204-2024.04.1
+      image: rstudio/rstudio-connect:ubuntu2204-2024.05.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -5,6 +5,8 @@
 - Bump Connect version to 2024.05.0
 - BREAKING: local execution only
   - Default installed R versions upgraded to 4.4.0 and 4.3.3.
+- Enable TensorFlow by default in `values.yaml` when running in local or
+  off-host execution mode.
 
 ## 0.7.1
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2
+
+- Bump Connect version to 2024.05.0
+- BREAKING: local execution only
+  - Default installed R versions upgraded to 4.4.0 and 4.3.3.
+
 ## 0.7.1
 
 - Add documentation about PostgreSQL database configuration and mounting passwords from secrets as env variables

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 2024.04.1](https://img.shields.io/badge/AppVersion-2024.04.1-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![AppVersion: 2024.04.1](https://img.shields.io/badge/AppVersion-2024.04.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.1:
+To install the chart with the release name `my-release` at version 0.7.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.1
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -348,8 +348,8 @@ config:
     # For Off-Host Execution, Python versions are defined by the set of Execution Environments
     # https://docs.posit.co/connect/admin/python/
     Executable:
-      - /opt/python/3.9.17/bin/python
-      - /opt/python/3.8.17/bin/python
+      - /opt/python/3.12.1/bin/python
+      - /opt/python/3.11.7/bin/python
   Quarto:
     Enabled: true
     # Note: The `Executable` listed below is only used for Local Execution.

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -356,6 +356,12 @@ config:
     # For Off-Host Execution, Quarto versions are defined by the set of Execution Environments
     # https://docs.posit.co/connect/admin/quarto/
     Executable: "/opt/quarto/1.4.552/bin/quarto"
+  TensorFlow:
+    Enabled: true
+    # Note: The `Executable` listed below is only used for Local Execution.
+    # For Off-Host Execution, TensorFlow versions are defined by the set of Execution Environments
+    # https://docs.posit.co/connect/admin/tensorflow/
+    Executable: "/usr/bin/tensorflow_model_server"
   Scheduler:
     InitTimeout: 5m
   Logging:


### PR DESCRIPTION
- Upgrade default R versions for local execution to 4.4.0 and 4.3.3
- Upgrade default Python versions for local execution to 3.12.1 and 3.11.7
- Enable Tensorflow by default for local and off-host execution

Fixes #513