### PR TITLE
Bump Workbench to 2024.09.1

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.6
+version: 0.8.7
 apiVersion: v2
-appVersion: 2024.09.0
+appVersion: 2024.09.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.09.0
+      image: rstudio/rstudio-workbench:ubuntu2204-2024.09.1
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.09.0
+      image: rstudio/r-session-complete:ubuntu2204-2024.09.1
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.7
+
+- Bump Workbench version to 2024.09.1
+
 ## 0.8.6
 
 - Pin the rstudio-library version dependency so we can update the library chart without breaking all the charts that depend on it.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.6](https://img.shields.io/badge/Version-0.8.6-informational?style=flat-square) ![AppVersion: 2024.09.0](https://img.shields.io/badge/AppVersion-2024.09.0-informational?style=flat-square)
+![Version: 0.8.7](https://img.shields.io/badge/Version-0.8.7-informational?style=flat-square) ![AppVersion: 2024.09.1](https://img.shields.io/badge/AppVersion-2024.09.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.6:
+To install the chart with the release name `my-release` at version 0.8.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.6
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.7
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
I think we'll want to wait until the 2024.09.1 images are available before merging this one. Those images should be built once https://github.com/rstudio/rstudio-docker-products/pull/865 is merged.