### PR TITLE
Bump rstudio-connect chart to 0.8.31 and fix IPv6 handling

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.8.31
+version: 0.8.32
 apiVersion: v2
 appVersion: 2026.02.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.32
+
+- Fix IPv6 address handling in `prestart.bash` to properly bracket IPv6 `KUBERNETES_SERVICE_HOST` addresses
+
 ## 0.8.31
 
 - Add `deployment.annotations` to support user-defined annotations on the Deployment resource

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.8.31](https://img.shields.io/badge/Version-0.8.31-informational?style=flat-square) ![AppVersion: 2026.02.0](https://img.shields.io/badge/AppVersion-2026.02.0-informational?style=flat-square)
+![Version: 0.8.32](https://img.shields.io/badge/Version-0.8.32-informational?style=flat-square) ![AppVersion: 2026.02.0](https://img.shields.io/badge/AppVersion-2026.02.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.8.31:
+To install the chart with the release name `my-release` at version 0.8.32:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.31
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.8.32
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/prestart.bash
+++ b/charts/rstudio-connect/prestart.bash
@@ -4,7 +4,11 @@ set -o pipefail
 
 kubernetes_health_check() {
   local cacert='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-  local k8s_url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+  local host="${KUBERNETES_SERVICE_HOST}"
+  if [[ "${host}" == *:* ]]; then
+    host="[${host}]"
+  fi
+  local k8s_url="https://${host}:${KUBERNETES_SERVICE_PORT}"
 
   _logf 'Loading service account token'
   local sa_token


### PR DESCRIPTION
- Fix IPv6 address handling in prestart.bash to properly bracket KUBERNETES_SERVICE_HOST when it contains an IPv6 address
- Update NEWS.md and README.md for version 0.8.31

related: https://github.com/rstudio/helm/pull/796