### PR TITLE
Update chronicle version to 2024.09.0

### DIFF
--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: posit-chronicle
 description: Official Helm chart for Posit Chronicle Server
-version: 0.3.1
-appVersion: 2024.03.0
+version: 0.3.2
+appVersion: 2024.09.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.posit.co
 sources:

--- a/charts/posit-chronicle/NEWS.md
+++ b/charts/posit-chronicle/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+- Bump Chronicle to version 2024.09.0
+
 ## 0.3.1
 
 - Documentation site updates

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -1,6 +1,6 @@
 # Posit Chronicle
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: 2024.03.0](https://img.shields.io/badge/AppVersion-2024.03.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![AppVersion: 2024.09.0](https://img.shields.io/badge/AppVersion-2024.09.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Chronicle Server_
 
@@ -25,11 +25,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.3.1:
+To install the chart with the release name `my-release` at version 0.3.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.1
+helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.2
 ```
 
 To explore other chart versions, look at:
@@ -60,7 +60,7 @@ pod:
       mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"
@@ -76,7 +76,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"
@@ -179,7 +179,7 @@ The credentials Chronicle uses for S3 storage must have the following permission
 | config.S3Storage.Region | string | `"us-east-2"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/rstudio/chronicle"` |  |
-| image.tag | string | `"2024.03.0"` |  |
+| image.tag | string | `"2024.09.0"` |  |
 | nodeSelector | object | `{}` | A map used verbatim as the pod's "nodeSelector" definition |
 | pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the chronicle-server pods |

--- a/charts/posit-chronicle/README.md.gotmpl
+++ b/charts/posit-chronicle/README.md.gotmpl
@@ -30,7 +30,7 @@ pod:
       mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"
@@ -46,7 +46,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/posit-chronicle/values.yaml
+++ b/charts/posit-chronicle/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: "ghcr.io/rstudio/chronicle"
-  tag: "2024.03.0"
+  tag: "2024.09.0"
   imagePullPolicy: "IfNotPresent"
 
 serviceaccount:

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.7.7
+version: 0.7.8
 apiVersion: v2
 appVersion: 2024.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.8
+
+- Bump Chronicle Agent to version 2024.09.0
+
 ## 0.7.7
 
 - Add helm values for `pod.hostAliases` and `launcher.templateValues.pod.hostAliases`

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.7:
+To install the chart with the release name `my-release` at version 0.7.8:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.7
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.8
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/ci/complex-values.yaml
+++ b/charts/rstudio-connect/ci/complex-values.yaml
@@ -50,7 +50,7 @@ pod:
       imagePullPolicy: "IfNotPresent"
     # This will spin up the chronicle-agent sidecar container
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.31
+version: 0.5.32
 apiVersion: v2
 appVersion: 2024.08.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -7,11 +7,6 @@
 
 - Add documentation about PostgreSQL database configuration and mounting passwords from secrets as an env variable
 
-
-## 0.5.31
-
-- Bump Chronicle Agent to version 2024.09.0
-
 ## 0.5.30
 
 - Update default Posit Package Manager version to 2024.08.0-6

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,8 +1,12 @@
 # Changelog
+## 0.5.32
+
+- Bump Chronicle Agent to version 2024.09.0
 
 ## 0.5.31
 
 - Add documentation about PostgreSQL database configuration and mounting passwords from secrets as an env variable
+
 
 ## 0.5.30
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.31](https://img.shields.io/badge/Version-0.5.31-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
+![Version: 0.5.32](https://img.shields.io/badge/Version-0.5.32-informational?style=flat-square) ![AppVersion: 2024.08.0](https://img.shields.io/badge/AppVersion-2024.08.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.31:
+To install the chart with the release name `my-release` at version 0.5.32:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.31
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.32
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-pm/ci/all-values.yaml
+++ b/charts/rstudio-pm/ci/all-values.yaml
@@ -79,7 +79,7 @@ priorityClassName: someval
 # Testing with the chronicle-agent sidecar container
 extraContainers:
   - name: chronicle-agent
-    image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+    image: ghcr.io/rstudio/chronicle-agent:2024.09.0
     imagePullPolicy: Always
     env:
     - name: CHRONICLE_SERVER_ADDRESS

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.0
+version: 0.8.1
 apiVersion: v2
 appVersion: 2024.04.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Bump Chronicle Agent to version 2024.09.0
+
 ## 0.8.0
 
 - BREAKING: the prometheus endpoint has changed from port `9108` to `8989` by default

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 2024.04.2](https://img.shields.io/badge/AppVersion-2024.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.0:
+To install the chart with the release name `my-release` at version 0.8.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.0
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/ci/complex-values.yaml
+++ b/charts/rstudio-workbench/ci/complex-values.yaml
@@ -36,7 +36,7 @@ pod:
   # This will spin up the chronicle-agent sidecar container
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.03.0
+      image: ghcr.io/rstudio/chronicle-agent:2024.09.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"


### PR DESCRIPTION
### Background
Part of the Chronicle release described here: https://github.com/rstudio/chronicle/issues/1067. The Chronicle team has made a new code release and we're updating our helm to match.

### Summary
Updates Chronicle server values
Update our docs
Update the Connect/Workbench/PPM CI files to match these Chronicle updates
This requires bumping up the chart versions for Connect/Workbench/PPM as well