### PR TITLE
Add audited jobs by default.

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.0
+version: 0.9.1
 apiVersion: v2
 appVersion: 2024.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.0:
+To install the chart with the release name `my-release` at version 0.9.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.0
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -462,6 +462,7 @@ config:
         admin-group: rstudio-server
         authorization-enabled: 1
         thread-pool-size: 4
+        enable-debug-logging: 0
       cluster:
         name: Kubernetes
         type: Kubernetes
@@ -472,6 +473,7 @@ config:
       default-session-cluster: Kubernetes
     vscode.conf:
       enabled: 1
+      session-timeout-kill-hours: 12
     vscode.extensions.conf: |
       quarto.quarto
       posit.shiny

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -453,6 +453,7 @@ config:
       launcher-port: 5559
       launcher-sessions-enabled: 1
       launcher-default-cluster: Kubernetes
+      audited-jobs: 1
     launcher.conf:
       server:
         address: 127.0.0.1
@@ -461,7 +462,6 @@ config:
         admin-group: rstudio-server
         authorization-enabled: 1
         thread-pool-size: 4
-        enable-debug-logging: 0
       cluster:
         name: Kubernetes
         type: Kubernetes
@@ -472,7 +472,6 @@ config:
       default-session-cluster: Kubernetes
     vscode.conf:
       enabled: 1
-      session-timeout-kill-hours: 12
     vscode.extensions.conf: |
       quarto.quarto
       posit.shiny


### PR DESCRIPTION
Ok this adds `audited-jobs=1` to the default for the `rserver.conf` in helm.