### PR TITLE
docs: add NEWS.md entry for rstudio-workbench 0.10.8

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.10.8
+version: 0.10.9
 apiVersion: v2
 appVersion: 2026.01.1
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.10.9
+
+- Add missing NEWS.md entry for 0.10.8
+
 ## 0.10.8
 
 - Fix session launch failure for projects with long names caused by Go YAML marshal wrapping `name` and `service_ports` annotations in `job.tpl` at 80 characters, producing invalid YAML

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.10.8](https://img.shields.io/badge/Version-0.10.8-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
+![Version: 0.10.9](https://img.shields.io/badge/Version-0.10.9-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.10.8:
+To install the chart with the release name `my-release` at version 0.10.9:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.8
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.9
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
## Summary

- Add missing NEWS.md changelog entry for the 0.10.8 release (#795)

Missed in #795 — documents the `job.tpl` fix for long session name YAML wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)