### PR TITLE
Ephemeral storage fix

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.9
+version: 0.9.10
 apiVersion: v2
 appVersion: 2025.05.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.9.10
 
-- Fix a bug with the new `ephermalStorage` options where it was set every time, even if it was unset in the `values.yaml`
+- Fix a bug with the new `ephermalStorage` options where it was set every time, even if it was unset in the `values.yaml`.
 
 ## 0.9.9
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.10
+
+- Fix a bug with the new `ephermalStorage` options where it was set every time, even if it was unset in the `values.yaml`
+
 ## 0.9.9
 
 - Add options to specify resources for the Chronicle Agent container.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
+![Version: 0.9.10](https://img.shields.io/badge/Version-0.9.10-informational?style=flat-square) ![AppVersion: 2025.05.1](https://img.shields.io/badge/AppVersion-2025.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.9:
+To install the chart with the release name `my-release` at version 0.9.10:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.9
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.9.10
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/files/job.tpl
+++ b/charts/rstudio-workbench/files/job.tpl
@@ -316,14 +316,18 @@ spec:
               {{- range $key, $val := $requests }}
               {{ $key }}: {{ toYaml $val }}
               {{- end }}
+              {{- if gt (len $templateData.pod.ephemeralStorage.request) 0 }}
               ephemeral-storage: {{ $templateData.pod.ephemeralStorage.request }}
+              {{- end }}
             {{- end }}
             {{- if any (ne (len $limits) 0) (ne (len $templateData.pod.ephemeralStorage.limit) 0) }}
             limits:
               {{- range $key, $val := $limits }}
               {{ $key }}: {{ toYaml $val }}
               {{- end }}
+              {{- if gt (len $templateData.pod.ephemeralStorage.limit) 0 }}
               ephemeral-storage: {{ $templateData.pod.ephemeralStorage.limit }}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- if or (ne (len .Job.volumes) 0) (ne (len $templateData.pod.volumeMounts) 0) }}


### PR DESCRIPTION
I received reports of errors occurring in internal environments because ephemeral storage was being set all the time, rather than only when defined in the `values.yaml` this PR appropriately wraps the ephemeralStorage definitions to set them only if they have a value.