### PR TITLE
Disable TensorFlow serving by default in Connect

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.27
+version: 0.8.28
 apiVersion: v2
 appVersion: 2026.02.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.28
+
+- Disable TensorFlow serving by default in Connect configuration
+
 ## 0.8.27
 
 - Bump Connect version to 2026.02.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.27](https://img.shields.io/badge/Version-0.8.27-informational?style=flat-square) ![AppVersion: 2026.02.0](https://img.shields.io/badge/AppVersion-2026.02.0-informational?style=flat-square)
+![Version: 0.8.28](https://img.shields.io/badge/Version-0.8.28-informational?style=flat-square) ![AppVersion: 2026.02.0](https://img.shields.io/badge/AppVersion-2026.02.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.27:
+To install the chart with the release name `my-release` at version 0.8.28:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.27
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.28
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -446,7 +446,7 @@ config:
     # https://docs.posit.co/connect/admin/quarto/
     Executable: "/opt/quarto/1.4.557/bin/quarto"
   TensorFlow:
-    Enabled: true
+    Enabled: false
     # Note: The `Executable` listed below is only used for Local Execution.
     # For Off-Host Execution, TensorFlow versions are defined by the set of Execution Environments
     # https://docs.posit.co/connect/admin/tensorflow/


### PR DESCRIPTION
## Summary

- Disable TensorFlow serving by default (`TensorFlow.Enabled: false`) in the Connect chart's `values.yaml`
- Bump chart version to 0.8.28

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify `just test rstudio-connect` passes