### PR TITLE
PPM: implement service.targetPort as configurable

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.44
+version: 0.5.45
 apiVersion: v2
 appVersion: 2024.11.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.45
+
+- Allow value for `service.targetPort` 
+
 ## 0.5.44
 
 - Set `enableMigration: false` to by default disable the migration job because it is not needed for new installations and is only needed if you update from a Package Manager version that is 3+ years old. If you are upgrading from a Package Manager version that does run as root, you can enable the migration job by setting `enableMigration: true`.

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.44](https://img.shields.io/badge/Version-0.5.44-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2024.11.0-informational?style=flat-square)
+![Version: 0.5.45](https://img.shields.io/badge/Version-0.5.45-informational?style=flat-square) ![AppVersion: 2024.11.0](https://img.shields.io/badge/AppVersion-2024.11.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.44:
+To install the chart with the release name `my-release` at version 0.5.45:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.44
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.45
 ```
 
 To explore other chart versions, look at:
@@ -251,6 +251,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | service.loadBalancerIP | string | `""` | The external IP to use with `service.type` LoadBalancer, when supported by the cloud provider |
 | service.nodePort | bool | `false` | The explicit nodePort to use for `service.type` NodePort. If not provided, Kubernetes will choose one automatically |
 | service.port | int | `80` | The Service port. This is the port your service will run under. |
+| service.targetPort | int | `4242` | The port to forward to on the Package Manager pod. Also see pod.port |
 | service.type | string | `"ClusterIP"` | The service type, usually ClusterIP (in-cluster only) or LoadBalancer (to expose the service using your cloud provider's load balancer) |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount, if any |
 | serviceAccount.create | bool | `true` | Whether to create a [Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) |

--- a/charts/rstudio-pm/templates/svc.yaml
+++ b/charts/rstudio-pm/templates/svc.yaml
@@ -27,7 +27,7 @@ spec:
 {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-    targetPort: 4242
+    targetPort: {{ .Values.service.targetPort }}
 {{- if .Values.config.Metrics.Enabled }}
   - name: metrics
     port: 2112

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -85,6 +85,8 @@ service:
   nodePort: false
   # -- The Service port. This is the port your service will run under.
   port: 80
+  # -- The port to forward to on the Package Manager pod. Also see pod.port
+  targetPort: 4242
 
 # -- replicas is the number of replica pods to maintain for this service
 replicas: 1


### PR DESCRIPTION
service.targetPort was hard coded as port 4242. Modifed this to be a configurable value to support use cases when customer requires routing to alternate port.
