### PR TITLE
Chronicle agent server address resolution fixes

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.6
+version: 0.8.7
 apiVersion: v2
 appVersion: 2025.07.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.7
+
+- Skip `rstudio-library` template call when `chronicleAgent.autoDiscovery=false`. Require `chronicleAgent.serverAddress` 
+  to be set instead.
+
 ## 0.8.6
 
 - Add options to specify resources for the Chronicle Agent container.

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -118,7 +118,11 @@ spec:
         {{- end }}
         env:
           - name: CHRONICLE_SERVER_ADDRESS
+            {{- if .Values.chronicleAgent.autoDiscovery }}
             value: {{ include "rstudio-library.chronicle-agent.serverAddress" (dict "chronicleAgent" .Values.chronicleAgent "Release" .Release) | trim | quote }}
+            {{- else }}
+            value: {{ required "chronicleAgent.serverAddress must be specified if autoDiscovery is disabled." .Values.chronicleAgent.serverAddress | quote }}
+            {{- end }}
           - name: CHRONICLE_CONNECT_APIKEY
             {{- if .Values.chronicleAgent.connectApiKey.valueFrom }}
             valueFrom:

--- a/charts/rstudio-library/Chart.yaml
+++ b/charts/rstudio-library/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rstudio-library
 description: Helm library helpers for use by official RStudio charts
 type: library
-version: 0.1.34
-appVersion: 0.1.34
+version: 0.1.35
+appVersion: 0.1.35
 
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com

--- a/charts/rstudio-library/NEWS.md
+++ b/charts/rstudio-library/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.1.35
+
+- Fix `rstudio-library.chronicle-agent.serverAddress` failure when lookup returns none.
+- Fail `rstudio-library.chronicle-agent.serverAddress` if no server address could be resolved.
+
 ## 0.1.34
 
 - Add HTTP/HTTPS protocol prefix to `rstudio-library.chronicle-agent.serverAddress` function return.

--- a/charts/rstudio-library/templates/_chronicle-agent.tpl
+++ b/charts/rstudio-library/templates/_chronicle-agent.tpl
@@ -39,7 +39,7 @@ Takes a dict:
 {{- define "rstudio-library.chronicle-agent.serverAddress" }}
 {{- if .chronicleAgent.serverAddress }}
 {{- .chronicleAgent.serverAddress }}
-{{- else }}
+{{- else if lookup "v1" "Service" (default .Release.Namespace .chronicleAgent.serverNamespace) "" }}
 {{- range $index, $service := (lookup "v1" "Service" (default .Release.Namespace .chronicleAgent.serverNamespace) "").items }}
 {{- $name := get $service.metadata.labels "app.kubernetes.io/name" }}
 {{- $component := get $service.metadata.labels "app.kubernetes.io/component" }}
@@ -47,5 +47,7 @@ Takes a dict:
 {{- (index $service.spec.ports 0).name }}://{{ $service.metadata.name }}.{{ $service.metadata.namespace }}
 {{- end }}
 {{- end }}
+{{- else }}
+{{- fail "Unable to resolve a Chronicle server address for Chronicle agent. Ensure that a Chronicle server is deployed in the same namespace as this chart or the namespace is specfied with chronicleAgent.serverNamespace when using chronicleAgent.autoDiscovery=true. Alternatively, specify chronicleAgent.serverAddress in the values.yaml file." }}
 {{- end }}
 {{- end }}

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.9.10
+version: 0.9.11
 apiVersion: v2
 appVersion: 2025.05.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.11
+
+- Skip `rstudio-library` template call when `chronicleAgent.autoDiscovery=false`. Require `chronicleAgent.serverAddress`
+  to be set instead.
+
 ## 0.9.10
 
 - Fix a bug with the new `ephermalStorage` options where it was set every time, even if it was unset in the `values.yaml`.

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -125,7 +125,11 @@ spec:
           {{- end }}
           env:
             - name: CHRONICLE_SERVER_ADDRESS
+              {{- if .Values.chronicleAgent.autoDiscovery }}
               value: {{ include "rstudio-library.chronicle-agent.serverAddress" (dict "chronicleAgent" .Values.chronicleAgent "Release" .Release) | trim | quote }}
+              {{- else }}
+              value: {{ required "chronicleAgent.serverAddress must be specified if autoDiscovery is disabled." .Values.chronicleAgent.serverAddress | quote }}
+              {{- end }}
             - name: CHRONICLE_WORKBENCH_APIKEY
               {{- if .Values.chronicleAgent.workbenchApiKey.valueFrom }}
               valueFrom:


### PR DESCRIPTION
- Skip calling `rstudio-library` when `chronicleAgent.autoDiscovery=false`. Require `chronicleAgent.serverAddress` be specified instead.
- Add validation step in `rstudio-library.chronicle-agent.serverAddress` to check if the lookup returns an empty value.
- Fail `rstudio-library.chronicle-agent.serverAddress` render if no server address can be resolved.