### PR TITLE
Add the sealed secrets helm chart to the kind cluster for install testing

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -103,6 +103,12 @@ jobs:
         uses: helm/kind-action@v1.10.0
         if: ${{ steps.list-changed.outputs.changed == 'true' || github.ref == 'refs/heads/main' }}
 
+      - name: Install SealedSecrets Helm Chart
+        if: ${{ steps.list-changed.outputs.changed == 'true' || github.ref == 'refs/heads/main' }}
+        run: |
+          helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+          helm install sealed-secrets sealed-secrets/sealed-secrets
+
       # no allow-failure until https://github.com/actions/toolkit/issues/399
       - name: Run chart-testing (install changed)
         id: ct-install


### PR DESCRIPTION
Will handle other install test failures after this PR is merged