### PR TITLE
Only send Slack messages on main

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Notify Slack of chart documentation failure
-        if: failure()
+      - name: Notify Slack of chart documentation failure on main
+        if: github.ref == 'refs/heads/main' && failure()
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload-delimiter: "_"
@@ -100,8 +100,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Notify Slack of chart documentation (rbac) failure
-        if: failure()
+      - name: Notify Slack of chart documentation (rbac) failure on main
+        if: github.ref == 'refs/heads/main' && failure()
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload-delimiter: "_"

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -47,8 +47,8 @@ jobs:
         run: ct lint --target-branch main --all --chart-dirs charts --chart-dirs other-charts
         continue-on-error: true
 
-      - name: Notify Slack of chart linting failure
-        if: steps.ct-lint.outcome == 'failure' || steps.ct-lint-all.outcome == 'failure'
+      - name: Notify Slack of chart linting failure if on main
+        if: github.ref == 'refs/heads/main' && (steps.ct-lint.outcome == 'failure' || steps.ct-lint-all.outcome == 'failure')
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload-delimiter: "_"
@@ -95,8 +95,8 @@ jobs:
           done
         continue-on-error: true
 
-      - name: Notify Slack of chart unittest failure
-        if: steps.unittest.outcome == 'failure'
+      - name: Notify Slack of chart unittest failure if on main
+        if: github.ref == 'refs/heads/main' && steps.unittest.outcome == 'failure'
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload-delimiter: "_"
@@ -185,8 +185,8 @@ jobs:
         run: ct install --target-branch main --all --chart-dirs charts --chart-dirs other-charts --excluded-charts rstudio-library --namespace posit-test
         continue-on-error: true
 
-      - name: Notify Slack of chart install failure
-        if: steps.ct-install.outcome == 'failure' || steps.ct-install-all.outcome == 'failure'
+      - name: Notify Slack of chart install failure if on main
+        if: github.ref == 'refs/heads/main' && (steps.ct-install.outcome == 'failure' || steps.ct-install-all.outcome == 'failure')
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload-delimiter: "_"


### PR DESCRIPTION
As discussed internally, we just want to see Slack messages for main failures now.  They will still of course still run, show up here, message people in their own way on failure, and stop people from merging when things fail.