### PR TITLE
Bump Workbench to 2025.05.0

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.0
+version: 0.9.1
 apiVersion: v2
 appVersion: 2024.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -2,7 +2,7 @@ name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
 version: 0.9.1
 apiVersion: v2
-appVersion: 2024.12.1
+appVersion: 2025.05.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2024.12.1
+      image: rstudio/rstudio-workbench:ubuntu2204-2025.05.0
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2024.12.1
+      image: rstudio/r-session-complete:ubuntu2204-2025.05.0
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.1
+
+- Bump Workbench version to 2025.05.0
+- Enable `audited-jobs`
+
 ## 0.9.0
 
 - BREAKING: `launcher.useTemplates: true` is now the default. `launcher.templateValues` settings are the recommended way to pass values to the launcher jobs. If you must use the older `job-json-overrides` method, set `launcher.useTemplates: false`, the two methods cannot be used concurrently and will error if detected.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.0:
+To install the chart with the release name `my-release` at version 0.9.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.0
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2024.12.1](https://img.shields.io/badge/AppVersion-2024.12.1-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -462,6 +462,7 @@ config:
         admin-group: rstudio-server
         authorization-enabled: 1
         thread-pool-size: 4
+        enable-debug-logging: 0
       cluster:
         name: Kubernetes
         type: Kubernetes
@@ -472,6 +473,7 @@ config:
       default-session-cluster: Kubernetes
     vscode.conf:
       enabled: 1
+      session-timeout-kill-hours: 12
     vscode.extensions.conf: |
       quarto.quarto
       posit.shiny

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -453,6 +453,7 @@ config:
       launcher-port: 5559
       launcher-sessions-enabled: 1
       launcher-default-cluster: Kubernetes
+      audited-jobs: 1
     launcher.conf:
       server:
         address: 127.0.0.1
@@ -461,7 +462,6 @@ config:
         admin-group: rstudio-server
         authorization-enabled: 1
         thread-pool-size: 4
-        enable-debug-logging: 0
       cluster:
         name: Kubernetes
         type: Kubernetes
@@ -472,7 +472,6 @@ config:
       default-session-cluster: Kubernetes
     vscode.conf:
       enabled: 1
-      session-timeout-kill-hours: 12
     vscode.extensions.conf: |
       quarto.quarto
       posit.shiny


### PR DESCRIPTION
Don't merge until the new 2025.05.0 Docker images are available. The images will be built and pushed after the https://github.com/rstudio/rstudio-docker-products/pull/919 is merged into main.

- bump pwb to 2025.05.0
- pull in changes from #660 