### PR TITLE
Update Chronicle description and links to include public documentation

### DIFF
--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -9,7 +9,7 @@ R and Python packages that Data Scientists need to create and share data product
 Data Scientists use [Posit Workbench](https://posit.co/products/enterprise/workbench/) to analyze data and create data
 products using R and Python.
   {{- else if eq .Name "posit-chronicle" -}}
-Chronicle helps data science managers and other stakeholders understand their
+[Posit Chronicle](https://docs.posit.co/chronicle/) helps data science managers and other stakeholders understand their
 organization's use of other Posit products, primarily Posit Connect and
 Workbench.
   {{- end -}}

--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -9,18 +9,25 @@ sources:
   - https://github.com/rstudio/helm
 maintainers:
   - name: sol-eng
-    email: docker@rstudio.com
+    email: docker@posit.co
     url: https://github.com/rstudio/helm
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/links: |
+    - name: Chronicle Documentation
+      url: https://docs.posit.co/chronicle
     - name: Docker Images
       url: https://github.com/rstudio/rstudio-docker-products
     - name: Posit Community
-      url: https://community.rstudio.com/c/r-admin/5
+      url: https://forum.posit.co/c/posit-professional-hosted/5
     - name: About Posit Team
       url: https://posit.co/products/enterprise/team/
 keywords:
   - "rstudio"
   - "posit"
   - "chronicle"
+  - "metrics"
+  - "monitoring"
+  - "observability"
+  - "analytics"
+  - "data science"

--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: posit-chronicle
 description: Official Helm chart for Posit Chronicle Server
-version: 0.3.7
+version: 0.3.8
 appVersion: 2025.03.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.posit.co

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -4,7 +4,7 @@
 
 #### _Official Helm chart for Posit Chronicle Server_
 
-Chronicle helps data science managers and other stakeholders understand their
+[Posit Chronicle](https://docs.posit.co/chronicle/) helps data science managers and other stakeholders understand their
 organization's use of other Posit products, primarily Posit Connect and
 Workbench.
 


### PR DESCRIPTION
- Adds link to Chronicle documentation in `artifacthub.io/links` chart annotation.
- Adds link to Chronicle documentation to associated `rstudio.blurb` template.
- Update maintainer email to use posit.co domain.
- Update community link for board rename and use posit.co domain.
- Update keywords list with additional relevant keywords.