### PR TITLE
Update Chronicle default persistence accessMode to ReadWriteMany

### DIFF
--- a/charts/posit-chronicle/Chart.yaml
+++ b/charts/posit-chronicle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: posit-chronicle
 description: Official Helm chart for Posit Chronicle Server
-version: 0.4.1
+version: 0.4.2
 appVersion: 2025.05.3
 icon: https://posit.co/wp-content/themes/Posit/dist/images/favicon/apple-touch-icon-180x180.png
 home: https://www.posit.co

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -231,7 +231,7 @@ reference page](https://docs.posit.co/chronicle/appendix/library/advanced-server
 | image.tag | string | `""` | The image tag, defaults to the chart app version |
 | nameOverride | string | `""` | Override for the name of the release |
 | namespaceOverride | string | `""` | Override for the namespace of the chart deployment |
-| persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent Volume Access Modes |
+| persistence.accessModes | list | `["ReadWriteMany"]` | Persistent Volume Access Modes |
 | persistence.annotations | object | `{}` | Additional annotations for the PVC |
 | persistence.enabled | bool | `true` | Enable persistence using Persistent Volume Claims |
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Finalizers for the PVC |

--- a/charts/posit-chronicle/README.md
+++ b/charts/posit-chronicle/README.md
@@ -1,6 +1,6 @@
 # Posit Chronicle
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 2025.05.3](https://img.shields.io/badge/AppVersion-2025.05.3-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 2025.05.3](https://img.shields.io/badge/AppVersion-2025.05.3-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Chronicle Server_
 
@@ -25,11 +25,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.4.1:
+To install the chart with the release name `my-release` at version 0.4.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/posit-chronicle --version=0.4.1
+helm upgrade --install my-release rstudio/posit-chronicle --version=0.4.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/posit-chronicle/tests/statefulset_test.yaml
+++ b/charts/posit-chronicle/tests/statefulset_test.yaml
@@ -339,7 +339,7 @@ tests:
               helm.sh/chart: posit-chronicle-9.9.9_test
           spec:
             accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
             resources:
               requests:
                 storage: 10Gi

--- a/charts/posit-chronicle/values.yaml
+++ b/charts/posit-chronicle/values.yaml
@@ -89,7 +89,7 @@ persistence:
   size: 10Gi
   # -- Persistent Volume Access Modes
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   # -- Selector to match an existing Persistent Volume for the data PVC
   selectorLabels: {}
   # -- Additional annotations for the PVC


### PR DESCRIPTION
Discussion on this change happened internally, but the take-aways are this:

1. This change does not enable multiple Chronicle server replicas and doesn't enable any type of HA
2. This change is purely to allow Connect pods to run on other hosts while reporting on Chronicle data and makes the `values.yaml` enable this configuration as a default.