### PR TITLE
Fix: PPM startup probe should wait until web services are available

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.40
+version: 0.5.41
 apiVersion: v2
 appVersion: 2024.08.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.41
+
+- Update the default `pod.startupProbe` to use the `/__api__/status` route instead of `/__ping__` for a more reliable startup.
+
 ## 0.5.40
 
 - Add helm unit test scaffold.

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.40](https://img.shields.io/badge/Version-0.5.40-informational?style=flat-square) ![AppVersion: 2024.08.2](https://img.shields.io/badge/AppVersion-2024.08.2-informational?style=flat-square)
+![Version: 0.5.41](https://img.shields.io/badge/Version-0.5.41-informational?style=flat-square) ![AppVersion: 2024.08.2](https://img.shields.io/badge/AppVersion-2024.08.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -14,7 +14,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
- 
+
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.40:
+To install the chart with the release name `my-release` at version 0.5.41:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.40
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.41
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -14,7 +14,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
-
+ 
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -269,7 +269,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | sharedStorage.selector | object | `{}` | selector for PVC definition |
 | sharedStorage.storageClassName | bool | `false` | storageClassName - the type of storage to use. Must allow ReadWriteMany |
 | sharedStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
-| startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/__ping__","port":4242},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | startupProbe is used to configure the container's startupProbe |
+| startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/__api__/status","port":4242},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | startupProbe is used to configure the container's startupProbe |
 | startupProbe.failureThreshold | int | `30` | failureThreshold * periodSeconds should be strictly > worst case startup time |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"100%","maxUnavailable":0},"type":"RollingUpdate"}` | The update strategy used by the main service pod. |
 | tolerations | list | `[]` | An array used verbatim as the pod's "tolerations" definition |

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -170,7 +170,7 @@ livenessProbe:
 startupProbe:
   enabled: false
   httpGet:
-    path: /__ping__
+    path: /__api__/status
     port: 4242
   initialDelaySeconds: 10
   periodSeconds: 10


### PR DESCRIPTION
This changes the startup probe to use the `__api__/status` route instead of ping for initial readiness. It's more heavyweight, so I left the liveness and readiness probes alone.

Refs: https://github.com/rstudio/package-manager/issues/14644