### PR TITLE
feat: add nameservice configuration for current user execution

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.17
+version: 0.8.18
 apiVersion: v2
 appVersion: 2025.12.1
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.17](https://img.shields.io/badge/Version-0.8.17-informational?style=flat-square) ![AppVersion: 2025.12.1](https://img.shields.io/badge/AppVersion-2025.12.1-informational?style=flat-square)
+![Version: 0.8.18](https://img.shields.io/badge/Version-0.8.18-informational?style=flat-square) ![AppVersion: 2025.12.1](https://img.shields.io/badge/AppVersion-2025.12.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.17:
+To install the chart with the release name `my-release` at version 0.8.18:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.17
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.18
 ```
 
 To explore other chart versions, look at:
@@ -278,6 +278,11 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | license.server | bool | `false` | server is the <hostname>:<port> for a license server |
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | Used to configure the container's livenessProbe. Only included if enabled = true |
 | nameOverride | string | `""` | The name of the chart deployment (can be overridden) |
+| nameservice | object | `{"apiKey":"","enabled":false,"secretName":"","server":"http://127.0.0.1:3939"}` | Nameservice configuration for current user execution (RunAsCurrentUser). This can only be enabled if using an SSO authentication provider (OAuth2, SAML, or LDAP). |
+| nameservice.apiKey | string | `""` | Connect API key for nameservice module. Must be a Viewer API key. |
+| nameservice.enabled | bool | `false` | Whether to enable nameservice integration. |
+| nameservice.secretName | string | `""` | Optional: name of existing secret containing libnss_connect.conf (overrides apiKey and server). The secret must be in the same namespace as the Connect deployment. |
+| nameservice.server | string | `"http://127.0.0.1:3939"` | Connect server URL for nameservice module. |
 | nodeSelector | object | `{}` | A map used verbatim as the pod's "nodeSelector" definition |
 | pod.affinity | object | `{}` | A map used verbatim as the pod's "affinity" definition |
 | pod.annotations | object | `{}` | Additional annotations to add to the rstudio-connect pods |

--- a/charts/rstudio-connect/prestart.bash
+++ b/charts/rstudio-connect/prestart.bash
@@ -2,9 +2,7 @@
 set -o errexit
 set -o pipefail
 
-main() {
-  local startup_script="${1:-/usr/local/bin/startup.sh}"
-
+kubernetes_health_check() {
   local cacert='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
   local k8s_url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
 
@@ -18,6 +16,50 @@ main() {
     --cacert "${cacert}" \
     "${k8s_url}/healthz" 2>&1 | _indent
   printf '\n'
+}
+
+configure_nameservice_module() {
+  # Check if NSS Connect config file exists (mounted as a secret)
+  if [[ ! -f "/etc/libnss_connect.conf" ]]; then
+    _logf 'Nameservice config not found at /etc/libnss_connect.conf. Skipping nameservice setup'
+    return 0
+  fi
+
+  _logf 'Found /etc/libnss_connect.conf mounted from secret'
+  _logf 'Configuring nameservice module'
+
+  cp /etc/nsswitch.conf /etc/nsswitch.conf.backup
+
+  # Ensure required lines exist in nsswitch.conf
+  # Default to 'files' which matches glibc's implicit default when a line is missing
+  for db in passwd group initgroups; do
+    grep -q "^${db}:" /etc/nsswitch.conf || echo "${db}: files" >> /etc/nsswitch.conf
+  done
+
+  # Add 'connect' module to each line
+  sed -i \
+    -e '/^passwd:/ { /connect/! s/$/ connect/ }' \
+    -e '/^group:/ { /connect/! s/$/ connect/ }' \
+    -e '/^initgroups:/ { /connect/! s/$/ connect/ }' \
+    /etc/nsswitch.conf
+
+  _logf 'Updated /etc/nsswitch.conf with connect module'
+
+  # Run the nameservice activation script
+  if [[ -x "/opt/rstudio-connect/extras/nameservice/activate-nameservice.sh" ]]; then
+    /opt/rstudio-connect/extras/nameservice/activate-nameservice.sh
+  else
+    _logf 'WARNING: nameservice activation script not found or not executable'
+  fi
+
+  printf '\n'
+}
+
+main() {
+  local startup_script="${1:-/usr/local/bin/startup.sh}"
+
+  kubernetes_health_check
+  configure_nameservice_module
 
   _logf 'Replacing process with %s' "${startup_script}"
   exec "${startup_script}"

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -219,6 +219,12 @@ spec:
             {{- end }}
           {{- end }}
           {{ include "rstudio-library.license-mount" (dict "license" ( .Values.license )) | indent 10 }}
+          {{- if .Values.nameservice.enabled }}
+          - name: nameservice-config
+            mountPath: "/etc/libnss_connect.conf"
+            subPath: "libnss_connect.conf"
+            readOnly: true
+          {{- end }}
       {{- if .Values.pod.volumeMounts }}
           {{- toYaml .Values.pod.volumeMounts | nindent 10 }}
       {{- end }}
@@ -288,6 +294,15 @@ spec:
       {{- end }}
       {{- if .Values.pod.volumes }}
 {{ toYaml .Values.pod.volumes | indent 6 }}
+      {{- end }}
+      {{- if .Values.nameservice.enabled }}
+      - name: nameservice-config
+        secret:
+          secretName: {{ .Values.nameservice.secretName | default (printf "%s-nameservice-config" (include "rstudio-connect.fullname" .)) }}
+          defaultMode: 0444
+          items:
+          - key: libnss_connect.conf
+            path: libnss_connect.conf
       {{- end }}
       {{- if .Values.launcher.enabled }}
       {{- if .Values.launcher.useTemplates }}

--- a/charts/rstudio-connect/templates/nameservice-secret.yaml
+++ b/charts/rstudio-connect/templates/nameservice-secret.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.nameservice.enabled }}
+{{- $authProvider := "" }}
+{{- if hasKey .Values.config "Authentication" }}
+{{- if hasKey .Values.config.Authentication "Provider" }}
+{{- $authProvider = .Values.config.Authentication.Provider }}
+{{- end }}
+{{- end }}
+{{- $validProviders := list "oauth2" "saml" "ldap" }}
+{{- if not (has $authProvider $validProviders) }}
+{{- fail (printf "nameservice.enabled requires config.Authentication.Provider to be one of: %s. Current provider: '%s'" (join ", " $validProviders) $authProvider) }}
+{{- end }}
+{{- if and .Values.nameservice.secretName .Values.nameservice.apiKey }}
+{{- fail "nameservice.secretName and nameservice.apiKey cannot both be set. Use secretName to use an existing secret OR apiKey to create a new secret." }}
+{{- end }}
+{{- if and (not .Values.nameservice.secretName) (not .Values.nameservice.apiKey) }}
+{{- fail "When nameservice.enabled is true, either nameservice.secretName (for existing secret) or nameservice.apiKey (to create new secret) must be provided." }}
+{{- end }}
+{{- if not .Values.nameservice.secretName }}
+{{- $config := printf "CONNECT_API_KEY=%s\nCONNECT_SERVER=%s" .Values.nameservice.apiKey .Values.nameservice.server }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rstudio-connect.fullname" . }}-nameservice-config
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "rstudio-connect.labels" . | nindent 4 }}
+type: Opaque
+data:
+  libnss_connect.conf: {{ $config | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/rstudio-connect/tests/nameservice_test.yaml
+++ b/charts/rstudio-connect/tests/nameservice_test.yaml
@@ -1,0 +1,271 @@
+suite: Connect Nameservice
+templates:
+  - nameservice-secret.yaml
+  - deployment.yaml
+  - configmap.yaml
+  - configmap-prestart.yaml
+tests:
+  # =============================================================================
+  # nameservice-secret.yaml
+  # =============================================================================
+
+  - it: should not create secret when nameservice is disabled
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: false
+        apiKey: "test-key"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create secret when nameservice is enabled with valid auth provider and apiKey
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rstudio-connect-nameservice-config
+      - equal:
+          path: type
+          value: Opaque
+      - exists:
+          path: data["libnss_connect.conf"]
+      - equal:
+          path: data["libnss_connect.conf"]
+          decodeBase64: true
+          value: |-
+            CONNECT_API_KEY=test-key
+            CONNECT_SERVER=http://127.0.0.1:3939
+
+  - it: should work with oauth2 authentication provider
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should work with saml authentication provider
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: saml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should work with ldap authentication provider
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: ldap
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should fail when nameservice enabled with password authentication
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: password
+    asserts:
+      - failedTemplate:
+          errorMessage: "nameservice.enabled requires config.Authentication.Provider to be one of: oauth2, saml, ldap. Current provider: 'password'"
+
+  - it: should fail when both secretName and apiKey are provided
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+        secretName: "existing-secret"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - failedTemplate:
+          errorMessage: "nameservice.secretName and nameservice.apiKey cannot both be set. Use secretName to use an existing secret OR apiKey to create a new secret."
+
+  - it: should fail when neither secretName nor apiKey are provided
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - failedTemplate:
+          errorMessage: "When nameservice.enabled is true, either nameservice.secretName (for existing secret) or nameservice.apiKey (to create new secret) must be provided."
+
+  - it: should not create secret when using existing secretName
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        secretName: "my-existing-secret"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom server value in secret
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+        server: "https://connect.example.com:3939"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - exists:
+          path: data["libnss_connect.conf"]
+      - equal:
+          path: data["libnss_connect.conf"]
+          decodeBase64: true
+          value: |-
+            CONNECT_API_KEY=test-key
+            CONNECT_SERVER=https://connect.example.com:3939
+
+  - it: should have proper labels on created secret
+    template: nameservice-secret.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: oauth2
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rstudio-connect
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]
+
+  # =============================================================================
+  # deployment.yaml
+  # =============================================================================
+
+  - it: should not mount nameservice config when disabled
+    template: deployment.yaml
+    set:
+      nameservice:
+        enabled: false
+      launcher:
+        enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "nameservice-config")]
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == "nameservice-config")]
+
+  - it: should mount nameservice config when enabled with apiKey
+    template: deployment.yaml
+    set:
+      nameservice:
+        enabled: true
+        apiKey: "test-key"
+      config:
+        Authentication:
+          Provider: oauth2
+      launcher:
+        enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nameservice-config
+            mountPath: "/etc/libnss_connect.conf"
+            subPath: "libnss_connect.conf"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nameservice-config
+            secret:
+              secretName: RELEASE-NAME-rstudio-connect-nameservice-config
+              defaultMode: 0444
+              items:
+              - key: libnss_connect.conf
+                path: libnss_connect.conf
+
+  - it: should mount nameservice config when enabled with existing secretName
+    template: deployment.yaml
+    set:
+      nameservice:
+        enabled: true
+        secretName: "my-existing-secret"
+      config:
+        Authentication:
+          Provider: oauth2
+      launcher:
+        enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nameservice-config
+            mountPath: "/etc/libnss_connect.conf"
+            subPath: "libnss_connect.conf"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nameservice-config
+            secret:
+              secretName: "my-existing-secret"
+              defaultMode: 0444
+              items:
+              - key: libnss_connect.conf
+                path: libnss_connect.conf

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -401,6 +401,19 @@ launcher:
     # -- The securityContext for the default initContainer
     securityContext: {}
 
+# -- Nameservice configuration for current user execution (RunAsCurrentUser).
+# This can only be enabled if using an SSO authentication provider (OAuth2, SAML, or LDAP).
+nameservice:
+  # -- Whether to enable nameservice integration.
+  enabled: false
+  # -- Connect API key for nameservice module. Must be a Viewer API key.
+  apiKey: ""
+  # -- Connect server URL for nameservice module.
+  server: "http://127.0.0.1:3939"
+  # -- Optional: name of existing secret containing libnss_connect.conf (overrides apiKey and server).
+  # The secret must be in the same namespace as the Connect deployment.
+  secretName: ""
+
 # -- A nested map of maps that generates the rstudio-connect.gcfg file
 # @default -- [Posit Connect Configuration Reference](https://docs.posit.co/connect/admin/appendix/off-host/helm-reference/)
 config:


### PR DESCRIPTION
Closes https://github.com/posit-dev/connect/issues/34411

## Testing Results

### Environment

- EKS reference architecture with Keycloak SSO (OAuth2 provider), Postgres, and EFS
- Connect daily build with RACU + nameservice enabled


### Configuration

  ```yaml
config:
    Authentication:
      Provider: oauth2
    OAuth2:
      GroupsClaim: groups
      GroupsAutoProvision: true
    Applications:
      RunAsCurrentUser: true
    EarlyAccess:
      RunAsCurrentUserSSO: true

  nameservice:
    enabled: true
    apiKey: "<viewer-api-key>"
    server: "http://127.0.0.1:3939" ## nameservice module is installed in the same container as the Connect process, so we can use the loopback address for API calls.
```

### Test Cases

1. NSS module resolves nameservice user with supplementary groups

      The `administrators` group GID (7001) was set via the Connect PATCH groups API:
      
      ```bash
       curl -X PATCH -H "Authorization: Key $ADMIN_API_KEY" \
          -d '{"gid": 7001}' \
          "http://<connect>/__api__/v1/groups/<guid>"
      ```

      ```bash
      # keycloak admin user was automatically assigned a UID of 29173 on first login to Connect and appended the UID to the Linux username.
      # The admin user is a member of the administrators group and inherits its GID (7001) as a Linux supplementary group.
      $ kubectl exec <connect-pod> -- id admin-29173
      uid=29173(admin-29173) gid=999(rstudio-connect) groups=999(rstudio-connect),7001(administrators)
      ```

  2. Supplementary group file access works

        Created a test directory and file with group 7001 ownership (file has 0640 permissions so only group members can read the file):
  
        ```bash
        drwxr-x--- root:7001 /mnt/shared/
        -rw-r----- root:7001 /mnt/shared/secret.txt
        ```

      Content running as `admin-29173` (member of group 7001) successfully read the file.

<img width="924" height="612" alt="Screenshot 2026-01-13 at 5 02 27 PM" src="https://github.com/user-attachments/assets/23914e96-b9e2-4519-a0ba-1fd4eac48454" />
