### PR TITLE
a single asterisk matches everything except a /.  In order to handle …

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,18 +2,18 @@
 * @rstudio/infraops @rstudio/platform-cloud
 
 # package-manager resources
-/charts/rstudio-pm/* @rstudio/ppm
-/ci/rstudio-pm/* @rstudio/ppm
+/charts/rstudio-pm/** @rstudio/ppm
+/ci/rstudio-pm/** @rstudio/ppm
 
 # connect resources
-/charts/rstudio-connect/* @aronatkins @dbkegley @christierney @zackverham
-/ci/rstudio-connect/* @aronatkins @dbkegley @christierney @zackverham
-/examples/connect/* @aronatkins @dbkegley @christierney @zackverham
+/charts/rstudio-connect/** @aronatkins @dbkegley @christierney @zackverham
+/ci/rstudio-connect/** @aronatkins @dbkegley @christierney @zackverham
+/examples/connect/** @aronatkins @dbkegley @christierney @zackverham
 
 # posit-chronicle resources
-/charts/posit-chronicle/* @matt-urbina @markrtucker @t-margheim
-/ci/posit-chronicle/* @matt-urbina @markrtucker @t-margheim
+/charts/posit-chronicle/** @matt-urbina @markrtucker @t-margheim
+/ci/posit-chronicle/** @matt-urbina @markrtucker @t-margheim
 
 # rstudio-workbench resources
-/charts/rstudio-workbench/* @GCrev @zachhannum
-/ci/rstudio-workbench/* @GCrev @zachhannum
+/charts/rstudio-workbench/** @GCrev @zachhannum
+/ci/rstudio-workbench/** @GCrev @zachhannum


### PR DESCRIPTION
…subdirectories it needs to be a double asterisk.

I noticed that the workbench team members weren't getting added as reviewers for my PR https://github.com/rstudio/helm/pull/615

This will fix that issue

<img width="754" alt="image" src="https://github.com/user-attachments/assets/abaa83f3-7d4f-4fda-bc95-3f6d20e5ab6e">

<img width="676" alt="image" src="https://github.com/user-attachments/assets/5a63172e-f3a8-4bbf-9a54-a520e4ff061b">
