### PR TITLE
Fixes to `chronicle-agent` helper functions

### DIFF
--- a/charts/rstudio-library/Chart.yaml
+++ b/charts/rstudio-library/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-library
 description: Helm library helpers for use by official RStudio charts
 type: library
-version: 0.1.32
-appVersion: 0.1.32
+version: 0.1.33
+appVersion: 0.1.33
 
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com

--- a/charts/rstudio-library/NEWS.md
+++ b/charts/rstudio-library/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.33
+
+- Fixes to `rstudio-library.chronicle-agent.serverAddress` function.
+
 ## 0.1.32
 
 - Add `rstudio-library.chronicle-agent.image` and `rstudio-library.chronicle-agent.serverAddress` helper functions for

--- a/charts/rstudio-library/README.md
+++ b/charts/rstudio-library/README.md
@@ -1,6 +1,6 @@
 # rstudio-library
 
-![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.32](https://img.shields.io/badge/AppVersion-0.1.32-informational?style=flat-square)
+![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.1.33](https://img.shields.io/badge/AppVersion-0.1.33-informational?style=flat-square)
 
 #### _Helm library helpers for use by official RStudio charts_
 

--- a/charts/rstudio-library/templates/_chronicle-agent.tpl
+++ b/charts/rstudio-library/templates/_chronicle-agent.tpl
@@ -17,7 +17,7 @@ Takes a dict:
 {{- range $index, $service := (lookup "v1" "Service" (default .Release.Namespace .chronicleAgent.serverNamespace) "").items }}
 {{- $name := get $service.metadata.labels "app.kubernetes.io/name" }}
 {{- $component := get $service.metadata.labels "app.kubernetes.io/component" }}
-{{- if and (contains "posit-chronicle" $name) (eq $component "server") }}
+{{- if and (eq $name "posit-chronicle") (eq $component "server") }}
 {{- $version = get $service.metadata.labels "app.kubernetes.io/version" }}
 {{- end }}
 {{- end }}
@@ -38,13 +38,13 @@ Takes a dict:
 */}}
 {{- define "rstudio-library.chronicle-agent.serverAddress" }}
 {{- if .chronicleAgent.serverAddress }}
-{{ .chronicleAgent.serverAddress}}
+{{ .chronicleAgent.serverAddress }}
 {{- else }}
 {{- range $index, $service := (lookup "v1" "Service" (default .Release.Namespace .chronicleAgent.serverNamespace) "").items }}
-{{- $name := get $service.metadata.labels "app.kubernetes.io/name "}}
-{{- $component := get $service.metadata.labels "app.kubernetes.io/component "}}
-{{- if and (contains "posit-chronicle" $name) (eq $component "server") }}
-{{ $name }}.{{ $service.metadata.namespace }}
+{{- $name := get $service.metadata.labels "app.kubernetes.io/name" }}
+{{- $component := get $service.metadata.labels "app.kubernetes.io/component" }}
+{{- if and (eq $name "posit-chronicle") (eq $component "server") }}
+{{ $service.metadata.name }}.{{ $service.metadata.namespace }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- Fix misplaced spaces on labels in `serverAddress` lookup
- Change `name` to `service.metadata.name`
- Use `eq` instead of `contains`