### PR TITLE
Update chronicle version to 2024.09.0

### DIFF
--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Rebuild index.yaml
         env:
           version: v1.2.1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ ! -d "$RUNNER_TOOL_CACHE" ]]; then
               echo "Cache directory '$RUNNER_TOOL_CACHE' does not exist" >&2

--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: posit-chronicle
 description: Official Helm chart for Posit Chronicle Server
-version: 0.3.1
-appVersion: 2024.03.0
+version: 0.3.2
+appVersion: 2024.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.posit.co
 sources:

--- a/charts/posit-chronicle/NEWS.md
+++ b/charts/posit-chronicle/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+- Bump Chronicle to version 2024.09.0
+
 ## 0.3.1
 
 - Documentation site updates

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -179,7 +179,7 @@ The credentials Chronicle uses for S3 storage must have the following permission
 | config.S3Storage.Region | string | `"us-east-2"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/rstudio/chronicle"` |  |
-| image.tag | string | `"2024.03.0"` |  |
+| image.tag | string | `"2024.09.0"` |  |
 | nodeSelector | object | `{}` | A map used verbatim as the pod's "nodeSelector" definition |
 | pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the chronicle-server pods |

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -1,6 +1,6 @@
 # Posit Chronicle
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: 2024.03.0](https://img.shields.io/badge/AppVersion-2024.03.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![AppVersion: 2024.09.0](https://img.shields.io/badge/AppVersion-2024.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Chronicle Server_
 
@@ -25,11 +25,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.3.1:
+To install the chart with the release name `my-release` at version 0.3.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.1
+helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.2
 ```
 
 To explore other chart versions, look at:
@@ -60,7 +60,7 @@ pod:
       mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"
@@ -76,7 +76,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/posit-chronicle/README.md.gotmpl
+++ b/charts/posit-chronicle/README.md.gotmpl
@@ -30,7 +30,7 @@ pod:
       mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"
@@ -46,7 +46,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/posit-chronicle/values.yaml
+++ b/charts/posit-chronicle/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: "ghcr.io/rstudio/chronicle"
-  tag: "2024.03.0"
+  tag: "2024.09.0"
   imagePullPolicy: "IfNotPresent"
 
 serviceaccount:

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.7.6
+version: 0.7.7
 apiVersion: v2
 appVersion: 2024.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.8
+
+- Bump Chronicle Agent to version 2024.09.0
 
 ## 0.7.7
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.7
+
+- Add helm values for `pod.hostAliases` and `launcher.templateValues.pod.hostAliases`
+- Add helm values for `launcher.defaultInitContainer.resources`
+
 ## 0.7.6
 
 - Bump Connect version to 2024.08.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -31,9 +31,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 ## Installing the chart
 
 To install the chart with the release name `my-release` at version 0.7.7:
+To install the chart with the release name `my-release` at version 0.7.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
 helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
 ```
 

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.8:
+To install the chart with the release name `my-release` at version 0.7.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.8
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -30,13 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.7:
-To install the chart with the release name `my-release` at version 0.7.7:
+To install the chart with the release name `my-release` at version 0.7.8:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.8
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.6:
+To install the chart with the release name `my-release` at version 0.7.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.6
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
 ```
 
 To explore other chart versions, look at:
@@ -166,10 +166,11 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
 | launcher.additionalRuntimeImages | list | `[]` | Optional. Additional images to append to the end of the "launcher.customRuntimeYaml" (in the "images" key). If `customRuntimeYaml` is a "map", then "additionalRuntimeImages" will only be used if it is a "list". |
 | launcher.customRuntimeYaml | string | `"base"` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "base", which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. If set to "pro", will pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the cost of a larger image). Starting with Connect v2023.05.0, this configuration is used to bootstrap the initial set of execution environments the first time the server starts. If any execution environments already exist in the database, these values are ignored; execution environments are not created or modified during subsequent restarts. |
-| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","securityContext":{},"tag":"","tagPrefix":"ubuntu2204-"}` | Image definition for the default Posit Connect Content InitContainer |
+| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","resources":{},"securityContext":{},"tag":"","tagPrefix":"ubuntu2204-"}` | Image definition for the default Posit Connect Content InitContainer |
 | launcher.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. |
 | launcher.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |
 | launcher.defaultInitContainer.repository | string | `"ghcr.io/rstudio/rstudio-connect-content-init"` | The repository to use for the Content InitContainer image |
+| launcher.defaultInitContainer.resources | object | `{}` | Optional resources for the default initContainer |
 | launcher.defaultInitContainer.securityContext | object | `{}` | The securityContext for the default initContainer |
 | launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | launcher.defaultInitContainer.tagPrefix | string | `"ubuntu2204-"` | A tag prefix for the Content InitContainer image (common selections: jammy-, ubuntu2204-). Only used if tag is not defined |
@@ -179,7 +180,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | launcher.includeTemplateValues | bool | `true` | whether to include the templateValues rendering process |
 | launcher.launcherKubernetesProfilesConf | object | `{}` | User definition of launcher.kubernetes.profiles.conf for job customization |
 | launcher.namespace | string | `""` | The namespace to launch sessions into. Uses the Release namespace by default |
-| launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"command":[],"containerSecurityContext":{},"defaultSecurityContext":{},"env":[],"extraContainers":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"priorityClassName":"","securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the Posit Connect session templating process |
+| launcher.templateValues | object | `{"job":{"annotations":{},"labels":{}},"pod":{"affinity":{},"annotations":{},"command":[],"containerSecurityContext":{},"defaultSecurityContext":{},"env":[],"extraContainers":[],"hostAliases":[],"imagePullPolicy":"","imagePullSecrets":[],"initContainers":[],"labels":{},"nodeSelector":{},"priorityClassName":"","securityContext":{},"serviceAccountName":"","tolerations":[],"volumeMounts":[],"volumes":[]},"service":{"annotations":{},"labels":{},"type":"ClusterIP"}}` | Values to pass along to the Posit Connect session templating process |
 | launcher.templateValues.pod.command | list | `[]` | command for all pods. This is really not something we should expose and will be removed once we have a better option |
 | launcher.useTemplates | bool | `true` | Whether to use launcher templates when launching sessions. Defaults to true |
 | license.file | object | `{"contents":false,"mountPath":"/etc/rstudio-licensing","mountSubPath":false,"secret":false,"secretKey":"license.lic"}` | the file section is used for licensing with a license file |
@@ -197,6 +198,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-connect pods |
 | pod.env | list | `[]` | An array of maps that is injected as-is into the "env:" component of the pod.container spec |
 | pod.haste | bool | `true` | A helper that defines the RSTUDIO_CONNECT_HASTE environment variable |
+| pod.hostAliases | list | `[]` | Array of hostnames to supply to the main pod |
 | pod.labels | object | `{}` | Additional labels to add to the rstudio-connect pods |
 | pod.port | int | `3939` | The containerPort used by the main pod container |
 | pod.securityContext | object | `{}` | Values to set the `securityContext` for the connect pod |

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -50,7 +50,7 @@ pod:
       imagePullPolicy: "IfNotPresent"
     # This will spin up the chronicle-agent sidecar container
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -78,6 +78,10 @@ spec:
       {{- if or $templateData.pod.serviceAccountName .Job.serviceAccountName }}
       serviceAccountName: {{ .Job.serviceAccountName | default $templateData.pod.serviceAccountName | quote }}
       {{- end }}
+      {{- with $templateData.pod.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       shareProcessNamespace: {{ .Job.shareProcessNamespace }}
       {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumes) 0) }}
       volumes:

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -23,9 +23,10 @@ data:
       {{- $initContainerImageTag := .Values.launcher.defaultInitContainer.tag | default (printf "%s%s" .Values.launcher.defaultInitContainer.tagPrefix $defaultVersion )}}
       {{- $initContainerImage := print .Values.launcher.defaultInitContainer.repository ":" ( $initContainerImageTag ) }}
       {{- $initContainerPullPolicy := default "IfNotPresent" .Values.launcher.defaultInitContainer.imagePullPolicy }}
+      {{- $initContainerResources := .Values.launcher.defaultInitContainer.resources }}
       {{- $initContainerSecurityContext := .Values.launcher.defaultInitContainer.securityContext }}
       {{- $initContainerVolumeMount := dict "name" ("rsc-volume") "mountPath" ("/mnt/rstudio-connect-runtime/") }}
-      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "imagePullPolicy" ($initContainerPullPolicy) "volumeMounts" ( list  $initContainerVolumeMount ) "securityContext" $initContainerSecurityContext }}
+      {{- $initContainerJson := dict "name" ("init") "image" ($initContainerImage) "imagePullPolicy" ($initContainerPullPolicy) "resources" ($initContainerResources) "volumeMounts" ( list  $initContainerVolumeMount ) "securityContext" $initContainerSecurityContext }}
       {{- $jobJsonInitContainer := dict "target" ("/spec/template/spec/initContainers/0") "name" ("defaultInitContainer") "json" $initContainerJson }}
     {{- /* set up job-json defaults */ -}}
       {{- $jobJsonDefaults := list }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.pod.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -127,6 +127,8 @@ pod:
   port: 3939
   # -- The termination grace period seconds allowed for the pod before shutdown
   terminationGracePeriodSeconds: 120
+  # -- Array of hostnames to supply to the main pod
+  hostAliases: []
 
 # -- The pod's run command. By default, it uses the container's default
 command: []
@@ -307,6 +309,7 @@ launcher:
       tolerations: []
       affinity: {}
       nodeSelector: {}
+      hostAliases: []
       priorityClassName: ""
       # -- command for all pods. This is really not something we should expose and will be removed once we have a better option
       command: []
@@ -325,6 +328,14 @@ launcher:
     tag: ""
     # -- The imagePullPolicy for the default initContainer
     imagePullPolicy: ""
+  # -- Optional resources for the default initContainer
+    resources: {}
+      # requests:
+      #   cpu: "128m"
+      #   memory: "128Mi"
+      # limits:
+      #   cpu: "512m"
+      #   memory: "512Mi"
     # -- The securityContext for the default initContainer
     securityContext: {}
 

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.30
+version: 0.5.31
 apiVersion: v2
 appVersion: 2024.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.31
+- Bump Chronicle Agent to version 2024.09.0
+
 ## 0.5.30
 
 - Update default Posit Package Manager version to 2024.08.0-6

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.30](https://img.shields.io/badge/Version-0.5.30-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.5.31](https://img.shields.io/badge/Version-0.5.31-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.30:
+To install the chart with the release name `my-release` at version 0.5.31:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.30
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.31
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-pm/ci/all-values.yaml
+++ b/charts/rstudio-pm/ci/all-values.yaml
@@ -79,7 +79,7 @@ priorityClassName: someval
 # Testing with the chronicle-agent sidecar container
 extraContainers:
   - name: chronicle-agent
-    image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+    image: ghcr.io/rstudio/chronicle-agent:2024.09.0
     imagePullPolicy: Always
     env:
     - name: CHRONICLE_SERVER_ADDRESS

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.0
+version: 0.8.1
 apiVersion: v2
 appVersion: 2024.04.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Bump Chronicle Agent to version 2024.09.0
+
 ## 0.8.0
 
 - BREAKING: the prometheus endpoint has changed from port `9108` to `8989` by default

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.0:
+To install the chart with the release name `my-release` at version 0.8.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.0
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -36,7 +36,7 @@ pod:
   # This will spin up the chronicle-agent sidecar container
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"


### PR DESCRIPTION
### Background
Part of the Chronicle release described here: https://github.com/rstudio/chronicle/issues/1067. The Chronicle team has made a new code release and we're updating our helm to match.

### Summary
Updates Chronicle server values
Update our docs
Update the Connect/Workbench/PPM CI files to match these Chronicle updates
This requires bumping up the chart versions for Connect/Workbench/PPM as well