### PR TITLE
Fh al wb conditional secret fields

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.10.1
+version: 0.10.2
 apiVersion: v2
 appVersion: 2025.09.2
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-Flat.png

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.2
+
+- Add support for `config.existingSecrets` to reference external Kubernetes Secrets.
+- Avoid templating `launcher.pem` and `secureCookieKey` into chart-managed secret when using existing secrets (redundant).
+
 ## 0.10.1
 
 - Resolve bug in database.conf legacy support for config.secret.database.conf key.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: 2025.09.2](https://img.shields.io/badge/AppVersion-2025.09.2-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![AppVersion: 2025.09.2](https://img.shields.io/badge/AppVersion-2025.09.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.10.1:
+To install the chart with the release name `my-release` at version 0.10.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.1
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.2
 ```
 
 To explore other chart versions, look at:
@@ -497,6 +497,43 @@ chronicleAgent:
 For additional information on enabling the API and generating API keys, see
 [the Workbench documentation](https://docs.posit.co/ide/server-pro/admin/workbench_api/workbench_api.html).
 
+## Using existing secrets
+
+This chart supports referencing existing Kubernetes Secrets for sensitive configuration values.
+
+**Note**: For database configuration, see the [Database](#database) section above for usage of `config.database.conf.existingSecret`.
+
+### Using existing secrets for `launcher.pem` and `secureCookieKey`
+
+Instead of having the chart generate and manage `launcher.pem` and `secureCookieKey`, you can reference existing Kubernetes Secrets:
+
+```yaml
+launcherPem:
+  existingSecret: my-launcher-pem-secret  # Secret must have key: launcher.pem
+
+secureCookieKey:
+  existingSecret: my-cookie-key-secret    # Secret must have key: secure-cookie-key
+```
+
+When using `existingSecret`, the chart will **not** template these values into the chart-managed secret, avoiding duplication and ensuring the external secret is the single source of truth.
+
+### Using existing secrets for arbitrary configurations
+
+For other secret configuration files (like `openid-client-secret`), use `config.existingSecrets`:
+
+```yaml
+config:
+  existingSecrets:
+    - name: my-secret-name
+      items:
+        - key: openid-client-secret
+          path: openid-client-secret
+```
+
+All files specified in `config.existingSecrets` are mounted to `/mnt/secret-configmap/rstudio/` with `0600` permissions, alongside any files defined in `config.secret`.
+
+**Note**: `config.existingSecrets` and `config.secret` work together - you can use both simultaneously. Use `config.secret` for inline values and `config.existingSecrets` for externally managed secrets.
+
 ## Sealed secrets
 
 This chart supports the use of [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) to allow for storing secrets in SCM and to ensure secrets are never leaked via Helm. The target cluster must include a `SealedSecret` controller as the controller is responsible for converting a `SealedSecret` to a `Secret`.
@@ -547,6 +584,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | config.defaultMode.sessionSecret | int | 0420 | default mode for session secrets |
 | config.defaultMode.startup | int | 0755 | default mode for startup config |
 | config.defaultMode.userProvisioning | int | 0600 | default mode for userProvisioning config |
+| config.existingSecrets | list | `[]` | a list of existing Kubernetes Secrets to project into `/mnt/secret-configmap/rstudio/`. Each item should have `name` (secret name) and `items` (list of keys to mount with their paths). Mounted with 0600 permissions by default. |
 | config.pam | object | `{}` | a map of pam config files. Will be mounted into the container directly / per file, in order to avoid overwriting system pam files |
 | config.profiles | object | `{}` | a map of server-scoped config files (akin to `config.server`), but with specific behavior that supports profiles. See README for more information. |
 | config.secret | string | `nil` | a map of secret, server-scoped config files (database.conf, databricks.conf, openid-client-secret). Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions |

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -443,6 +443,43 @@ chronicleAgent:
 For additional information on enabling the API and generating API keys, see
 [the Workbench documentation](https://docs.posit.co/ide/server-pro/admin/workbench_api/workbench_api.html).
 
+## Using existing secrets
+
+This chart supports referencing existing Kubernetes Secrets for sensitive configuration values.
+
+**Note**: For database configuration, see the [Database](#database) section above for usage of `config.database.conf.existingSecret`.
+
+### Using existing secrets for `launcher.pem` and `secureCookieKey`
+
+Instead of having the chart generate and manage `launcher.pem` and `secureCookieKey`, you can reference existing Kubernetes Secrets:
+
+```yaml
+launcherPem:
+  existingSecret: my-launcher-pem-secret  # Secret must have key: launcher.pem
+
+secureCookieKey:
+  existingSecret: my-cookie-key-secret    # Secret must have key: secure-cookie-key
+```
+
+When using `existingSecret`, the chart will **not** template these values into the chart-managed secret, avoiding duplication and ensuring the external secret is the single source of truth.
+
+### Using existing secrets for arbitrary configurations
+
+For other secret configuration files (like `openid-client-secret`), use `config.existingSecrets`:
+
+```yaml
+config:
+  existingSecrets:
+    - name: my-secret-name
+      items:
+        - key: openid-client-secret
+          path: openid-client-secret
+```
+
+All files specified in `config.existingSecrets` are mounted to `/mnt/secret-configmap/rstudio/` with `0600` permissions, alongside any files defined in `config.secret`.
+
+**Note**: `config.existingSecrets` and `config.secret` work together - you can use both simultaneously. Use `config.secret` for inline values and `config.existingSecrets` for externally managed secrets.
+
 ## Sealed secrets
 
 This chart supports the use of [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) to allow for storing secrets in SCM and to ensure secrets are never leaked via Helm. The target cluster must include a `SealedSecret` controller as the controller is responsible for converting a `SealedSecret` to a `Secret`.

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -133,7 +133,7 @@ containers:
     - name: rstudio-session-secret
       mountPath: {{ .Values.session.defaultSecretMountPath }}
     {{- end }}
-    {{- if or .Values.launcherPem.existingSecret .Values.secureCookieKey.existingSecret .Values.global.secureCookieKey.existingSecret .Values.config.database.conf.existingSecret .Values.config.secret }}
+    {{- if or .Values.launcherPem.existingSecret .Values.secureCookieKey.existingSecret .Values.global.secureCookieKey.existingSecret .Values.config.database.conf.existingSecret .Values.config.secret .Values.config.existingSecrets }}
     - name: rstudio-secret
       mountPath: "/mnt/secret-configmap/rstudio/"
     {{- end }}
@@ -316,7 +316,7 @@ volumes:
     name: {{ include "rstudio-workbench.fullname" . }}-pam
     defaultMode: {{ .Values.config.defaultMode.pam }}
 {{- end }}
-{{- if or .Values.launcherPem.existingSecret .Values.secureCookieKey.existingSecret .Values.global.secureCookieKey.existingSecret .Values.config.database.conf.existingSecret .Values.config.secret }}
+{{- if or .Values.launcherPem.existingSecret .Values.secureCookieKey.existingSecret .Values.global.secureCookieKey.existingSecret .Values.config.database.conf.existingSecret .Values.config.secret .Values.config.existingSecrets }}
 - name: rstudio-secret
   projected:
     sources:
@@ -361,6 +361,16 @@ volumes:
         - key: database.conf
           path: database.conf
           mode: {{ .Values.config.defaultMode.secret }}
+{{- end }}
+{{- range .Values.config.existingSecrets }}
+    - secret:
+        name: {{ .name }}
+        items:
+        {{- range .items }}
+        - key: {{ .key }}
+          path: {{ .path }}
+          mode: {{ $.Values.config.defaultMode.secret }}
+        {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.config.userProvisioning }}

--- a/charts/rstudio-workbench/templates/configmap-secret.yaml
+++ b/charts/rstudio-workbench/templates/configmap-secret.yaml
@@ -49,10 +49,14 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 stringData:
   {{- include "rstudio-library.config.ini" .Values.config.secret | nindent 2 }}
+  {{- if not .Values.launcherPem.existingSecret }}
   launcher.pem: |
     {{- include "rstudio-workbench.launcherPem" . | nindent 4 }}
+  {{- end }}
+  {{- if not (or .Values.secureCookieKey.existingSecret .Values.global.secureCookieKey.existingSecret) }}
   secure-cookie-key: |
     {{- include "rstudio-workbench.secureCookieKey" . | nindent 4 }}
+  {{- end }}
   {{- if .Values.launcherPub }}
   # TODO: would ideally be able to generate launcher.pub as well
   launcher.pub: |

--- a/charts/rstudio-workbench/tests/secrets_test.yaml
+++ b/charts/rstudio-workbench/tests/secrets_test.yaml
@@ -48,6 +48,20 @@ kubernetesProvider:
         namespace: NAMESPACE
       data:
         database.conf: cHJvdmlkZXI9cG9zdGdyZXNxbApkYXRhYmFzZT1yc3AKcG9ydD01NDMyCmhvc3Q9ZGIuZXhhbXBsZS5jb20KdXNlcm5hbWU9cnN0dWRpb19hcHAKcGFzc3dvcmQ9c2VjdXJlcGFzc3dvcmQK # base64 encoded database config
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: my-oidc-secret
+        namespace: NAMESPACE
+      data:
+        openid-client-secret: bXktb2lkYy1jbGllbnQtc2VjcmV0 # base64 encoded "my-oidc-client-secret"
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: my-custom-secret
+        namespace: NAMESPACE
+      data:
+        custom-file.conf: bXktY3VzdG9tLWNvbmZpZw== # base64 encoded "my-custom-config"
 tests:
   - it: should set userPassword from existing secret
     template: deployment.yaml
@@ -272,3 +286,77 @@ tests:
       - equal:
           path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[0].secret.items[0].path'
           value: 'database.conf'
+  - it: should NOT include launcher.pem in the chart-managed secret when launcherPem.existingSecret is set
+    template: configmap-secret.yaml
+    set:
+      launcherPem:
+        existingSecret: "launcherpem-secret"
+    asserts:
+      - notExists:
+          path: 'stringData.launcher\.pem'
+  - it: should NOT include secure-cookie-key in the chart-managed secret when secureCookieKey.existingSecret is set
+    template: configmap-secret.yaml
+    set:
+      secureCookieKey:
+        existingSecret: "securecookiekey-secret"
+    asserts:
+      - notExists:
+          path: 'stringData.secure-cookie-key'
+  - it: should NOT include secure-cookie-key in the chart-managed secret when global.secureCookieKey.existingSecret is set
+    template: configmap-secret.yaml
+    set:
+      global:
+        secureCookieKey:
+          existingSecret: "globalsecurecookiekey-secret"
+    asserts:
+      - notExists:
+          path: 'stringData.secure-cookie-key'
+  - it: should specify a volumeMount and projected volume for rstudio-secret with config.existingSecrets
+    template: deployment.yaml
+    set:
+      config:
+        defaultMode:
+          secret: 0600
+        existingSecrets:
+          - name: my-oidc-secret
+            items:
+              - key: openid-client-secret
+                path: openid-client-secret
+          - name: my-custom-secret
+            items:
+              - key: custom-file.conf
+                path: custom-file.conf
+    asserts:
+      - equal:
+          path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-secret")].mountPath'
+          value: "/mnt/secret-configmap/rstudio/"
+      - equal:
+          path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-secret")].name'
+          value: "rstudio-secret"
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].name'
+          value: "rstudio-secret"
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[0].secret.name'
+          value: 'my-oidc-secret'
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[0].secret.items[0].key'
+          value: 'openid-client-secret'
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[0].secret.items[0].mode'
+          value: 0600
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[0].secret.items[0].path'
+          value: 'openid-client-secret'
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[1].secret.name'
+          value: 'my-custom-secret'
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[1].secret.items[0].key'
+          value: 'custom-file.conf'
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[1].secret.items[0].mode'
+          value: 0600
+      - equal:
+          path: 'spec.template.spec.volumes[?(@.name=="rstudio-secret")].projected.sources[1].secret.items[0].path'
+          value: 'custom-file.conf'

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -520,6 +520,16 @@ config:
   sessionSecret: {}
   # -- a map of secret, server-scoped config files (database.conf, databricks.conf, openid-client-secret). Mounted to `/mnt/secret-configmap/rstudio/` with 0600 permissions
   secret:
+  # -- a list of existing Kubernetes Secrets to project into `/mnt/secret-configmap/rstudio/`. Each item should have `name` (secret name) and `items` (list of keys to mount with their paths). Mounted with 0600 permissions by default.
+  existingSecrets: []
+  # - name: my-oidc-secret
+  #   items:
+  #   - key: openid-client-secret
+  #     path: openid-client-secret
+  # - name: my-custom-secret
+  #   items:
+  #   - key: custom-file.conf
+  #     path: custom-file.conf
   # -- a map of sssd config files, used for user provisioning. Mounted to `/etc/sssd/conf.d/` with 0600 permissions
   userProvisioning: {}
   # -- a map of server config files. Mounted to `/mnt/configmap/rstudio/`


### PR DESCRIPTION
From: https://github.com/rstudio/helm/pull/736

Related to #733 and #726

For the `rstudio-workbench` Helm chart, add support for referencing externally managed Kubernetes Secrets via an `existingSecrets` Helm value.

- The chart now conditionally excludes `launcher.pem` and `secure-cookie-key` from the chart-managed secret (`configmap-secret.yaml`) when `existingSecret` is configured for each value. This avoids duplication, ensures the existing secret is the single source of truth, and prevents exposure in version control if using this chart via the [rendered manifests](https://akuity.io/blog/the-rendered-manifests-pattern) pattern.
- Added `config.existingSecrets` to support projecting arbitrary external Kubernetes Secrets into `/mnt/secret-configmap/rstudio/` (e.g., for `openid-client-secret` and other sensitive configurations).
- Added documentation in README covering both features with examples.
- Added 4 new test cases covering the new functionality.