### PR TITLE
Use subPaths when mounting the runtime components to the content container

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.13
+version: 0.8.14
 apiVersion: v2
 appVersion: 2025.10.0
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.14
+
+- Use individual `R`, `python`, `scripts`, `ext` subPath mounts when mounting the `rsc-volume` EmptyDir
+  to the content runtime container after the init-container copy. This avoids masking all of `/opt/rstudio-connect`.
+
 ## 0.8.13
 
 - Bump Connect version to 2025.10.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.13](https://img.shields.io/badge/Version-0.8.13-informational?style=flat-square) ![AppVersion: 2025.10.0](https://img.shields.io/badge/AppVersion-2025.10.0-informational?style=flat-square)
+![Version: 0.8.14](https://img.shields.io/badge/Version-0.8.14-informational?style=flat-square) ![AppVersion: 2025.10.0](https://img.shields.io/badge/AppVersion-2025.10.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.13:
+To install the chart with the release name `my-release` at version 0.8.14:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.13
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.14
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -16,8 +16,14 @@ data:
       {{- $emptyRscVolume := dict "name" ("rsc-volume") "emptydir" (dict) }}
       {{- $jobJsonRuntimeVolume := dict "target" ("/spec/template/spec/volumes/-") "name" ("defaultRuntimeConnectVolume") "json" ( $emptyRscVolume ) }}
     {{- /* 2 - volumeMount */ -}}
-      {{- $rscVolumeMount := dict "name" ("rsc-volume") "mountPath" ("/opt/rstudio-connect") }}
-      {{- $jobJsonRuntimeMount := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMount") "json" ( $rscVolumeMount ) }}
+      {{- $rscVolumeMountR := dict "name" ("rsc-volume") "mountPath" ("/opt/rstudio-connect/R") "subPath" ("R") }}
+      {{- $rscVolumeMountPython := dict "name" ("rsc-volume") "mountPath" ("/opt/rstudio-connect/python") "subPath" ("python") }}
+      {{- $rscVolumeMountScripts := dict "name" ("rsc-volume") "mountPath" ("/opt/rstudio-connect/scripts") "subPath" ("scripts") }}
+      {{- $rscVolumeMountExt := dict "name" ("rsc-volume") "mountPath" ("/opt/rstudio-connect/ext") "subPath" ("ext") }}
+      {{- $jobJsonRuntimeMountR := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMountR") "json" ( $rscVolumeMountR ) }}
+      {{- $jobJsonRuntimeMountPython := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMountPython") "json" ( $rscVolumeMountPython ) }}
+      {{- $jobJsonRuntimeMountScripts := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMountScripts") "json" ( $rscVolumeMountScripts ) }}
+      {{- $jobJsonRuntimeMountExt := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMountExt") "json" ( $rscVolumeMountExt ) }}
     {{- /* 3 - init container */ -}}
       {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
       {{- $initContainerImageTag := .Values.launcher.defaultInitContainer.tag | default (printf "%s%s" .Values.launcher.defaultInitContainer.tagPrefix $defaultVersion )}}
@@ -31,7 +37,7 @@ data:
     {{- /* set up job-json defaults */ -}}
       {{- $jobJsonDefaults := list }}
       {{- if and (not .Values.launcher.useTemplates) .Values.launcher.defaultInitContainer.enabled }}
-        {{- $jobJsonDefaults = list $jobJsonRuntimeVolume $jobJsonRuntimeMount $jobJsonInitContainer }}
+        {{- $jobJsonDefaults = list $jobJsonRuntimeVolume $jobJsonRuntimeMountR $jobJsonRuntimeMountPython $jobJsonRuntimeMountScripts $jobJsonRuntimeMountExt $jobJsonInitContainer }}
       {{- end }}
     {{- /* build the configuration for profiles */ -}}
       {{- $profilesConfig := .Values.launcher.launcherKubernetesProfilesConf }}
@@ -48,7 +54,7 @@ data:
       {{- $_ := set $sessionTemplate.pod "initContainers" $initList }}
       {{- $volumeList := append $sessionTemplate.pod.volumes $emptyRscVolume }}
       {{- $_ := set $sessionTemplate.pod "volumes" $volumeList }}
-      {{- $volumeMountList := append $sessionTemplate.pod.volumeMounts $rscVolumeMount }}
+      {{- $volumeMountList := concat $sessionTemplate.pod.volumeMounts (list $rscVolumeMountR $rscVolumeMountPython $rscVolumeMountScripts $rscVolumeMountExt ) }}
       {{- $_ := set $sessionTemplate.pod "volumeMounts" $volumeMountList }}
     {{- end }}
 {{- if not .Values.launcher.useTemplates }}


### PR DESCRIPTION
Containerized apps fail to run because `/opt/rstudio-connect/mnt/app` is masked by our runtime mounts from the `rsc-volume` EmptyDir. 

We can use `subPath`s to prevent overwriting the `mnt/app` directory inside the image

```
❯ k logs run-containerized-application-vnkk5-ng42w
Defaulted container "rs-launcher-container" out of: rs-launcher-container, init (init)
2025/11/14 22:25:32.313147029 [connect-session] Connect Session v2025.11.0-dev+100-gab8d91ed05
2025/11/14 22:25:33.300040976 [connect-session] Content GUID: 159aaba4-b8d3-4669-8666-fedca5345c01
2025/11/14 22:25:33.300060353 [connect-session] Content ID: 1
2025/11/14 22:25:33.300062909 [connect-session] Bundle ID: 1
2025/11/14 22:25:33.300065131 [connect-session] Job Key: a1Q4pmiqWkujpiZ2
2025/11/14 22:25:33.372709441 Running on host: run-containerized-application-vnkk5-ng42w
2025/11/14 22:25:33.372724044 Process ID: 31
2025/11/14 22:25:33.376820384 Linux distribution: Ubuntu 22.04.5 LTS (jammy)
2025/11/14 22:25:33.377715438 Running as user: uid=999 gid=999 groups=999
2025/11/14 22:25:33.377725184 Connect version: 2025.11.0-dev+111-g52c5f855e2
2025/11/14 22:25:33.377752374 LANG: en_US.UTF-8
2025/11/14 22:25:33.377753519 Working directory: /opt/rstudio-connect/mnt/app
2025/11/14 22:25:33.377758965 Bootstrapping environment using Python 3.11.9 (main, Apr 22 2025, 14:41:31) [GCC 11.4.0] at /opt/python/3.11.9/bin/python
2025/11/14 22:25:33.377769135 Running content using the current Python environment
2025/11/14 22:25:34.067395424 Running content using Python "3.11.9 (main, Apr 22 2025, 14:41:31) [GCC 11.4.0]" at "/opt/python/3.11.9/bin/python"
2025/11/14 22:25:34.067488629 Loading code from "app"
2025/11/14 22:25:34.067663673 Error while loading Python API: Could not import module 'app'. Connect expected to find a file in the application directory named 'app.py'. Please check the entrypoint specified in the manifest.json file or on the rsconnect-python command line. Reason: No module named 'app'.
```

- [x] Confirmed that both templates and jobJsonOverrides are now working with the [latest commit](https://github.com/rstudio/helm/pull/737/commits/2f502df97b098c74558bf4ca190e662a1367332a).