### PR TITLE
chore: add issue templates to help assign issues to product teams

### DIFF
--- a/.github/ISSUE_TEMPLATE/chronicle.md
+++ b/.github/ISSUE_TEMPLATE/chronicle.md
@@ -1,0 +1,11 @@
+---
+name: Posit Chronicle
+about: A bug or feature request for the Chronicle helm chart
+labels: ["team: chronicle"]
+---
+
+<!--
+Thanks for reporting an issue! To help us triage, please describe the issue below, and add any labels (bug, enhancement, etc.) that help categorize the issue. -->
+
+## Description
+<!-- What is it? Why do we want to do it? -->

--- a/.github/ISSUE_TEMPLATE/connect.md
+++ b/.github/ISSUE_TEMPLATE/connect.md
@@ -1,0 +1,11 @@
+---
+name: Posit Connect
+about: A bug or feature request for the Connect helm chart
+labels: ["team: connect"]
+---
+
+<!--
+Thanks for reporting an issue! To help us triage, please describe the issue below, and add any labels (bug, enhancement, etc.) that help categorize the issue. -->
+
+## Description
+<!-- What is it? Why do we want to do it? -->

--- a/.github/ISSUE_TEMPLATE/package-manager.md
+++ b/.github/ISSUE_TEMPLATE/package-manager.md
@@ -1,0 +1,11 @@
+---
+name: Posit Package Manager
+about: A bug or feature request for the PPM helm chart
+labels: ["team: package manager"]
+---
+
+<!--
+Thanks for reporting an issue! To help us triage, please describe the issue below, and add any labels (bug, enhancement, etc.) that help categorize the issue. -->
+
+## Description
+<!-- What is it? Why do we want to do it? -->

--- a/.github/ISSUE_TEMPLATE/workbench.md
+++ b/.github/ISSUE_TEMPLATE/workbench.md
@@ -1,0 +1,11 @@
+---
+name: Posit Workbench
+about: A bug or feature request for the Workbench helm chart
+labels: ["team: workbench"]
+---
+
+<!--
+Thanks for reporting an issue! To help us triage, please describe the issue below, and add any labels (bug, enhancement, etc.) that help categorize the issue. -->
+
+## Description
+<!-- What is it? Why do we want to do it? -->


### PR DESCRIPTION
Fixes #657. Along with #658, this will allow us to have new issues automatically be visible to the product teams they correspond to.

I don't think there's a way to verify these changes on the PR, you'll have to merge to see them show up in the "New issue" flow.

We will need to create the `team: chronicle` label too, but the others already exist.