### PR TITLE
Bump Workbench to 2025.05.1

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.2
+version: 0.9.3
 apiVersion: v2
-appVersion: 2025.05.0
+appVersion: 2025.05.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2025.05.0
+      image: rstudio/rstudio-workbench:ubuntu2204-2025.05.1
     - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2025.05.0
+      image: rstudio/r-session-complete:ubuntu2204-2025.05.1
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3
+
+- Bump Workbench version to 2025.05.1
+
 ## 0.9.2
 
 - Bump `rstudio-library` chart version to `0.1.34`.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
+![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -14,7 +14,7 @@ To ensure a stable production deployment:
 * "Pin" the version of the Helm chart that you are using. You can do this using the:
   * `helm dependency` command *and* the associated "Chart.lock" files *or*
   * the `--version` flag.
- 
+
     ::: {.callout-important}
     This protects you from breaking changes.
     :::
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.2:
+To install the chart with the release name `my-release` at version 0.9.3:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.2
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.3
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
Don't merge until the new 2025.05.1 Docker images are available. The images will be built and pushed after the https://github.com/rstudio/rstudio-docker-products/pull/931 is merged into main.

Bump Posit Workbench to 2025.05.1
