### PR TITLE
Use latest chart-releaser action and cr.yaml config

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
 
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -25,18 +26,19 @@ jobs:
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
+      # Uses the default cr.yaml config file in the repository
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1
         with:
-          charts_repo_url: https://helm.rstudio.com
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser (other)
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1
         with:
           charts_dir: other-charts
-          charts_repo_url: https://helm.rstudio.com
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+owner: rstudio
+git-repo: helm


### PR DESCRIPTION
Additionally add the skip_existing flag: https://github.com/helm/chart-releaser?tab=readme-ov-file#usage

We use the cr.yaml config file to set up the chart-releaser action

This will fix the failed push of the package-manager chart: https://github.com/rstudio/helm/actions/runs/15493154743