### PR TITLE
Connect: set meaningful (fallback) defaults for job resources 

### DIFF
--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -281,6 +281,14 @@ spec:
               {{ $key }}: {{ toYaml $val }}
               {{- end }}
             {{- end }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           {{- end }}
           {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumeMounts) 0) }}
           volumeMounts:

--- a/charts/rstudio-connect/files/job.tpl
+++ b/charts/rstudio-connect/files/job.tpl
@@ -267,18 +267,32 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- if any (ne (len $requests) 0) (ne (len $limits) 0) }}
+          {{- if or (ne (len $requests) 0) (ne (len $limits) 0) }}
           resources:
             {{- if ne (len $requests) 0 }}
             requests:
-              {{- range $key, $val := $requests }}
-              {{ $key }}: {{ toYaml $val }}
+              {{- if $requests.cpu }}
+              cpu: {{ $requests.cpu }}
+              {{- else }}
+              cpu: 500m
+              {{- end }}
+              {{- if $requests.memory }}
+              memory: {{ $requests.memory }}
+              {{- else }}
+              memory: 1Gi
               {{- end }}
             {{- end }}
             {{- if ne (len $limits) 0 }}
             limits:
-              {{- range $key, $val := $limits }}
-              {{ $key }}: {{ toYaml $val }}
+              {{- if $limits.cpu }}
+              cpu: {{ $limits.cpu }}
+              {{- else }}
+              cpu: 500m
+              {{- end }}
+              {{- if $limits.memory }}
+              memory: {{ $limits.memory }}
+              {{- else }}
+              memory: 1Gi
               {{- end }}
             {{- end }}
           {{- else }}


### PR DESCRIPTION
Without these, `packrat-restore` jobs will fail on clusters 

- that do not allow empty resources 
- inject a (too) low default `resources:` settings instead

This is often the case on Openshift.

Defining these fallback values safeguards `packrat-restore` jobs for new apps which don't have any resource definitions set and hence run into the condition described above.

