### PR TITLE
Update PPM NEWS for 2025.12.0-14 release update

### DIFF
--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.5.52
 
-- Update default Posit Package Manager version to 2025.12.0-12
+- Update default Posit Package Manager version to 2025.12.0-14
 
 ## 0.5.51
 


### PR DESCRIPTION
The `2025.12.0` image now points to 2025.12.0-14, so updating the NEWS to reflect that. There is no actual chart update, as 0.5.52 now uses 2025.12.0-14 automatically.