### PR TITLE
Bump Workbench to 2024.12.1

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.10
+version: 0.8.11
 apiVersion: v2
-appVersion: 2024.12.0
+appVersion: 2024.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.12.0
+      image: rstudio/rstudio-workbench:ubuntu2204-2024.12.1
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.12.0
+      image: rstudio/r-session-complete:ubuntu2204-2024.12.1
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## 0.8.11
+
+- Bump Workbench version to 2024.12.1
+
 ## 0.8.10
 
 - Bump Workbench version to 2024.12.0
 - Bump version of launcher templates `job.tpl` and `service.tpl`
   - Populate pod `initContainers` from `.Job.initContainers`
- 
+
 ## 0.8.9
 
 - Fix a logic bug where the resource limit key was set even if `resources.limits.enabled` is false

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.10](https://img.shields.io/badge/Version-0.8.10-informational?style=flat-square) ![AppVersion: 2024.12.0](https://img.shields.io/badge/AppVersion-2024.12.0-informational?style=flat-square)
+![Version: 0.8.11](https://img.shields.io/badge/Version-0.8.11-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.10:
+To install the chart with the release name `my-release` at version 0.8.11:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.10
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.11
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
Don't merge until the new 2024.12.1 Docker images are available.

The images will be built and pushed after the [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products/tree/main) PR is merged into `main`.

Docker image PR: https://github.com/rstudio/rstudio-docker-products/pull/897