### PR TITLE
Add protocol to Chronicle `serverAddress` helper

### DIFF
--- a/charts/rstudio-library/templates/_chronicle-agent.tpl
+++ b/charts/rstudio-library/templates/_chronicle-agent.tpl
@@ -24,7 +24,7 @@ Takes a dict:
 {{- else }}
 {{- $version = .chronicleAgent.image.tag }}
 {{- end }}
-{{ $registry }}/{{ $repository }}:{{ $version }}
+{{- $registry }}/{{ $repository }}:{{ $version }}
 {{- end }}
 
 {{/*
@@ -38,7 +38,7 @@ Takes a dict:
 */}}
 {{- define "rstudio-library.chronicle-agent.serverAddress" }}
 {{- if .chronicleAgent.serverAddress }}
-{{ .chronicleAgent.serverAddress }}
+{{- .chronicleAgent.serverAddress }}
 {{- else }}
 {{- range $index, $service := (lookup "v1" "Service" (default .Release.Namespace .chronicleAgent.serverNamespace) "").items }}
 {{- $name := get $service.metadata.labels "app.kubernetes.io/name" }}

--- a/charts/rstudio-library/templates/_chronicle-agent.tpl
+++ b/charts/rstudio-library/templates/_chronicle-agent.tpl
@@ -44,7 +44,7 @@ Takes a dict:
 {{- $name := get $service.metadata.labels "app.kubernetes.io/name" }}
 {{- $component := get $service.metadata.labels "app.kubernetes.io/component" }}
 {{- if and (eq $name "posit-chronicle") (eq $component "server") }}
-{{ $service.metadata.name }}.{{ $service.metadata.namespace }}
+{{- (index $service.spec.ports 0).name }}://{{ $name }}.{{ $service.metadata.namespace }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- Add protocol (http or https) to Chronicle's `serverAddress` helper based on the exposed port name.
- Fix left-hand whitespace trimming on helpers.