### PR TITLE
Bump Chronicle to 2025.03.0

### DIFF
--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: posit-chronicle
 description: Official Helm chart for Posit Chronicle Server
-version: 0.3.6
-appVersion: 2024.11.0
+version: 0.3.7
+appVersion: 2025.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.posit.co
 sources:

--- a/charts/posit-chronicle/NEWS.md
+++ b/charts/posit-chronicle/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.7
+
+- Bump Chronicle to version 2025.03.0
+
 ## 0.3.6
 
 - Bump Chronicle to version 2024.11.0

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -1,6 +1,6 @@
 # Posit Chronicle
 
-![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2025.03.0-informational?style=flat-square)
+![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![AppVersion: 2025.03.0](https://img.shields.io/badge/AppVersion-2025.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Chronicle Server_
 
@@ -15,7 +15,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
-
+ 
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -45,13 +45,25 @@ with the Workbench and Connect charts. To actually send data to the server, you
 will need to run the Chronicle agent as a sidecar container on your
 Workbench or Connect server pods by setting `pod.sidecar` in their respective `values.yaml` files
 
-Here is an example of Helm values to run the agent sidecar in **Workbench**:
+Here is an example of Helm values to run the agent sidecar in **Workbench**,
+where we set up a shared volume between containers for audit logs:
 
 ```yaml
 pod:
+  # We will need to create a new volume to share audit logs between
+  # the rstudio (workbench) and chronicle-agent containers
+  volumes:
+    - name: logs
+      emptyDir: {}
+  volumeMounts:
+    - name: logs
+      mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
       image: ghcr.io/rstudio/chronicle-agent:2025.03.0
+      volumeMounts:
+      - name: logs
+        mountPath: "/var/lib/rstudio-server/audit"
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"
@@ -64,7 +76,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -1,6 +1,6 @@
 # Posit Chronicle
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2024.11.0-informational?style=flat-square)
+![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2025.03.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Chronicle Server_
 
@@ -15,7 +15,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
- 
+
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -25,11 +25,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.3.6:
+To install the chart with the release name `my-release` at version 0.3.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.6
+helm upgrade --install my-release rstudio/posit-chronicle --version=0.3.7
 ```
 
 To explore other chart versions, look at:
@@ -45,25 +45,13 @@ with the Workbench and Connect charts. To actually send data to the server, you
 will need to run the Chronicle agent as a sidecar container on your
 Workbench or Connect server pods by setting `pod.sidecar` in their respective `values.yaml` files
 
-Here is an example of Helm values to run the agent sidecar in **Workbench**,
-where we set up a shared volume between containers for audit logs:
+Here is an example of Helm values to run the agent sidecar in **Workbench**:
 
 ```yaml
 pod:
-  # We will need to create a new volume to share audit logs between
-  # the rstudio (workbench) and chronicle-agent containers
-  volumes:
-    - name: logs
-      emptyDir: {}
-  volumeMounts:
-    - name: logs
-      mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
-      volumeMounts:
-      - name: logs
-        mountPath: "/var/lib/rstudio-server/audit"
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"
@@ -179,7 +167,7 @@ The credentials Chronicle uses for S3 storage must have the following permission
 | config.S3Storage.Region | string | `"us-east-2"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/rstudio/chronicle"` |  |
-| image.tag | string | `"2024.11.0"` |  |
+| image.tag | string | `"2025.03.0"` |  |
 | nodeSelector | object | `{}` | A map used verbatim as the pod's "nodeSelector" definition |
 | pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the chronicle-server pods |

--- a/charts/posit-chronicle/README.md.gotmpl
+++ b/charts/posit-chronicle/README.md.gotmpl
@@ -30,7 +30,7 @@ pod:
       mountPath: "/var/lib/rstudio-server/audit"
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"
@@ -46,7 +46,7 @@ API key from a Kubernetes Secret is used to unlock more detailed metrics:
 pod:
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/charts/posit-chronicle/values.yaml
+++ b/charts/posit-chronicle/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: "ghcr.io/rstudio/chronicle"
-  tag: "2024.11.0"
+  tag: "2025.03.0"
   imagePullPolicy: "IfNotPresent"
 
 serviceaccount:

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.7.22
+version: 0.7.23
 apiVersion: v2
 appVersion: 2025.02.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.23
+
+- Bump Chronicle Agent to version 2025.03.0
+
 ## 0.7.22
 
 - Bump Connect version to 2025.02.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.22](https://img.shields.io/badge/Version-0.7.22-informational?style=flat-square) ![AppVersion: 2025.02.0](https://img.shields.io/badge/AppVersion-2025.02.0-informational?style=flat-square)
+![Version: 0.7.23](https://img.shields.io/badge/Version-0.7.23-informational?style=flat-square) ![AppVersion: 2025.02.0](https://img.shields.io/badge/AppVersion-2025.02.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.22:
+To install the chart with the release name `my-release` at version 0.7.23:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.22
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.23
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.8.11
+version: 0.8.12
 apiVersion: v2
 appVersion: 2024.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.12
+
+- Bump Chronicle Agent to version 2025.03.0
+
 ## 0.8.11
 
 - Bump Workbench version to 2024.12.1

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -14,7 +14,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
-
+ 
     ::: {.callout-important}
     This protects you from breaking changes.
     :::

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.8.11](https://img.shields.io/badge/Version-0.8.11-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
+![Version: 0.8.12](https://img.shields.io/badge/Version-0.8.12-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -14,7 +14,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
- 
+
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.11:
+To install the chart with the release name `my-release` at version 0.8.12:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.11
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.8.12
 ```
 
 To explore other chart versions, look at:

--- a/ci/rstudio-connect/lint/complex-values.yaml
+++ b/ci/rstudio-connect/lint/complex-values.yaml
@@ -50,7 +50,7 @@ pod:
       imagePullPolicy: "IfNotPresent"
     # This will spin up the chronicle-agent sidecar container
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       env:
       - name: CHRONICLE_SERVER_ADDRESS
         value: "http://chronicle-server.default"

--- a/ci/rstudio-pm/lint/all-values.yaml
+++ b/ci/rstudio-pm/lint/all-values.yaml
@@ -75,12 +75,3 @@ pod:
   labels:
     onelabel.com: value
 priorityClassName: someval
-
-# Testing with the chronicle-agent sidecar container
-extraContainers:
-  - name: chronicle-agent
-    image: ghcr.io/rstudio/chronicle-agent:2024.11.0
-    imagePullPolicy: Always
-    env:
-    - name: CHRONICLE_SERVER_ADDRESS
-      value: "http://chronicle-server.default"

--- a/ci/rstudio-workbench/lint/complex-values.yaml
+++ b/ci/rstudio-workbench/lint/complex-values.yaml
@@ -36,7 +36,7 @@ pod:
   # This will spin up the chronicle-agent sidecar container
   sidecar:
     - name: chronicle-agent
-      image: ghcr.io/rstudio/chronicle-agent:2024.11.0
+      image: ghcr.io/rstudio/chronicle-agent:2025.03.0
       volumeMounts:
       - name: logs
         mountPath: "/var/lib/rstudio-server/audit"


### PR DESCRIPTION
This PR updates the versions of Chronicle used in the helm charts to 2025.03.0.