### PR TITLE
Bump pwb 2024.12.0

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.9
+version: 0.8.10
 apiVersion: v2
-appVersion: 2024.09.1
+appVersion: 2024.12.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.09.1
+      image: rstudio/rstudio-workbench:ubuntu2204-2024.12.0
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.09.1
+      image: rstudio/r-session-complete:ubuntu2204-2024.12.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.10
+
+- Bump Workbench version to 2024.12.0
+
 ## 0.8.9
 
 - Fix a logic bug where the resource limit key was set even if `resources.limits.enabled` is false

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -3,7 +3,9 @@
 ## 0.8.10
 
 - Bump Workbench version to 2024.12.0
-
+- Bump version of launcher templates `job.tpl` and `service.tpl`
+  - Populate pod `initContainers` from `.Job.initContainers`
+ 
 ## 0.8.9
 
 - Fix a logic bug where the resource limit key was set even if `resources.limits.enabled` is false

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.9](https://img.shields.io/badge/Version-0.8.9-informational?style=flat-square) ![AppVersion: 2024.09.1](https://img.shields.io/badge/AppVersion-2024.09.1-informational?style=flat-square)
+![Version: 0.8.10](https://img.shields.io/badge/Version-0.8.10-informational?style=flat-square) ![AppVersion: 2024.12.0](https://img.shields.io/badge/AppVersion-2024.12.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.9:
+To install the chart with the release name `my-release` at version 0.8.10:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.9
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.10
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/files/service.tpl
+++ b/charts/rstudio-workbench/files/service.tpl
@@ -1,4 +1,4 @@
-# Version: 2.4.0
+# Version: 2.5.0
 # DO NOT MODIFY the "Version: " key
 # Helm Version: v1
 {{- $templateData := include "rstudio-library.templates.data" nil | mustFromJson }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -463,14 +463,28 @@ config:
       default-session-cluster: Kubernetes
     vscode.conf:
       enabled: 1
-      exe: /opt/code-server/bin/code-server
-      args: --host=0.0.0.0
+      session-timeout-kill-hours: 12
+    vscode.extensions.conf: |
+      quarto.quarto
+      posit.shiny
+      posit.publisher
     vscode-user-settings.json: |
       {
             "terminal.integrated.shell.linux": "/bin/bash",
             "extensions.autoUpdate": false,
             "extensions.autoCheckUpdates": false
       }
+    #  positron.conf:
+    #    enabled: 1
+    #  positron.extensions.conf: |
+    #    posit.shiny
+    #    posit.publisher
+    #  positron-user-settings.json: |
+    #    {
+    #          "terminal.integrated.shell.linux": "/bin/bash",
+    #          "extensions.autoUpdate": false,
+    #          "extensions.autoCheckUpdates": false
+    #    }
     logging.conf:
       "*":
         log-level: info


### PR DESCRIPTION
- bump pwb to 2024.12.0
- update vs code default config values to match those in workbench
- add positron config files commented out in case customers want to try it out while the feature is in preview
- pull in changes from https://github.com/rstudio/helm/pull/629