### PR TITLE
Update Package Manager to 2025.09.2

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.50
+version: 0.5.51
 apiVersion: v2
-appVersion: 2025.09.0
+appVersion: 2025.09.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png
 home: https://www.rstudio.com
 sources:
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:ubuntu2204-2025.09.0
+      image: rstudio/rstudio-package-manager:ubuntu2204-2025.09.2
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.51
+
+- Update default Posit Package Manager version to 2025.09.2-10
+
 ## 0.5.50
 
 - Update default Posit Package Manager version to 2025.09.0-7

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.50](https://img.shields.io/badge/Version-0.5.50-informational?style=flat-square) ![AppVersion: 2025.09.0](https://img.shields.io/badge/AppVersion-2025.09.0-informational?style=flat-square)
+![Version: 0.5.51](https://img.shields.io/badge/Version-0.5.51-informational?style=flat-square) ![AppVersion: 2025.09.2](https://img.shields.io/badge/AppVersion-2025.09.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.50:
+To install the chart with the release name `my-release` at version 0.5.51:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.50
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.51
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
I can't merge https://github.com/rstudio/helm/pull/734 because the github status won't update even after re-pushing to it?