### PR TITLE
Update Workbench Examples

### DIFF
--- a/examples/auto-scaling/rstudio-workbench/values.yaml
+++ b/examples/auto-scaling/rstudio-workbench/values.yaml
@@ -36,8 +36,11 @@ service:
 
 launcher:
   enabled: true
-  namespace: "soleng-team"
-
+  useTemplates: true
+  templateValues:
+    pod:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 rbac:
   create: true
 
@@ -73,10 +76,6 @@ config:
         max-mem-mb: "8192"
         allow-unknown-images: "1"
         cpu-request-ratio: "1"
-        job-json-overrides:
-          - target: "/spec/template/metadata/annotations/cluster-autoscaler.kubernetes.io~1safe-to-evict"
-            json: "false"
-            name: evict-annotation
   server:
     rserver.conf:
       admin-enabled: 1

--- a/examples/workbench/auth-user-provisioning/pam-security.qmd
+++ b/examples/workbench/auth-user-provisioning/pam-security.qmd
@@ -1,0 +1,12 @@
+---
+category: Authentication
+---
+
+# Configuring Posit Workbench with Secure Home Directories
+
+This example deploys Posit Workbench using pam to create user home directories with more secure permissions, in this example 700
+
+{{< include ../_prereqs.qmd >}}
+
+```{.yaml include="rstudio-workbench-pam-homedirectory-permissions.yaml" filename="values.yaml"}
+```

--- a/examples/workbench/auth-user-provisioning/rstudio-workbench-pam-homedirectory-permissions.yaml
+++ b/examples/workbench/auth-user-provisioning/rstudio-workbench-pam-homedirectory-permissions.yaml
@@ -1,0 +1,69 @@
+# Using a license file with the helm chart:
+# https://github.com/rstudio/helm/tree/main/charts/rstudio-workbench#license-file
+# If you would like to use a license key see this documentation:
+# https://github.com/rstudio/helm/tree/main/charts/rstudio-workbench#license-key
+license:
+  file:
+    secret: posit-licenses # TODO: Change to the secret name in your cluster
+    secretKey: workbench.lic # TODO: Change to the secret key containing your Workbench license
+
+# Configures user home directory shared storage
+homeStorage:
+  create: true
+  mount: true
+  storageClassName: nfs-sc-rwx # TODO: Change to a RWX StorageClass available in your cluster
+  # volumeName: wb-home-pv-name # Only needed if PVs have been statically provisioned, in which case this will need to match the PV name.
+  requests:
+    storage: 100G
+
+# Configures Workbench shared storage
+sharedStorage:
+  create: true
+  mount: true
+  storageClassName: nfs-sc-rwx # TODO: Change to a RWX StorageClass available in your cluster
+  # volumeName: wb-shared-pv-name # Only needed if PVs have been statically provisioned, in which case this will need to match the PV name.
+  requests:
+    storage: 1G
+
+config:
+  pam:
+    common-session: |
+      # ------------------------------------------------------------------------
+      # /etc/pam.d/common-session - session-related modules common to all services
+      # ------------------------------------------------------------------------
+      #
+      # This file is included from other service-specific PAM config files,
+      # and should contain a list of modules that define tasks to be performed
+      # at the start and end of interactive sessions.
+      #
+      # As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
+      # To take advantage of this, it is recommended that you configure any
+      # local modules either before or after the default block, and use
+      # pam-auth-update to manage selection of other modules.  See
+      # pam-auth-update(8) for details.
+
+      # here are the per-package modules (the "Primary" block)
+      session [default=1]                     pam_permit.so
+      # here's the fallback if no module succeeds
+      session requisite                       pam_deny.so
+      # prime the stack with a positive return value if there isn't one already;
+      # this avoids us returning an error just because nothing sets a success code
+      # since the modules above will each just jump around
+      session required                        pam_permit.so
+      # The pam_umask module will set the umask according to the system default in
+      # /etc/login.defs and user settings, solving the problem of different
+      # umask settings with different shells, display managers, remote sessions etc.
+      # See "man pam_umask".
+      session optional                        pam_umask.so
+      # and here are more per-package modules (the "Additional" block)
+      session required        pam_unix.so
+      session optional                        pam_sss.so
+      # end of pam-auth-update config
+
+      # allow home directory creation, with user access only home directories
+      session required pam_mkhomedir.so skel=/etc/skel umask=0077
+
+      # ------------------------------------------------------------------------
+      # Example for running a custom script
+      # ------------------------------------------------------------------------
+      # session required pam_exec.so log=/tmp/sams-pam-logs-2.0.log /tmp/symlink-homedirs.sh


### PR DESCRIPTION
This PR creates a new example that creates user home directories with 700 permissions, which is a common customer request.

It also updates the older auto-scaling example to use templates for that annotation, rather than job-json-overrides