### PR TITLE
Add selector labels for chart PVCs

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.0
+version: 0.8.1
 apiVersion: v2
 appVersion: 2025.05.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Add recommended labels to all PVCs created by the chart.
+
 ## 0.8.0
 
 - BREAKING: Connect now runs in [Off-Host Execution (OHE) mode](https://docs.posit.co/connect/admin/getting-started/off-host-install/) by default.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.0:
+To install the chart with the release name `my-release` at version 0.8.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.0
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![AppVersion: 2025.05.0](https://img.shields.io/badge/AppVersion-2025.05.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.1:
+To install the chart with the release name `my-release` at version 0.8.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.1
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/pvc.yaml
+++ b/charts/rstudio-connect/templates/pvc.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
     {{- .Values.sharedStorage.annotations | toYaml | nindent 4 }}
+  labels:
+    {{- include "rstudio-connect.labels" . | nindent 4 }}
 spec:
   accessModes:
     {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}

--- a/charts/rstudio-connect/tests/pvc_test.yaml
+++ b/charts/rstudio-connect/tests/pvc_test.yaml
@@ -1,0 +1,24 @@
+suite: test pvc
+templates:
+  - pvc.yaml
+tests:
+  - it: should have standard Helm labels on shared storage PVC
+    set:
+      sharedStorage.create: true
+    asserts:
+      - exists:
+          path: metadata.labels
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^rstudio-connect-[0-9]+\\.[0-9]+\\.[0-9]+.*"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rstudio-connect
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.47
+version: 0.5.48
 apiVersion: v2
 appVersion: 2025.04.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 0.5.48
+
+- Add recommended labels to all PVCs created by the chart.
  
 ## 0.5.47
 

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.47](https://img.shields.io/badge/Version-0.5.47-informational?style=flat-square) ![AppVersion: 2025.04.2](https://img.shields.io/badge/AppVersion-2025.04.2-informational?style=flat-square)
+![Version: 0.5.48](https://img.shields.io/badge/Version-0.5.48-informational?style=flat-square) ![AppVersion: 2025.04.2](https://img.shields.io/badge/AppVersion-2025.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.47:
+To install the chart with the release name `my-release` at version 0.5.48:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.47
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.48
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-pm/templates/pvc.yaml
+++ b/charts/rstudio-pm/templates/pvc.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
     {{- .Values.sharedStorage.annotations | toYaml | nindent 4}}
+  labels:
+    {{- include "rstudio-pm.labels" . | nindent 4 }}
 spec:
   accessModes:
     {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}

--- a/charts/rstudio-pm/tests/pvc_test.yaml
+++ b/charts/rstudio-pm/tests/pvc_test.yaml
@@ -1,0 +1,24 @@
+suite: test pvc
+templates:
+  - pvc.yaml
+tests:
+  - it: should have standard Helm labels on shared storage PVC
+    set:
+      sharedStorage.create: true
+    asserts:
+      - exists:
+          path: metadata.labels
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^rstudio-pm-[0-9]+\\.[0-9]+\\.[0-9]+.*"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rstudio-pm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.3
+version: 0.9.4
 apiVersion: v2
 appVersion: 2025.05.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.4
+
+- Add recommended labels to all PVCs created by the chart.
+
 ## 0.9.3
 
 - Bump Workbench version to 2025.05.1

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.3:
+To install the chart with the release name `my-release` at version 0.9.4:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.3
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.4
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/templates/pvc.yaml
+++ b/charts/rstudio-workbench/templates/pvc.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
 {{ .Values.sharedStorage.annotations | toYaml | indent 4}}
+  labels:
+    {{- include "rstudio-workbench.labels" . | nindent 4 }}
 spec:
   accessModes:
     {{- .Values.sharedStorage.accessModes | toYaml | nindent 4 }}
@@ -33,6 +35,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
+  labels:
+    {{- include "rstudio-workbench.labels" . | nindent 4 }}
 spec:
   accessModes:
     {{- .Values.homeStorage.accessModes | toYaml | nindent 4 }}

--- a/charts/rstudio-workbench/tests/pvc_test.yaml
+++ b/charts/rstudio-workbench/tests/pvc_test.yaml
@@ -1,0 +1,45 @@
+suite: test pvc
+templates:
+  - pvc.yaml
+tests:
+  - it: should have standard Helm labels on shared storage PVC
+    set:
+      sharedStorage.create: true
+    asserts:
+      - exists:
+          path: metadata.labels
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^rstudio-workbench-[0-9]+\\.[0-9]+\\.[0-9]+.*"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rstudio-workbench
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]
+
+  - it: should have standard Helm labels on home storage PVC
+    set:
+      homeStorage.create: true
+    asserts:
+      - exists:
+          path: metadata.labels
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: "^rstudio-workbench-[0-9]+\\.[0-9]+\\.[0-9]+.*"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rstudio-workbench
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]


### PR DESCRIPTION
## Summary
- Add standard Helm chart selector labels to PVCs in each product chart
- Add tests to verify labels are present and correctly formatted

## Test plan
- Run chart tests in each product directory
- Review rendered manifest output

closes #674 

🤖 Generated with [Claude Code](https://claude.ai/code)