### PR TITLE
update broken link to legacy documentation

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -9,7 +9,7 @@ The original mechanism for modifying kubernetes jobs using the Job Launcher is t
 [`job-json-overrides`](https://docs.posit.co/ide/server-pro/job_launcher/job_launcher.html).
 
 [There is a support article discussing the topic and examples in a legacy context 
-here](https://support.rstudio.com/hc/en-us/articles/360051652094-Using-Job-Json-Overrides-with-RStudio-Server-Pro-and-Kubernetes)
+here](https://docs.posit.co/ide/server-pro/job_launcher/kubernetes_plugin.html#kube-json)
 
 In helm, there is a helper that simplifies some of this configuration. As a result, we will include several snippets
 below to simplify use cases.

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -8,7 +8,7 @@ This is relevant for both Posit Workbench and Posit Connect when the job launche
 The original mechanism for modifying kubernetes jobs using the Job Launcher is to use 
 [`job-json-overrides`](https://docs.posit.co/ide/server-pro/job_launcher/job_launcher.html).
 
-[The documentation discussing this topic in more detail can be found here.](https://docs.posit.co/ide/server-pro/job_launcher/kubernetes_plugin.html#kube-json)
+See the [documentation](https://docs.posit.co/ide/server-pro/job_launcher/kubernetes_plugin.html#kube-json) discussing this topic in more detail.
 
 In helm, there is a helper that simplifies some of this configuration. As a result, we will include several snippets
 below to simplify use cases.

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -8,8 +8,7 @@ This is relevant for both Posit Workbench and Posit Connect when the job launche
 The original mechanism for modifying kubernetes jobs using the Job Launcher is to use 
 [`job-json-overrides`](https://docs.posit.co/ide/server-pro/job_launcher/job_launcher.html).
 
-[There is a support article discussing the topic and examples in a legacy context 
-here](https://docs.posit.co/ide/server-pro/job_launcher/kubernetes_plugin.html#kube-json)
+[The documentation discussing this topic in more detail can be found here.](https://docs.posit.co/ide/server-pro/job_launcher/kubernetes_plugin.html#kube-json)
 
 In helm, there is a helper that simplifies some of this configuration. As a result, we will include several snippets
 below to simplify use cases.


### PR DESCRIPTION
Proposing an update to the broken documentation referenced here: https://github.com/rstudio/docs.rstudio.com/issues/2141
