### PR TITLE
Bump Workbench to 2024.04.2

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.7.5
+version: 0.7.6
 apiVersion: v2
-appVersion: 2024.04.0
+appVersion: 2024.04.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.04.0
+      image: rstudio/rstudio-workbench:ubuntu2204-2024.04.2
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.04.0
+      image: rstudio/r-session-complete:ubuntu2204-2024.04.2
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.6
+
+- Bump Workbench version to 2024.04.2
+
 ## 0.7.5
 
 - Add documentation about PostgreSQL database configuration and mounting passwords from secrets as env variables

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![AppVersion: 2024.04.0](https://img.shields.io/badge/AppVersion-2024.04.0-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.5:
+To install the chart with the release name `my-release` at version 0.7.6:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.5
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.6
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
Closes #512 (upgrades to 2024.04.2, bypassing 2024.04.1)