### PR TITLE
PWB: Fix README and example for using `imagePullSecrets` for sessions

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.6
+version: 0.9.7
 apiVersion: v2
 appVersion: 2025.05.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.9.7
 
-- Correct the `README.md` to use the correct `imagePullSecrets` syntax for the launcher template values (`launcher.templateValues.pod.imagePullSecrets`).
+- Correct the `README.md` example to use the correct `imagePullSecrets` syntax for the launcher template values (`launcher.templateValues.pod.imagePullSecrets`).
 
 ## 0.9.6
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.7
+
+- Correct the `README.md` to use the correct `imagePullSecrets` syntax for the launcher template values (`launcher.templateValues.pod.imagePullSecrets`).
+
 ## 0.9.6
 
 - Switch to a hardcoded default for `chronicleAgent.image.tag` to be regularly updated for new releases.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
+![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.6:
+To install the chart with the release name `my-release` at version 0.9.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.6
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.7
 ```
 
 To explore other chart versions, look at:
@@ -397,8 +397,9 @@ For example, if you want to add a container image registry credentials secret to
 ```yaml
 launcher:
   templateValues:
-    imagePullSecrets:
-    - name: private-registry-creds
+    pod:
+      imagePullSecrets:
+      - name: private-registry-creds
 ```
 
 For example, if you want to add a toleration to each session, you can do so with the following:

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -342,8 +342,9 @@ For example, if you want to add a container image registry credentials secret to
 ```yaml
 launcher:
   templateValues:
-    imagePullSecrets:
-    - name: private-registry-creds
+    pod:
+      imagePullSecrets:
+      - name: private-registry-creds
 ```
 
 For example, if you want to add a toleration to each session, you can do so with the following:

--- a/examples/workbench/container-images/rstudio-workbench-custom-image-private.yaml
+++ b/examples/workbench/container-images/rstudio-workbench-custom-image-private.yaml
@@ -41,8 +41,9 @@ session:
 launcher:
   useTemplates: true # Required to set `imagePullSecrets` for `session.image`
   templateValues:
-    imagePullSecrets:
-    - name: private-registry-creds # TODO: Change this to match the secret of type kubernetes.io/dockercfg in your cluster containing authentication credentials to your registry. More information: https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+    pod:
+      imagePullSecrets:
+      - name: private-registry-creds # TODO: Change this to match the secret of type kubernetes.io/dockercfg in your cluster containing authentication credentials to your registry. More information: https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
 
 config:
   secret:


### PR DESCRIPTION
I noticed the current Workbench example and README provide the incorrect syntax for providing container registry credentials for session images. This PR fixes both the example and the section of the Workbench chart README.

This now lines up with the Connect example which is correct: https://github.com/rstudio/helm/blob/b83d01cfe3af84cbea06a95de73c1a1ff536140a/examples/connect/container-images/rstudio-connect-custom-image-private.yaml#L37