### PR TITLE
Bump Connect to version 2025.04.0

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.7.24
+version: 0.7.25
 apiVersion: v2
-appVersion: 2025.03.0
+appVersion: 2025.04.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,7 +18,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-connect
-      image: rstudio/rstudio-connect:ubuntu2204-2025.03.0
+      image: rstudio/rstudio-connect:ubuntu2204-2025.04.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.25
+
+- Bump Connect version to 2025.04.0
+
 ## 0.7.24
 
 - Bump Connect version to 2025.03.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.7.24](https://img.shields.io/badge/Version-0.7.24-informational?style=flat-square) ![AppVersion: 2025.03.0](https://img.shields.io/badge/AppVersion-2025.03.0-informational?style=flat-square)
+![Version: 0.7.25](https://img.shields.io/badge/Version-0.7.25-informational?style=flat-square) ![AppVersion: 2025.04.0](https://img.shields.io/badge/AppVersion-2025.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.7.24:
+To install the chart with the release name `my-release` at version 0.7.25:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.24
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.7.25
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
This PR was created automatically by the Posit Connect release scripts.

This PR should not be merged until the new 2025.04.0 Docker images are available in our public container registry.

The images will be built and pushed by GHA after the [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products/tree/main) PR is merged into main.

Docker image PR: https://github.com/rstudio/rstudio-docker-products/pull/918
