### PR TITLE
PPM: disable migration by default

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.43
+version: 0.5.44
 apiVersion: v2
 appVersion: 2024.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.44
 
-- Disable the migration job of root to non-root by default. This is because the migration job is not needed for new installations and is only needed if you run a version of Package Manager several years old. If you are upgrading from Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.
+- Set `enableMigration: false` to disable the migration job by default because it is not needed for new installations and is only needed if you update from a Package Manager version that is 3+ years old. If you are upgrading from a Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.
 
 ## 0.5.43
 

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.44
 
-- Set `enableMigration: false` to disable the migration job by default because it is not needed for new installations and is only needed if you update from a Package Manager version that is 3+ years old. If you are upgrading from a Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.
+- Set `enableMigration: false` to by default disable the migration job because it is not needed for new installations and is only needed if you update from a Package Manager version that is 3+ years old. If you are upgrading from a Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.
 
 ## 0.5.43
 

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.44
+
+- Disable the migration job of root to non-root by default. This is because the migration job is not needed for new installations and is only needed if you run a version of Package Manager several years old. If you are upgrading from Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.
+
 ## 0.5.43
 
 - Update default Posit Package Manager version to 2024.11.0-7

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.43](https://img.shields.io/badge/Version-0.5.43-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2024.11.0-informational?style=flat-square)
+![Version: 0.5.44](https://img.shields.io/badge/Version-0.5.44-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2024.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.43:
+To install the chart with the release name `my-release` at version 0.5.44:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.43
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.44
 ```
 
 To explore other chart versions, look at:
@@ -202,7 +202,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | awsSecretAccessKey | string | `nil` | awsSecretAccessKey is the secret access key, needs to be filled if access_key_id is |
 | command | bool | `false` | command is the pod's run command. By default, it uses the container's default |
 | config | object | `{"HTTP":{"Listen":":4242"},"Metrics":{"Enabled":true}}` | config is a nested map of maps that generates the rstudio-pm.gcfg file |
-| enableMigration | bool | `true` | Enable migrations for shared storage (if necessary) using Helm hooks. |
+| enableMigration | bool | `false` | Enable migrations for shared storage (if necessary) using Helm hooks. |
 | enableSandboxing | bool | `true` | Enable sandboxing of Git builds, which requires elevated security privileges for the Package Manager container. |
 | extraContainers | list | `[]` | sidecar container list |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template) |

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -104,7 +104,7 @@ args: false
 enableSandboxing: true
 
 # -- Enable migrations for shared storage (if necessary) using Helm hooks.
-enableMigration: true
+enableMigration: false
 
 # -- Whether the check for root accounts in the config file is fatal. This is meant to simplify migration to the new helm chart version.
 rootCheckIsFatal: true


### PR DESCRIPTION
This PR changes the default to `enableMigration: false`. This migration job launched by default on each PPM install has not been needed for over 3 years now and it occasionally causes customers issues when they can't use the default `busybox` image used by the job.

Eventually it makes sense to take this job out entirely but this change seems to be the most harmless way to proceed in case someone really needs it.

This will negate the need for https://github.com/rstudio/helm/issues/537 since it won't try to launch that job anymore and I doubt that customer needs the job to run (most customers just don't even know it tries to run this job).