### PR TITLE
Bump launcher templates for Workbench chart to 2.5.0

### DIFF
--- a/charts/rstudio-workbench/files/service.tpl
+++ b/charts/rstudio-workbench/files/service.tpl
@@ -1,4 +1,4 @@
-# Version: 2.4.0
+# Version: 2.5.0
 # DO NOT MODIFY the "Version: " key
 # Helm Version: v1
 {{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}


### PR DESCRIPTION
Adds init containers support from the Job spec from rstudio/launcher#1070

This should go out with the other 2024.12.0 post-release changes.