### PR TITLE
Update docs for Package Manager Postgres.UsageDataPassword bug

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.35
+version: 0.5.36
 apiVersion: v2
 appVersion: 2024.08.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.36
+
+- Update PostgreSQL configuration documentation to temporarily work around bug with `Postgres.UsageDataPassword` in Package Manager 2024.08.2.
+
 ## 0.5.35
 
 - Move `pod.containerSecurityContext.fsGroup = 999` to `pod.securityContext.fsGroup` to resolve

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.35](https://img.shields.io/badge/Version-0.5.35-informational?style=flat-square) ![AppVersion: 2024.08.2](https://img.shields.io/badge/AppVersion-2024.08.2-informational?style=flat-square)
+![Version: 0.5.36](https://img.shields.io/badge/Version-0.5.36-informational?style=flat-square) ![AppVersion: 2024.08.2](https://img.shields.io/badge/AppVersion-2024.08.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.35:
+To install the chart with the release name `my-release` at version 0.5.36:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.35
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.36
 ```
 
 To explore other chart versions, look at:
@@ -117,6 +117,14 @@ Second, specify the following in your `values.yaml`:
 pod:
   env:
     - name: PACKAGEMANAGER_POSTGRES_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rstudio-pm-database
+          key: password
+
+    # Temporarily work around bug in Package Manager 2024.08.2 where Postgres.UsageDataPassword
+    # does not default to Postgres.Password. This will be fixed in the next release of Package Manager.
+    - name: PACKAGEMANAGER_POSTGRES_USAGEDATAPASSWORD
       valueFrom:
         secretKeyRef:
           name: rstudio-pm-database

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -67,6 +67,14 @@ pod:
         secretKeyRef:
           name: {{ .Name }}-database
           key: password
+
+    # Temporarily work around bug in Package Manager 2024.08.2 where Postgres.UsageDataPassword
+    # does not default to Postgres.Password. This will be fixed in the next release of Package Manager.
+    - name: PACKAGEMANAGER_POSTGRES_USAGEDATAPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Name }}-database
+          key: password
 ```
 
 Alternatively, database passwords may be set during `helm install` with the following argument:


### PR DESCRIPTION
Same as #561, redoing for CI issue

`Postgres.UsageDataPassword` is supposed to default to `Postgres.Password`, but a bug in recent PPM versions prevents this from working. So as a temporary workaround, the `Postgres.UsageDataPassword` setting must be explicitly set to `Postgres.Password` when using Postgres with usage data enabled.

This will be fixed in the next Package Manager release. The config can be removed after the next release, but it also won't cause any issues if you keep it around for the next release.