### PR TITLE
feat(workbench): add annotations for session cm

### DIFF
--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -452,6 +452,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | args | list | `[]` | args is the pod container's run arguments. |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
+| config.annotations.session | object | `{}` | annotations for ConfigMap created for sessions |
 | config.defaultMode.jobJsonOverrides | int | 0644 | default mode for jobJsonOverrides config |
 | config.defaultMode.pam | int | 0644 | default mode for pam scripts |
 | config.defaultMode.prestart | int | 0755 | default mode for prestart config |

--- a/charts/rstudio-workbench/templates/configmap-session.yaml
+++ b/charts/rstudio-workbench/templates/configmap-session.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    {{- tpl ( toYaml .Values.config.annotations.session ) . | nindent 4 }}
   name: {{ include "rstudio-workbench.fullname" . }}-session
   namespace: {{ $.Release.Namespace }}
 data:
@@ -44,6 +46,8 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    {{- tpl ( toYaml .Values.config.annotations.session ) . | nindent 4 }}
   name: {{ include "rstudio-workbench.fullname" . }}-session
   namespace: {{ $targetNamespace }}
 data:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -417,6 +417,10 @@ config:
     # @default -- 0644
     pam: 0644
 
+  annotations:
+    # annotations for ConfigMap created for sessions
+    session: {}
+
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.
   session:
     repos.conf:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -418,7 +418,7 @@ config:
     pam: 0644
 
   annotations:
-    # annotations for ConfigMap created for sessions
+    # -- annotations for ConfigMap created for sessions
     session: {}
 
   # -- a map of session-scoped config files. Mounted to `/mnt/session-configmap/rstudio/` on both server and session, by default.


### PR DESCRIPTION
Exposed the option to set the annotations for session ConfigMap

Related to Posit Support Ticket #113916