### PR TITLE
update helm chart overview

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -23,53 +23,19 @@ title: Posit Helm Charts
 
 ## Installing Charts
 
-Example instructions to install a chart for each product are below. For full installation details, see the overview page for each product.
-
-::: {.panel-tabset}
-
-### Posit Workbench
+The general pattern for installing a Posit Helm chart:
 
 ```{.bash}
-kubectl create secret generic rstudio-workbench-license \
-  --from-file=licenses/rstudio-workbench.lic
-helm install workbench rstudio/rstudio-workbench \
-  --set license.file.secret=rstudio-workbench-license \
-  --set license.file.secretKey=rstudio-workbench.lic \
-  --values workbench-values.yaml
+helm install <release-name> rstudio/<chart-name> \
+  --values values.yaml
 ```
 
-### Posit Connect
+For product-specific installation instructions, including license configuration, see each chart's overview:
 
-```{.bash}
-kubectl create secret generic rstudio-connect-license \
-  --from-file=licenses/rstudio-connect.lic
-helm install connect rstudio/rstudio-connect \
-  --set license.file.secret=rstudio-connect-license \
-  --set license.file.secretKey=rstudio-connect.lic \
-  --values connect-values.yaml
-```
-
-### Posit Package Manager
-
-```{.bash}
-kubectl create secret generic rstudio-pm-license \
-  --from-file=licenses/rstudio-pm.lic
-helm install packagemanager rstudio/rstudio-pm \
-  --set license.file.secret=rstudio-pm-license \
-  --set license.file.secretKey=rstudio-pm.lic \
-  --values pm-values.yaml
-```
-
-### Posit Chronicle
-
-```{.bash}
-helm install chronicle rstudio/posit-chronicle \
-  --values chronicle-values.yaml
-```
-
-:::
-
-You can also provide a license via `license.server` (for a license server). See each chart's values reference for details.
+- [Posit Workbench](charts/rstudio-workbench/README.md#installing-the-chart)
+- [Posit Connect](charts/rstudio-connect/README.md#installing-the-chart)
+- [Posit Package Manager](charts/rstudio-pm/README.md#installing-the-chart)
+- [Posit Chronicle](charts/posit-chronicle/README.md#installing-the-chart)
 
 ## Upgrading a Release
 

--- a/index.qmd
+++ b/index.qmd
@@ -20,3 +20,99 @@ title: Posit Helm Charts
    ```{.bash}
    helm search repo rstudio
    ```
+
+## Installing Charts
+
+Example instructions to install a chart for each product are below. For full installation details, see the overview page for each product.
+
+::: {.panel-tabset}
+
+### Posit Workbench
+
+```{.bash}
+kubectl create secret generic rstudio-workbench-license \
+  --from-file=licenses/rstudio-workbench.lic
+helm install workbench rstudio/rstudio-workbench \
+  --set license.file.secret=rstudio-workbench-license \
+  --set license.file.secretKey=rstudio-workbench.lic \
+  --values workbench-values.yaml
+```
+
+### Posit Connect
+
+```{.bash}
+kubectl create secret generic rstudio-connect-license \
+  --from-file=licenses/rstudio-connect.lic
+helm install connect rstudio/rstudio-connect \
+  --set license.file.secret=rstudio-connect-license \
+  --set license.file.secretKey=rstudio-connect.lic \
+  --values connect-values.yaml
+```
+
+### Posit Package Manager
+
+```{.bash}
+kubectl create secret generic rstudio-pm-license \
+  --from-file=licenses/rstudio-pm.lic
+helm install packagemanager rstudio/rstudio-pm \
+  --set license.file.secret=rstudio-pm-license \
+  --set license.file.secretKey=rstudio-pm.lic \
+  --values pm-values.yaml
+```
+
+### Posit Chronicle
+
+```{.bash}
+helm install chronicle rstudio/posit-chronicle \
+  --values chronicle-values.yaml
+```
+
+:::
+
+You can also provide a license via `license.server` (for a license server). See each chart's values reference for details.
+
+## Upgrading a Release
+
+```{.bash}
+helm upgrade <release-name> rstudio/<chart-name> \
+  --values <values-file>.yaml
+```
+
+## Uninstalling a Release
+
+```{.bash}
+helm uninstall <release-name> --namespace posit
+```
+
+## Troubleshooting
+
+List running pods:
+
+```{.bash}
+kubectl get pods 
+```
+
+View application logs:
+
+```{.bash}
+kubectl logs <pod-name> 
+```
+
+View pod events and status:
+
+```{.bash}
+kubectl describe pod <pod-name> 
+```
+
+For troubleshooting pods themselves, and testing the installation of new packages/services, 
+open a shell in a pod:
+
+```{.bash}
+kubectl exec -it <pod-name> -- /bin/bash
+```
+
+Restart a deployment:
+
+```{.bash}
+kubectl rollout restart deployment/<deployment-name>
+```


### PR DESCRIPTION
Migrating information from older support articles into product documentation. Since this [article](https://support.posit.co/hc/en-us/articles/33089254334871-Posit-Helm-Cheatsheet) gave a broad overview that crosses product, it seemed reasonable to add it to the helm overview and point users to the product specific overviews with more details.

## Testing

- Tested this locally with `quarto preview`. I ran just docs per contributing guidelines but given this didnt touch charts/* I don't think it was needed.

- One action is failing. I believe this is due to the repo being a fork and not having access to secrets, can adjust as needed.