### PR TITLE
Enable the new prometheus endpoint for Workbench

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.7.6
+version: 0.8.0
 apiVersion: v2
 appVersion: 2024.04.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -3,7 +3,7 @@
 ## 0.8.0
 
 - BREAKING: the prometheus endpoint has changed from port `9108` to `8989` by default
-  - We are now using an internal prometheus endpoint with all new metrics
+  - We are now using an internal prometheus endpoint with new metrics
   - As a result, the `graphiteExporter` sidecar has been removed
   - Some metrics from the `graphiteExporter` will no longer be present
   - The parent / main "off-switch" for prometheus is at `prometheus.enabled`

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.8.0
+
+- BREAKING: the prometheus endpoint has changed from port `9108` to `8989` by default
+  - We are now using an internal prometheus endpoint with all new metrics
+  - As a result, the `graphiteExporter` sidecar has been removed
+  - Some metrics from the `graphiteExporter` will no longer be present
+  - The parent / main "off-switch" for prometheus is at `prometheus.enabled`
+  - To revert to the old exporter, set `prometheus.legacy=true` (and please reach out to let us know why!)
+
 ## 0.7.6
 
 - Bump Workbench version to 2024.04.2

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.6:
+To install the chart with the release name `my-release` at version 0.8.0:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.7.6
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.0
 ```
 
 To explore other chart versions, look at:
@@ -533,7 +533,10 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | pod.volumes | list | `[]` | volumes is injected as-is into the "volumes:" component of the pod.container spec |
 | podDisruptionBudget | object | `{}` | Pod disruption budget |
 | priorityClassName | string | `""` | The pod's priorityClassName |
-| prometheusExporter.enabled | bool | `true` | whether the  prometheus exporter sidecar should be enabled |
+| prometheus.enabled | bool | `true` | The parent setting for whether to enable prometheus metrics. Default is to use the built-in product exporter |
+| prometheus.legacy | bool | `false` | Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. If you change this to `true`, please let us know why! Requires prometheusExporter.enabled=true too |
+| prometheus.port | int | `8989` | The port that prometheus will listen on. If legacy=true, then this will be hard-coded to 9108 |
+| prometheusExporter.enabled | bool | `true` | DEPRECATED. Whether the prometheus exporter sidecar should be enabled. See prometheus.enabled instead. |
 | prometheusExporter.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | prometheusExporter.image.repository | string | `"prom/graphite-exporter"` |  |
 | prometheusExporter.image.tag | string | `"v0.9.0"` |  |

--- a/charts/rstudio-workbench/templates/NOTES.txt
+++ b/charts/rstudio-workbench/templates/NOTES.txt
@@ -52,3 +52,9 @@ Please consider removing this configuration value.
 {{- if .Values.serviceAccountName }}
   {{- fail "\n\n`serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead"}}
 {{- end }}
+
+{{- if and (hasKey (get .Values.config.server "rserver.conf") "monitor-graphite-enabled") (not .Values.prometheus.legacy) }}
+
+{{- print "\n\n`config.server.'rserver/.conf'.monitor-graphite-enabled` is overwritten by `prometheus.legacy=false`. Internal Workbench Prometheus will be used instead." }}
+
+{{- end }}

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -89,6 +89,10 @@ containers:
   ports:
   - containerPort: 8787
     name: http
+  {{- if and .Values.prometheus.enabled (not .Values.prometheus.legacy) }}
+  - containerPort: {{ .Values.prometheus.port }}
+    name: metrics
+  {{- end}}
   securityContext:
     {{- toYaml .Values.securityContext | nindent 4 }}
   volumeMounts:
@@ -206,7 +210,7 @@ containers:
       {{- toYaml . | nindent 10 }}
     {{- end }}
   {{- end }}
-{{- if .Values.prometheusExporter.enabled }}
+{{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
 - name: exporter
   image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
   imagePullPolicy: "{{ .Values.prometheusExporter.image.imagePullPolicy }}"
@@ -310,7 +314,7 @@ volumes:
     defaultMode: {{ .Values.config.defaultMode.userProvisioning }}
 {{- end }}
 {{ include "rstudio-library.license-volume" (dict "license" ( .Values.license ) "fullName" (include "rstudio-workbench.fullname" .)) }}
-{{- if .Values.prometheusExporter.enabled }}
+{{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
 - name: graphite-exporter-config
   configMap:
     name: {{ include "rstudio-workbench.fullname" . }}-graphite

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -70,6 +70,24 @@ data:
   {{- $overrideDict = mergeOverwrite $licenseServerConf $overrideDict }}
 {{- end }}
 {{- $overrideDict = mergeOverwrite $defaultRServerConfig $overrideDict }}
+{{- /* default metrics / prometheus configuration */}}
+  {{- if .Values.prometheus.enabled }}
+    {{- if .Values.prometheus.legacy }}
+      {{- /* we set the graphite values as a default, to hide from values.yaml */ -}}
+      {{- $graphiteDict := dict "rserver.conf" (dict "monitor-graphite-enabled" 1 "monitor-graphite-host" "127.0.0.1" "monitor-graphite-port" 9109 "monitor-graphite-client-id" "rstudio") }}
+      {{- $overrideDict = mergeOverwrite $graphiteDict $overrideDict }}
+    {{- else }}
+      {{- if hasKey $overrideDict "rserver.conf" }}
+        {{- if hasKey (get $overrideDict "rserver.conf") "monitor-graphite-enabled" }}
+          {{- /* we explicitly overwrite the graphite endpoint */ -}}
+          {{- $overrideDict = mergeOverwrite $overrideDict (dict "rserver.conf" (dict "monitor-graphite-enabled" "0")) }}
+        {{- end }}
+      {{- end }}
+
+      {{- /* and set a default for the prometheus listener */ -}}
+      {{- $overrideDict = merge $overrideDict (dict "rserver.conf" ( dict "metrics-enabled" 1 "metrics-port" .Values.prometheus.port))}}
+    {{- end }}
+  {{- end }}
 {{- $overrideDict = mergeOverwrite $defaultLauncherK8sConfig $overrideDict }}
 {{ include "rstudio-library.config.ini" $overrideDict | indent 2 }}
 {{/* helper variables to make things here a bit more sane */}}

--- a/charts/rstudio-workbench/templates/configmap-graphite-exporter.yaml
+++ b/charts/rstudio-workbench/templates/configmap-graphite-exporter.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusExporter.enabled }}
+{{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -21,15 +21,21 @@ spec:
     metadata:
       annotations:
         checksum/config-general: {{ include (print $.Template.BasePath "/configmap-general.yaml") . | sha256sum }}
+        {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
         checksum/config-graphite: {{ include (print $.Template.BasePath "/configmap-graphite-exporter.yaml") . | sha256sum }}
+        {{- end }}
         checksum/config-prestart: {{ include (print $.Template.BasePath "/configmap-prestart.yaml") . | sha256sum }}
         checksum/config-secret: {{ include (print $.Template.BasePath "/configmap-secret.yaml") . | sha256sum }}
         checksum/config-session: {{ include (print $.Template.BasePath "/configmap-session.yaml") . | sha256sum }}
-        {{- if .Values.prometheusExporter.enabled }}
+      {{- if .Values.prometheus }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
+        {{- if and .Values.prometheus.legacy .Values.prometheusExporter.enabled }}
         prometheus.io/port: "9108"
+        {{- else }}
+        prometheus.io/port: {{ .Values.prometheus.port | quote }}
         {{- end }}
+      {{- end }}
         {{- include "rstudio-workbench.pod.annotations" . | nindent 8 }}
       labels:
         {{- include "rstudio-workbench.selectorLabels" . | nindent 8 }}

--- a/charts/rstudio-workbench/templates/service-monitor.yaml
+++ b/charts/rstudio-workbench/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheusExporter.enabled .Values.serviceMonitor.enabled -}}
+{{- if and .Values.prometheus.enabled .Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/rstudio-workbench/templates/svc.yaml
+++ b/charts/rstudio-workbench/templates/svc.yaml
@@ -28,7 +28,12 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
     targetPort: 8787
-  {{- if .Values.prometheusExporter.enabled }}
+  {{- if .Values.prometheus.enabled }}
   - name: metrics
+    targetPort: metrics
+    {{- if .Values.prometheus.legacy }}
     port: 9108
+    {{- else }}
+    port: {{ .Values.prometheus.port }}
+    {{- end }}
   {{- end }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -321,8 +321,17 @@ pod:
   # -- The termination grace period seconds allowed for the pod before shutdown
   terminationGracePeriodSeconds: 120
 
+prometheus:
+  # -- The parent setting for whether to enable prometheus metrics. Default is to use the built-in product exporter
+  enabled: true
+  # -- The port that prometheus will listen on. If legacy=true, then this will be hard-coded to 9108
+  port: 8989
+  # -- Whether to enable the legacy prometheusExporter INSTEAD OF the built-in product exporter. If you change this to
+  # `true`, please let us know why! Requires prometheusExporter.enabled=true too
+  legacy: false
+
 prometheusExporter:
-  # -- whether the  prometheus exporter sidecar should be enabled
+  # -- DEPRECATED. Whether the prometheus exporter sidecar should be enabled. See prometheus.enabled instead.
   enabled: true
   # -- Yaml that defines the graphite exporter mapping. null by default, which uses the embedded / default mapping yaml file
   mappingYaml: null
@@ -435,10 +444,6 @@ config:
       launcher-port: 5559
       launcher-sessions-enabled: 1
       launcher-default-cluster: Kubernetes
-      monitor-graphite-enabled: 1
-      monitor-graphite-host: 127.0.0.1
-      monitor-graphite-port: 9109
-      monitor-graphite-client-id: rstudio
     launcher.conf:
       server:
         address: 127.0.0.1


### PR DESCRIPTION
This PR follows closely what @colearendt did for Connect here: https://github.com/rstudio/helm/pull/516
Closes: https://github.com/rstudio/helm/issues/490

Add a new .prometheus.enabled flag (defaults true) and a .legacyPrometheus flag (defaults false) to revert to old behavior. A simple `legacyPrometheus=true` should revert back to backwards-compatible behavior, but we want folks to switch to the new endpoint, so that is the new default!

Also removed the default / graphite values from the `values.yaml` file for simplicity. As per usual, settings that a user sets in our `.Values.config` will take precedence over convenience helpers like `prometheus.port`