### PR TITLE
Add deployment.annotations to Package Manager chart

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.53
+version: 0.5.54
 apiVersion: v2
 appVersion: 2025.12.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.54
+
+- Add `deployment.annotations` to support user-defined annotations on the Deployment resource
+
 ## 0.5.53
 
 - Update chart icon to Posit icon

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.53](https://img.shields.io/badge/Version-0.5.53-informational?style=flat-square) ![AppVersion: 2025.12.0](https://img.shields.io/badge/AppVersion-2025.12.0-informational?style=flat-square)
+![Version: 0.5.54](https://img.shields.io/badge/Version-0.5.54-informational?style=flat-square) ![AppVersion: 2025.12.0](https://img.shields.io/badge/AppVersion-2025.12.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.53:
+To install the chart with the release name `my-release` at version 0.5.54:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.53
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.54
 ```
 
 To explore other chart versions, look at:
@@ -202,6 +202,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | awsSecretAccessKey | string | `nil` | awsSecretAccessKey is the secret access key, needs to be filled if access_key_id is |
 | command | bool | `false` | command is the pod's run command. By default, it uses the container's default |
 | config | object | `{"HTTP":{"Listen":":4242"},"Metrics":{"Enabled":true}}` | config is a nested map of maps that generates the rstudio-pm.gcfg file |
+| deployment.annotations | object | `{}` | Additional annotations to add to the rstudio-pm deployment |
 | enableMigration | bool | `false` | Enable migrations for shared storage (if necessary) using Helm hooks. |
 | enableSandboxing | bool | `true` | Enable sandboxing of Git builds, which requires elevated security privileges for the Package Manager container. |
 | extraContainers | list | `[]` | sidecar container list |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: {{ include "rstudio-pm.fullname" . }}
   namespace: {{ $.Release.Namespace }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   strategy:
     type: {{ .Values.strategy.type }}

--- a/charts/rstudio-pm/tests/deployment_annotations_test.yaml
+++ b/charts/rstudio-pm/tests/deployment_annotations_test.yaml
@@ -1,0 +1,24 @@
+suite: test deployment annotations
+templates:
+  - configmap.yaml
+  - secret-aws-creds.yaml
+  - secret-rstudio-pm-key.yaml
+  - deployment.yaml
+tests:
+  - it: should not have annotations by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should apply annotations when deployment.annotations is set
+    template: deployment.yaml
+    set:
+      deployment.annotations:
+        example.com/owner: "my-team"
+        example.com/environment: "production"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            example.com/owner: "my-team"
+            example.com/environment: "production"

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -88,6 +88,10 @@ service:
   # -- The port to forward to on the Package Manager pod. Also see pod.port
   targetPort: 4242
 
+deployment:
+  # -- Additional annotations to add to the rstudio-pm deployment
+  annotations: {}
+
 # -- replicas is the number of replica pods to maintain for this service
 replicas: 1
 # -- awsAccessKeyId is the access key id for s3 access, used also to gate file creation


### PR DESCRIPTION
## Summary

- Add `deployment.annotations` value to the rstudio-pm chart, allowing users to add custom annotations to the Deployment resource metadata
- Matches the pattern added to Connect in #794
- Includes helm-unittest tests verifying default (no annotations) and custom annotation behavior