### PR TITLE
Set the `Server.Address` based on the Kubernetes service

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.26
+version: 0.8.27
 apiVersion: v2
 appVersion: 2026.01.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.27
+
+- Set `Server.Address` to match the Kubernetes Service
+
 ## 0.8.26
 
 - Fix bug in chart where sharedStorage.subPath did not propagate to launcher-managed job volumeMounts.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.26](https://img.shields.io/badge/Version-0.8.26-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
+![Version: 0.8.27](https://img.shields.io/badge/Version-0.8.27-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.26:
+To install the chart with the release name `my-release` at version 0.8.27:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.26
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.27
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/lint/complex-values.yaml
+++ b/charts/rstudio-connect/lint/complex-values.yaml
@@ -152,7 +152,6 @@ config:
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   Server:
-    Address: http://localhost:3939
     DataDir: /var/lib/rstudio-connect
     RVersionScanning: false
     RVersion:

--- a/charts/rstudio-connect/lint/simple-values.yaml
+++ b/charts/rstudio-connect/lint/simple-values.yaml
@@ -19,7 +19,6 @@ config:
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
   Server:
-    Address: http://localhost:3939
     DataDir: /var/lib/rstudio-connect
     RVersionScanning: false
     RVersion:

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -100,6 +100,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{- $defaultConfig = merge $defaultConfig (dict "Metrics" ( dict "PrometheusListen" (print ":" .Values.prometheus.port )))}}
     {{- end }}
   {{- end }}
+  {{- /* default Server.Address from the service name and port */}}
+  {{- $serverAddress := printf "http://%s:%v" (include "rstudio-connect.fullname" .) .Values.service.port }}
+  {{- $defaultConfig = merge $defaultConfig (dict "Server" (dict "Address" $serverAddress)) }}
   {{- include "rstudio-library.config.gcfg" ( mergeOverwrite $defaultConfig $configCopy ) }}
 {{- end -}}
 

--- a/charts/rstudio-connect/tests/server_address_test.yaml
+++ b/charts/rstudio-connect/tests/server_address_test.yaml
@@ -1,0 +1,31 @@
+suite: test Server.Address auto-computation
+templates:
+  - configmap.yaml
+tests:
+  - it: should auto-compute Server.Address from the service name and port
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "Address = http://RELEASE-NAME-rstudio-connect:80"
+
+  - it: should use explicit config.Server.Address when provided
+    documentIndex: 0
+    set:
+      config:
+        Server:
+          Address: https://connect.example.com
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "Address = https://connect.example.com"
+
+  - it: should reflect a custom service port in the computed address
+    documentIndex: 0
+    set:
+      service:
+        port: 8080
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "Address = http://RELEASE-NAME-rstudio-connect:8080"

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -429,7 +429,8 @@ config:
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
   Server:
-    Address: http://localhost:3939
+    # Address is auto-computed from the service name and port.
+    # Override here if you need a custom value.
     DataDir: /var/lib/rstudio-connect
   Python:
     Enabled: true


### PR DESCRIPTION
This change removes the need to specify `Server.Address` in a values
file. This sets the configuration value dynamically and merges it into
the `config` object.
