### PR TITLE
continue-on-error 'Prevents a job from failing when a step fails.'

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -114,7 +114,6 @@ jobs:
           if [[ $? -ne 0 ]]; then
             echo "failed=true" >> $GITHUB_OUTPUT
           fi
-        continue-on-error: true
 
       # no allow-failure until https://github.com/actions/toolkit/issues/399
       - name: Run chart-testing (install all)
@@ -125,7 +124,6 @@ jobs:
           if [[ $? -ne 0 ]]; then
             echo "failed=true" >> $GITHUB_OUTPUT
           fi
-        continue-on-error: true
 
       - name: Notify Slack of chart install failure
         if: steps.ct-install.outputs.failed == 'true' || steps.ct-install-all.outputs.failed == 'true'


### PR DESCRIPTION
 I'm hoping removing that setting allows the failing steps to trigger notification to slack