### PR TITLE
Allow us to manually kick off testing of the charts

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
There are some cases where we won't have a pull request, but still need to run the tests.

For instance, I need to update the license files for all the products, as they are expiring this month.  Those are changed as github secrets on the repo.  I need to be able to kick off the install tests to be sure they are working as expected.