### PR TITLE
Add yaml & quarto markdown in GH statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.yml linguist-detectable=true
+*.yml linguist-language=YAML
+*.qmd linguist-language=Markdown
+*.md linguist-detectable
+*.qmd linguist-detectable


### PR DESCRIPTION
Adding `.yaml` and `.qmd` file extensions into `.gitattributes` so that it's recognized in github statistics. 