### PR TITLE
Package Manager: Add README section on Database

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.30
+version: 0.5.31
 apiVersion: v2
 appVersion: 2024.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.31
 
-- Add documentation about PostgreSQL database configuration and mounting passwords from secrets as env variable
+- Add documentation about PostgreSQL database configuration and mounting passwords from secrets as an env variable
 
 ## 0.5.30
 

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.31
+
+- Add documentation about PostgreSQL database configuration and mounting passwords from secrets as env variable
+
 ## 0.5.30
 
 - Update default Posit Package Manager version to 2024.08.0-6

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.30](https://img.shields.io/badge/Version-0.5.30-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.5.31](https://img.shields.io/badge/Version-0.5.31-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.30:
+To install the chart with the release name `my-release` at version 0.5.31:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.30
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.31
 ```
 
 To explore other chart versions, look at:
@@ -86,6 +86,46 @@ Alternatively, license files can be set during `helm install` with the following
 ```{.bash}
 --set-file license.file.contents=licenses/rstudio-pm.lic
 ```
+
+## Database
+
+Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/rspm/admin/database/#database-postgres) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `URL` with your database details.
+
+```yaml
+config:
+  Database:
+    Provider: "Postgres"
+  Postgres:
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+```
+
+### Database password
+
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+```bash
+kubectl create secret generic rstudio-pm-database --from-literal=password=YOURPASSWORDHERE
+```
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: PACKAGEMANAGER_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rstudio-pm-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+`--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"`
 
 ## S3 configuration
 

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -33,6 +33,46 @@ This chart requires the following in order to function:
 
 {{ template "rstudio.licensing" . }}
 
+## Database
+
+Package Manager requires a PostgreSQL database when running in Kubernetes. You must configure a [valid connection URI and a password](https://docs.posit.co/rspm/admin/database/#database-postgres) for the product to function correctly. Both the connection URI and password may be specified in the `config` section of `values.yaml`. However, we recommend only adding the connection URI and putting the database password in a Kubernetes `Secret`, which can be [automatically set as an environment variable](#database-password).
+
+### Database configuration
+
+Add the following to your `values.yaml`, replacing the `URL` with your database details.
+
+```yaml
+config:
+  Database:
+    Provider: "Postgres"
+  Postgres:
+    URL: "postgres://<USERNAME>@<HOST>:<PORT>/<DATABASE>"
+```
+
+### Database password
+
+First, create a `Secret` declaratively with YAML or imperatively using the following command (replacing with your actual password):
+
+```bash
+kubectl create secret generic {{ .Name }}-database --from-literal=password=YOURPASSWORDHERE
+```
+
+Second, specify the following in your `values.yaml`:
+
+```yaml
+pod:
+  env:
+    - name: PACKAGEMANAGER_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
+```
+
+Alternatively, database passwords may be set during `helm install` with the following argument:
+
+`--set config.Postgres.Password="<YOUR_PASSWORD_HERE>"`
+
 ## S3 configuration
 
 Package Manager [can be configured to store its data in S3


### PR DESCRIPTION
This PR adds modern instructions for how to configure a Postgres database, including guidance on setting up a secret for the password. This matches the instructions given in the [Kubernetes installation section](https://docs.posit.co/rspm/admin/getting-started/installation/installation-kubernetes/#create-a-secret-containing-a-postgresql-database-password) of the admin guide.

Similar sections were added for [Workbench](https://github.com/rstudio/helm/blob/main/charts/rstudio-workbench/README.md#database) and [Connect](https://github.com/rstudio/helm/blob/main/charts/rstudio-connect/README.md#database).