### PR TITLE
Add sibling repo settings and worktree instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "../images-shared",
+      "../images",
+      "../images-examples",
+      "../images-connect",
+      "../images-package-manager",
+      "../images-workbench"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ _publish.yml
 
 # helm packages
 *.tgz
+
+# Claude
+.claude/settings.local.json
+.claude/worktrees/
+.claude/plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the official Helm charts repository for Posit (formerly RStudio) products: Connect, Workbench, Package Manager, and Chronicle.
 
+## Sibling Repositories
+
+This project is part of a multi-repo ecosystem for Posit container images. Sibling repos
+are configured as additional directories (see `.claude/settings.json`). **Read the CLAUDE.md
+in each affected sibling repo before making changes there.**
+
+- `../images-shared/` - Posit Bakery CLI tool for building, testing, and managing container images. Jinja2 templates, macros, and shared build tooling.
+- `../images/` - Meta repository with documentation, design principles, and links across all image repos.
+- `../images-connect/` - Posit Connect images: `connect` (Standard/Minimal variants), `connect-content` (matrix of R x Python), `connect-content-init`.
+- `../images-package-manager/` - Posit Package Manager image: `package-manager` (Standard/Minimal variants). Supports multi-platform builds (amd64/arm64).
+- `../images-workbench/` - Posit Workbench images: `workbench` (Standard/Minimal variants), `workbench-session` (R x Python matrix), `workbench-session-init`.
+- `../images-examples/` - Examples for using and extending Posit container images.
+
+### Worktrees for Cross-Repo Changes
+
+When making changes across repositories, use worktrees to isolate work from `main`. Multiple
+sessions may be running concurrently, so never work directly on `main` in any repo.
+
+- **Primary repo:** Use `EnterWorktree` with a descriptive name.
+- **Sibling repos:** Create worktrees via `git worktree add` before making changes. Store
+  them in `.claude/worktrees/<name>` within each repo (matching the `EnterWorktree` convention).
+
+```bash
+# Create a worktree in a sibling repo
+git -C ../images-shared worktree add .claude/worktrees/<name> -b <branch-name>
+```
+
+Read and write files via the worktree path (e.g., `../images-shared/.claude/worktrees/<name>/`)
+instead of the repo root. Clean up when finished:
+
+```bash
+git -C ../images-shared worktree remove .claude/worktrees/<name>
+```
+
+> **Note:** The `additionalDirectories` in `.claude/settings.json` point to the sibling repo
+> roots, not to worktree paths. File reads and writes via those directories will access the
+> repo root (typically on `main`). Always use the full worktree path when reading or writing
+> files in a sibling worktree.
+
 ## Common Commands
 
 ### Just Commands (primary tool)


### PR DESCRIPTION
## Summary

- Add sibling repositories section with worktree instructions to `CLAUDE.md`
- Create `.claude/settings.json` with `additionalDirectories` for all sibling repos
- Add `.claude/worktrees/` and `.claude/settings.local.json` to `.gitignore`

Part of a cross-repo change to set up Claude Code for multi-repo worktree workflows. See matching PRs in all sibling repos.