### PR TITLE
Add ephemeral storage support to the Workbench Helm chart for session pods

### DIFF
--- a/charts/rstudio-workbench/files/job.tpl
+++ b/charts/rstudio-workbench/files/job.tpl
@@ -309,19 +309,21 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- if any (ne (len $requests) 0) (ne (len $limits) 0) }}
+          {{- if any (ne (len $requests) 0) (ne (len $limits) 0) (ne (len $templateData.pod.ephemeralStorage) 0) }}
           resources:
-            {{- if ne (len $requests) 0 }}
+            {{- if any (ne (len $requests) 0) (ne (len $templateData.pod.ephemeralStorage.request) 0) }}
             requests:
               {{- range $key, $val := $requests }}
               {{ $key }}: {{ toYaml $val }}
               {{- end }}
+              ephemeral-storage: {{ $templateData.pod.ephemeralStorage.request }}
             {{- end }}
-            {{- if ne (len $limits) 0 }}
+            {{- if any (ne (len $limits) 0) (ne (len $templateData.pod.ephemeralStorage.limit) 0) }}
             limits:
               {{- range $key, $val := $limits }}
               {{ $key }}: {{ toYaml $val }}
               {{- end }}
+              ephemeral-storage: {{ $templateData.pod.ephemeralStorage.limit }}
             {{- end }}
           {{- end }}
           {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumeMounts) 0) }}

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -150,6 +150,9 @@ launcher:
       affinity: {}
       nodeSelector: {}
       hostAliases: []
+      ephemeralStorage:
+        request: ""
+        limit: ""
       # -- command for all pods. This is really not something we should expose and will be removed once we have a better option
       command: []
     job:


### PR DESCRIPTION
This change allows administrators to define ephemeral-storage defaults for Workbench session containers!