### PR TITLE
Add deployment annotations support to Workbench chart

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.10.10
+version: 0.10.11
 apiVersion: v2
 appVersion: 2026.01.1
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.10.11
+
+- Add ability to set custom annotations on the Deployment resource via `deployment.annotations`
+
 ## 0.10.10
 
 - Fix IPv6 address handling in `prestart-launcher.bash` to properly bracket IPv6 `KUBERNETES_SERVICE_HOST` addresses

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.10.10](https://img.shields.io/badge/Version-0.10.10-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
+![Version: 0.10.11](https://img.shields.io/badge/Version-0.10.11-informational?style=flat-square) ![AppVersion: 2026.01.1](https://img.shields.io/badge/AppVersion-2026.01.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.10.10:
+To install the chart with the release name `my-release` at version 0.10.11:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.10
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.11
 ```
 
 To explore other chart versions, look at:
@@ -596,6 +596,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | config.startupUserProvisioning | object | `{"sssd.conf":"[program:sssd]\ncommand=/usr/sbin/sssd -i -c /etc/sssd/sssd.conf --logger=stderr\nautorestart=false\nnumprocs=1\nstdout_logfile=/dev/stdout\nstdout_logfile_maxbytes=0\nstdout_logfile_backups=0\nstderr_logfile=/dev/stderr\nstderr_logfile_maxbytes=0\nstderr_logfile_backups=0\n"}` | a map of supervisord .conf files to define user provisioning services. Mounted into the container at /startup/user-provisioning/ |
 | config.userProvisioning | object | `{}` | a map of sssd config files, used for user provisioning. Mounted to `/etc/sssd/conf.d/` with 0600 permissions |
 | dangerRegenerateAutomatedValues | bool | `false` |  |
+| deployment.annotations | object | `{}` | Additional annotations to add to the rstudio-workbench deployment |
 | diagnostics | object | `{"directory":"/var/log/rstudio","enabled":false}` | Settings for enabling server diagnostics |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template) |
 | fullnameOverride | string | `""` | the full name of the release (can be overridden) |

--- a/charts/rstudio-workbench/templates/deployment.yaml
+++ b/charts/rstudio-workbench/templates/deployment.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: {{ include "rstudio-workbench.fullname" . }}
   namespace: {{ $.Release.Namespace }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   strategy:
     type: {{ .Values.strategy.type }}

--- a/charts/rstudio-workbench/tests/deployment_annotations_test.yaml
+++ b/charts/rstudio-workbench/tests/deployment_annotations_test.yaml
@@ -1,0 +1,25 @@
+suite: test deployment annotations
+templates:
+  - configmap-general.yaml
+  - configmap-prestart.yaml
+  - configmap-secret.yaml
+  - configmap-session.yaml
+  - deployment.yaml
+tests:
+  - it: should not have annotations by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should apply annotations when deployment.annotations is set
+    template: deployment.yaml
+    set:
+      deployment.annotations:
+        example.com/owner: "my-team"
+        example.com/environment: "production"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            example.com/owner: "my-team"
+            example.com/environment: "production"

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -250,6 +250,9 @@ service:
   # -- The port to forward to on the Workbench pod. Also see pod.port
   targetPort: 8787
 
+deployment:
+  # -- Additional annotations to add to the rstudio-workbench deployment
+  annotations: {}
 
 # -- resources define requests and limits for the rstudio-server pod
 resources:


### PR DESCRIPTION
## Summary

- Add `deployment.annotations` to the Workbench chart, allowing users to set custom annotations on the Deployment resource
- Matches the existing Connect chart implementation from #794
- Includes unit tests for default (no annotations) and configured states