### PR TITLE
Use posit-dev images for Workbench chart

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.11.2
+version: 0.20.0
 apiVersion: v2
 appVersion: 2026.04.0
 icon:
@@ -18,10 +18,10 @@ dependencies:
     repository: https://helm.rstudio.com
 annotations:
   artifacthub.io/images: |
-    - name: rstudio-workbench
-      image: rstudio/rstudio-workbench:ubuntu2204-2026.04.0
-    - name: r-session-complete
-      image: rstudio/r-session-complete:ubuntu2204-2026.04.0
+    - name: workbench
+      image: posit/workbench:2026.04.0-ubuntu-24.04
+    - name: workbench-session
+      image: posit/workbench-session:R4.5.2-python3.14.3-ubuntu-24.04
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: Docker Images

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -7,7 +7,7 @@
   - `session.image.repository` changed from `rstudio/workbench-session` to `posit/workbench-session`
   - `components.sessionInit.image.repository` changed to `posit/workbench-session-init`
   - `components.positron.image.repository` changed to `posit/workbench-positron-init`
-  - Image tag format changed from `{tagPrefix}{version}` to `{version}-{os}`
+  - Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`
   - `image.tagPrefix` replaced by `image.os`
   - `session.image.tagPrefix` replaced by `session.image.os`, `session.image.rVersion`, `session.image.pythonVersion`
   - `versionOverride` no longer affects the session image tag (use `session.image.rVersion`, `session.image.pythonVersion`, `session.image.os` instead)

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.20.0
+
+- **BREAKING**: Default images now pull from the `posit/` namespace on Docker Hub
+  - `image.repository` changed from `rstudio/rstudio-workbench` to `posit/workbench`
+  - `session.image.repository` changed from `rstudio/workbench-session` to `posit/workbench-session`
+  - `components.sessionInit.image.repository` changed to `posit/workbench-session-init`
+  - `components.positron.image.repository` changed to `posit/workbench-positron-init`
+  - Image tag format changed from `{tagPrefix}{version}` to `{version}-{os}`
+  - `image.tagPrefix` replaced by `image.os`
+  - `session.image.tagPrefix` replaced by `session.image.os`, `session.image.rVersion`, `session.image.pythonVersion`
+  - `versionOverride` no longer affects the session image tag (use `session.image.rVersion`, `session.image.pythonVersion`, `session.image.os` instead)
 
 ## 0.11.2
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.11.2:
+To install the chart with the release name `my-release` at version 0.20.0:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.11.2
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.20.0
 ```
 
 To explore other chart versions, look at:
@@ -62,7 +62,7 @@ To function, this chart requires the following:
 * If using load balancing (by setting `replicas > 1`), you need similar storage defined for `sharedStorage` to
   store shared project configuration. However, you can also configure the product to store its shared data underneath `/home` by
   setting `config.server.rserver\.conf.server-shared-storage-path=/home/some-shared-dir`.
-* A method to join the deployed `rstudio-workbench` container to your auth domain. The default `rstudio/rstudio-workbench` image has `sssd` installed and started by default.
+* A method to join the deployed `rstudio-workbench` container to your auth domain. The default `posit/workbench` image has `sssd` installed and started by default.
   You can include `sssd` configuration in `config.userProvisioning` like so:
 
     ```yaml
@@ -172,29 +172,32 @@ Alternatively, database passwords may be set during `helm install` with the foll
 
 `--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
 
+## Upgrade guidance
+
+### 0.20.0
+
+- Chart version 0.20.0 switches default images from `rstudio/` to the `posit/` namespace on Docker Hub (also available at `ghcr.io/posit-dev/`). See the [migration guide](https://docs.posit.co/helm/docs/migrating-to-posit-images.html) for details.
+- Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`. The chart will fail with a clear error if you have `image.tagPrefix` or `session.image.tagPrefix` set.
+- Session image tag is now constructed from `session.image.rVersion`, `session.image.pythonVersion`, and `session.image.os` (format: `R{rVersion}-python{pythonVersion}-{os}`).
+
 ## Session images
 
-By default, session pods use the `rstudio/workbench-session` image with an init
-container (`rstudio/workbench-session-init`) that delivers Workbench session
-components at pod startup.
+By default, session pods use the `posit/workbench-session` image (also available
+at `ghcr.io/posit-dev/workbench-session`) with an init container
+(`posit/workbench-session-init`) that delivers Workbench session components at
+pod startup.
 
-### Upgrading from 0.10.x
+The session image tag is constructed from three values: `session.image.rVersion`,
+`session.image.pythonVersion`, and `session.image.os`. Override
+`session.image.tag` to bypass this construction entirely.
 
-Chart defaults require no additional configuration, but the default
-`session.image.tag` now pins an explicit R/Python matrix (see `values.yaml`)
-because `rstudio/workbench-session` does not publish Workbench-version-shaped
-tags. Review the pinned tag against
-[hub.docker.com/r/rstudio/workbench-session/tags](https://hub.docker.com/r/rstudio/workbench-session/tags)
-during each Workbench upgrade.
+### Upgrading from 0.11.x
 
-If you pin `session.image.repository: rstudio/r-session-complete`, also set
-`components.enabled: false` to preserve the previous behavior. The
-`r-session-complete` tag format (`<tagPrefix><appVersion>`) still works there.
+If you use default values, no action is needed. If you customized session images:
 
-If you adopt the init-container pattern with a custom session image, confirm
-that the image does not already include Workbench session components (only
-language runtimes, system tools, and similar dependencies). Otherwise, the init
-container repeats work that the image already performs.
+- Replace `session.image.tagPrefix` with `session.image.os`, `session.image.rVersion`, and `session.image.pythonVersion`
+- Replace `session.image.repository: rstudio/workbench-session` with `posit/workbench-session`
+- If you pinned `session.image.tag` to an old-format string (e.g., `ubuntu2204-r4.5.2_4.4.3-py3.13.9_3.12.11`), verify that tag exists in the `posit/workbench-session` repository or update to the new format
 
 For platform-level upgrade steps, see the [Posit Workbench administrator guide](https://docs.posit.co/ide/server-pro/).
 
@@ -632,12 +635,12 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | chronicleAgent.workbenchApiKey.value | string | `""` | Workbench API key as a raw string to set as the `CHRONICLE_WORKBENCH_APIKEY` environment variable    (not recommended) |
 | chronicleAgent.workbenchApiKey.valueFrom | object | `{}` | Workbench API key as a `valueFrom` reference (ex. a Kubernetes Secret reference) to set as the    `CHRONICLE_WORKBENCH_APIKEY` environment variable (recommended) |
 | command | list | `[]` | command is the pod container's run command. By default, it uses the container's default. However, the chart expects a container using `supervisord` for startup |
-| components | object | `{"enabled":true,"positron":{"image":{"repository":"rstudio/workbench-positron-init","tag":""},"version":""},"sessionInit":{"image":{"repository":"rstudio/workbench-session-init","tag":""}}}` | Session component delivery via init containers. When enabled (default), the chart configures rserver.conf so the launcher injects init containers into session pods at startup. Set `enabled: false` and change `session.image.repository` to `rstudio/r-session-complete` to use the classic all-in-one session image instead. |
+| components | object | `{"enabled":true,"positron":{"image":{"repository":"posit/workbench-positron-init","tag":""},"version":""},"sessionInit":{"image":{"repository":"posit/workbench-session-init","tag":""}}}` | Session component delivery via init containers. When enabled (default), the chart configures rserver.conf so the launcher injects init containers into session pods at startup. Set `enabled: false` and change `session.image.repository` to `rstudio/r-session-complete` to use the classic all-in-one session image instead. |
 | components.enabled | bool | `true` | Enable session component delivery via init containers. When false, no init containers are configured and session.image must be a self-contained image like r-session-complete. |
-| components.positron.image.repository | string | `"rstudio/workbench-positron-init"` | The image repository for the Positron init container |
+| components.positron.image.repository | string | `"posit/workbench-positron-init"` | The image repository for the Positron init container |
 | components.positron.image.tag | string | `""` | A tag override for the Positron init container image. Defaults to the positron version |
 | components.positron.version | string | `""` | A Positron version to enable the Positron init container for session pods. When set, configures rserver.conf with the Positron init container settings and attaches a Positron init container to the Workbench server pod. |
-| components.sessionInit.image.repository | string | `"rstudio/workbench-session-init"` | The repository for the session init container image |
+| components.sessionInit.image.repository | string | `"posit/workbench-session-init"` | The repository for the session init container image |
 | components.sessionInit.image.tag | string | `""` | A tag override for the session init container. Default tag is the chart appVersion (or versionOverride) |
 | config.database | object | `{"conf":{"existingSecret":"","value":""}}` | a map of database connection config files. Mounted to `/mnt/secret-configmap/rstudio/database.conf` with 0600 permissions |
 | config.database.conf.existingSecret | string | `""` | Secret for database connection config. Will take precedence over `config.database.conf.value`.  Key: 'database.conf' |
@@ -682,9 +685,9 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | homeStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | image.imagePullPolicy | string | `"IfNotPresent"` | the imagePullPolicy for the main pod image |
 | image.imagePullSecrets | list | `[]` | an array of kubernetes secrets for pulling the main pod image from private registries |
-| image.repository | string | `"rstudio/rstudio-workbench"` | the repository to use for the main pod image |
+| image.os | string | `"ubuntu-24.04"` | The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined |
+| image.repository | string | `"posit/workbench"` | the repository to use for the main pod image |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| image.tagPrefix | string | `"ubuntu2204-"` | A tag prefix for the server image (common selection: ubuntu2204-). Only used if tag is not defined |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | string | `nil` |  |
@@ -767,9 +770,11 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | session.defaultConfigMount | bool | `true` | Whether to automatically mount the config.session configuration into session pods. If launcher.namespace is different from Release Namespace, then the chart will duplicate the session configmap in both namespaces to facilitate this |
 | session.defaultHomeMount | bool | `true` | Whether to automatically add the homeStorage PVC to the session (i.e. via the `launcher-mounts` file) |
 | session.defaultSecretMountPath | string | `"/mnt/session-secret/"` | The path to mount the sessionSecret (from `config.sessionSecret`) onto the server and session pods |
-| session.image.repository | string | `"rstudio/workbench-session"` | The repository to use for the session image |
-| session.image.tag | string | `"ubuntu2204-r4.5.2_4.4.3-py3.13.9_3.12.11"` | A tag override for the session image. Pinned to an explicit R/Python matrix because `rstudio/workbench-session` publishes tags by language runtime version, not by Workbench release (unlike `rstudio/r-session-complete`). Pick a published tag from https://hub.docker.com/r/rstudio/workbench-session/tags. |
-| session.image.tagPrefix | string | `"ubuntu2204-"` | A tag prefix for session images (common selections: ubuntu2204-). Only used if tag is not defined. The `rstudio/workbench-session` default repository does not publish tags in `{{ tagPrefix }}{{ appVersion }}` form — see the pinned tag below — so `tagPrefix` is effectively unused for the default session image. |
+| session.image.os | string | `"ubuntu-24.04"` | The OS version for the session image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined |
+| session.image.pythonVersion | string | `"3.14.3"` | The Python version for the session image tag. Only used if tag is not defined |
+| session.image.rVersion | string | `"4.5.2"` | The R version for the session image tag. Only used if tag is not defined |
+| session.image.repository | string | `"posit/workbench-session"` | The repository to use for the session image |
+| session.image.tag | string | `""` | A tag override for the session image. Overrides rVersion, pythonVersion, and os. Default tag is `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}` |
 | shareProcessNamespace | bool | `false` | whether to provide `shareProcessNamespace` to the pod. |
 | sharedStorage.accessModes | list | `["ReadWriteMany"]` | accessModes defined for the storage PVC (represented as YAML) |
 | sharedStorage.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Define the annotations for the Persistent Volume Claim resource |
@@ -793,7 +798,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | userPassword.existingSecret | string | `""` | Existing Secret for userPassword. Will take precedence over `userPassword.value`. Key: 'password' |
 | userPassword.value | string | `"rstudio"` | userPassword determines the password of the created user. Will only be used if `userPassword.existingSecret` is not set. |
 | userUid | string | `"10000"` | userUid determines the UID of the created user |
-| versionOverride | string | `""` | A Workbench version to override the "tag" for the RStudio Workbench image and the session images. Necessary until https://github.com/helm/helm/issues/8194 |
+| versionOverride | string | `""` | A Workbench version to override the "tag" for the server image and session-init container. Does not affect the session image tag, which is controlled by session.image.rVersion, session.image.pythonVersion, and session.image.os. Necessary until https://github.com/helm/helm/issues/8194 |
 | xdgConfigDirs | string | `"/mnt/dynamic:/mnt/session-configmap:/mnt/secret-configmap:/mnt/configmap:/mnt/load-balancer/"` | The XDG config dirs (directories where configuration will be read from). Do not change without good reason. |
 | xdgConfigDirsExtra | list | `[]` | A list of additional XDG config dir paths |
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -774,7 +774,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | session.image.pythonVersion | string | `"3.14.3"` | The Python version for the session image tag. Only used if tag is not defined |
 | session.image.rVersion | string | `"4.5.2"` | The R version for the session image tag. Only used if tag is not defined |
 | session.image.repository | string | `"posit/workbench-session"` | The repository to use for the session image |
-| session.image.tag | string | `""` | A tag override for the session image. Overrides rVersion, pythonVersion, and os. Default tag is `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}` |
+| session.image.tag | string | `""` | A tag override for the session image. When empty, the chart computes the tag as `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}` |
 | shareProcessNamespace | bool | `false` | whether to provide `shareProcessNamespace` to the pod. |
 | sharedStorage.accessModes | list | `["ReadWriteMany"]` | accessModes defined for the storage PVC (represented as YAML) |
 | sharedStorage.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Define the annotations for the Persistent Volume Claim resource |

--- a/charts/rstudio-workbench/README.md.gotmpl
+++ b/charts/rstudio-workbench/README.md.gotmpl
@@ -33,7 +33,7 @@ To function, this chart requires the following:
 * If using load balancing (by setting `replicas > 1`), you need similar storage defined for `sharedStorage` to
   store shared project configuration. However, you can also configure the product to store its shared data underneath `/home` by
   setting `config.server.rserver\.conf.server-shared-storage-path=/home/some-shared-dir`.
-* A method to join the deployed `rstudio-workbench` container to your auth domain. The default `rstudio/rstudio-workbench` image has `sssd` installed and started by default.
+* A method to join the deployed `rstudio-workbench` container to your auth domain. The default `posit/workbench` image has `sssd` installed and started by default.
   You can include `sssd` configuration in `config.userProvisioning` like so:
 
     ```yaml
@@ -118,29 +118,32 @@ Alternatively, database passwords may be set during `helm install` with the foll
 
 `--set config.secret.'database\.conf'.password="<YOUR_PASSWORD_HERE>"`
 
+## Upgrade guidance
+
+### 0.20.0
+
+- Chart version 0.20.0 switches default images from `rstudio/` to the `posit/` namespace on Docker Hub (also available at `ghcr.io/posit-dev/`). See the [migration guide](https://docs.posit.co/helm/docs/migrating-to-posit-images.html) for details.
+- Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`. The chart will fail with a clear error if you have `image.tagPrefix` or `session.image.tagPrefix` set.
+- Session image tag is now constructed from `session.image.rVersion`, `session.image.pythonVersion`, and `session.image.os` (format: `R{rVersion}-python{pythonVersion}-{os}`).
+
 ## Session images
 
-By default, session pods use the `rstudio/workbench-session` image with an init
-container (`rstudio/workbench-session-init`) that delivers Workbench session
-components at pod startup.
+By default, session pods use the `posit/workbench-session` image (also available
+at `ghcr.io/posit-dev/workbench-session`) with an init container
+(`posit/workbench-session-init`) that delivers Workbench session components at
+pod startup.
 
-### Upgrading from 0.10.x
+The session image tag is constructed from three values: `session.image.rVersion`,
+`session.image.pythonVersion`, and `session.image.os`. Override
+`session.image.tag` to bypass this construction entirely.
 
-Chart defaults require no additional configuration, but the default
-`session.image.tag` now pins an explicit R/Python matrix (see `values.yaml`)
-because `rstudio/workbench-session` does not publish Workbench-version-shaped
-tags. Review the pinned tag against
-[hub.docker.com/r/rstudio/workbench-session/tags](https://hub.docker.com/r/rstudio/workbench-session/tags)
-during each Workbench upgrade.
+### Upgrading from 0.11.x
 
-If you pin `session.image.repository: rstudio/r-session-complete`, also set
-`components.enabled: false` to preserve the previous behavior. The
-`r-session-complete` tag format (`<tagPrefix><appVersion>`) still works there.
+If you use default values, no action is needed. If you customized session images:
 
-If you adopt the init-container pattern with a custom session image, confirm
-that the image does not already include Workbench session components (only
-language runtimes, system tools, and similar dependencies). Otherwise, the init
-container repeats work that the image already performs.
+- Replace `session.image.tagPrefix` with `session.image.os`, `session.image.rVersion`, and `session.image.pythonVersion`
+- Replace `session.image.repository: rstudio/workbench-session` with `posit/workbench-session`
+- If you pinned `session.image.tag` to an old-format string (e.g., `ubuntu2204-r4.5.2_4.4.3-py3.13.9_3.12.11`), verify that tag exists in the `posit/workbench-session` repository or update to the new format
 
 For platform-level upgrade steps, see the [Posit Workbench administrator guide](https://docs.posit.co/ide/server-pro/).
 

--- a/charts/rstudio-workbench/templates/NOTES.txt
+++ b/charts/rstudio-workbench/templates/NOTES.txt
@@ -53,8 +53,16 @@ Please consider removing this configuration value.
   {{- fail "\n\n`serviceAccountName` is no longer used. Use `rbac.serviceAccount.name` instead"}}
 {{- end }}
 
+{{- if .Values.image.tagPrefix }}
+  {{- fail "\n\n`image.tagPrefix` has been removed. Use `image.os` instead (e.g. `ubuntu-24.04`). The image tag format is now `{version}-{os}`." }}
+{{- end }}
+
+{{- if .Values.session.image.tagPrefix }}
+  {{- fail "\n\n`session.image.tagPrefix` has been removed. Use `session.image.os`, `session.image.rVersion`, and `session.image.pythonVersion` instead. The session image tag format is now `R{rVersion}-python{pythonVersion}-{os}`." }}
+{{- end }}
+
 {{- if and .Values.components.enabled (eq .Values.session.image.repository "rstudio/r-session-complete") }}
-{{ print "\n\nWARNING: `components.enabled=true` is combined with `session.image.repository: rstudio/r-session-complete`. The init containers configured by `components.enabled` deliver session components that are already baked into `r-session-complete`, so this combination is likely unintended.\n\nEither:\n  - Keep the new default: `session.image.repository: rstudio/workbench-session` (with `components.enabled: true`), or\n  - Restore the previous behavior: set `components.enabled: false` along with `session.image.repository: rstudio/r-session-complete`." }}
+{{ print "\n\nWARNING: `components.enabled=true` is combined with `session.image.repository: rstudio/r-session-complete`. The init containers configured by `components.enabled` deliver session components that are already baked into `r-session-complete`, so this combination is likely unintended.\n\nEither:\n  - Keep the new default: `session.image.repository: posit/workbench-session` (with `components.enabled: true`), or\n  - Restore the previous behavior: set `components.enabled: false` along with `session.image.repository: rstudio/r-session-complete`." }}
 {{- end }}
 
 {{- if and (hasKey (get .Values.config.server "rserver.conf") "monitor-graphite-enabled") (not .Values.prometheus.legacy) }}

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -29,7 +29,7 @@ If release name contains chart name it will be used as a full name.
 containers:
 - name: rstudio
   {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-  {{- $imageTag := .Values.image.tag | default (printf "%s%s" .Values.image.tagPrefix $defaultVersion )}}
+  {{- $imageTag := .Values.image.tag | default (printf "%s-%s" $defaultVersion .Values.image.os )}}
   image: "{{ .Values.image.repository }}:{{ $imageTag }}"
   {{- with .Values.pod.lifecycle }}
   lifecycle:

--- a/charts/rstudio-workbench/templates/configmap-general.yaml
+++ b/charts/rstudio-workbench/templates/configmap-general.yaml
@@ -1,6 +1,6 @@
 {{- /* Define the default values that will be merged over */}}
 {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-{{- $sessionTag := .Values.session.image.tag | default (printf "%s%s" .Values.session.image.tagPrefix $defaultVersion ) }}
+{{- $sessionTag := .Values.session.image.tag | default (printf "R%s-python%s-%s" .Values.session.image.rVersion .Values.session.image.pythonVersion .Values.session.image.os ) }}
 {{- $defaultImages := list (printf "%s:%s" .Values.session.image.repository $sessionTag) }}
 {{- $defaultOverrides := list }}
 {{- $sessionTemplate := deepCopy .Values.launcher.templateValues }}

--- a/charts/rstudio-workbench/tests/configmap_test.yaml
+++ b/charts/rstudio-workbench/tests/configmap_test.yaml
@@ -15,7 +15,7 @@ tests:
           pattern: "launcher-sessions-auto-update=1"
       - matchRegex:
           path: data["rserver.conf"]
-          pattern: "launcher-sessions-init-container-image-name=rstudio/workbench-session-init"
+          pattern: "launcher-sessions-init-container-image-name=posit/workbench-session-init"
       - matchRegex:
           path: data["rserver.conf"]
           pattern: "launcher-sessions-init-container-image-tag=\\d+\\.\\d+\\.\\d+"
@@ -26,7 +26,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["launcher.kubernetes.profiles.conf"]
-          pattern: "default-container-image=rstudio/workbench-session:"
+          pattern: "default-container-image=posit/workbench-session:"
 
   # -- Components disabled (classic mode)
   - it: should not include session-init settings when components are disabled
@@ -121,7 +121,7 @@ tests:
           pattern: "launcher-positron-init-container-enabled=1"
       - matchRegex:
           path: data["rserver.conf"]
-          pattern: "launcher-positron-init-container-image-name=rstudio/workbench-positron-init"
+          pattern: "launcher-positron-init-container-image-name=posit/workbench-positron-init"
       - matchRegex:
           path: data["rserver.conf"]
           pattern: "launcher-positron-init-container-image-tag=2026.03.0-213"

--- a/charts/rstudio-workbench/tests/deployment_test.yaml
+++ b/charts/rstudio-workbench/tests/deployment_test.yaml
@@ -741,7 +741,7 @@ tests:
           path: 'spec.template.spec.initContainers[?(@.name=="positron-init")]'
       - equal:
           path: 'spec.template.spec.initContainers[?(@.name=="positron-init")].image'
-          value: "rstudio/workbench-positron-init:2026.03.0-213"
+          value: "posit/workbench-positron-init:2026.03.0-213"
       - equal:
           path: 'spec.template.spec.initContainers[?(@.name=="positron-init")].env[0].name'
           value: "PWB_POSITRON_TARGET"
@@ -777,7 +777,7 @@ tests:
     asserts:
       - equal:
           path: 'spec.template.spec.initContainers[?(@.name=="positron-init")].image'
-          value: "rstudio/workbench-positron-init:custom-build-abc123"
+          value: "posit/workbench-positron-init:custom-build-abc123"
 
   - it: should use custom positron image repository in init container
     template: deployment.yaml

--- a/charts/rstudio-workbench/tests/notes_test.yaml
+++ b/charts/rstudio-workbench/tests/notes_test.yaml
@@ -19,7 +19,7 @@ tests:
         enabled: true
       session:
         image:
-          repository: "rstudio/workbench-session"
+          repository: "posit/workbench-session"
     asserts:
       - notMatchRegexRaw:
           pattern: "WARNING.*components\\.enabled=true.*r-session-complete"
@@ -34,3 +34,20 @@ tests:
     asserts:
       - notMatchRegexRaw:
           pattern: "WARNING.*components\\.enabled=true.*r-session-complete"
+
+  - it: should fail when image.tagPrefix is set
+    set:
+      image:
+        tagPrefix: "ubuntu2204-"
+    asserts:
+      - failedTemplate:
+          errorPattern: "image.tagPrefix.*has been removed.*image.os"
+
+  - it: should fail when session.image.tagPrefix is set
+    set:
+      session:
+        image:
+          tagPrefix: "ubuntu2204-"
+    asserts:
+      - failedTemplate:
+          errorPattern: "session.image.tagPrefix.*has been removed.*session.image.os"

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -29,7 +29,7 @@ session:
     pythonVersion: "3.14.3"
     # -- The repository to use for the session image
     repository: "posit/workbench-session"
-    # -- A tag override for the session image. Overrides rVersion, pythonVersion, and os. Default tag is `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}`
+    # -- A tag override for the session image. When empty, the chart computes the tag as `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}`
     tag: ""
 
 # -- Session component delivery via init containers. When enabled (default), the chart

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -3,7 +3,7 @@ nameOverride: ""
 # -- the full name of the release (can be overridden)
 fullnameOverride: ""
 
-# -- A Workbench version to override the "tag" for the RStudio Workbench image and the session images. Necessary until https://github.com/helm/helm/issues/8194
+# -- A Workbench version to override the "tag" for the server image and session-init container. Does not affect the session image tag, which is controlled by session.image.rVersion, session.image.pythonVersion, and session.image.os. Necessary until https://github.com/helm/helm/issues/8194
 versionOverride: ""
 
 # -- Settings for enabling server diagnostics
@@ -21,17 +21,16 @@ session:
   # -- The path to mount the sessionSecret (from `config.sessionSecret`) onto the server and session pods
   defaultSecretMountPath: /mnt/session-secret/
   image:
-    # -- A tag prefix for session images (common selections: ubuntu2204-). Only used if tag is not defined.
-    # The `rstudio/workbench-session` default repository does not publish tags in `{{ tagPrefix }}{{ appVersion }}`
-    # form — see the pinned tag below — so `tagPrefix` is effectively unused for the default session image.
-    tagPrefix: ubuntu2204-
+    # -- The OS version for the session image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined
+    os: "ubuntu-24.04"
+    # -- The R version for the session image tag. Only used if tag is not defined
+    rVersion: "4.5.2"
+    # -- The Python version for the session image tag. Only used if tag is not defined
+    pythonVersion: "3.14.3"
     # -- The repository to use for the session image
-    repository: "rstudio/workbench-session"
-    # -- A tag override for the session image. Pinned to an explicit R/Python matrix because
-    # `rstudio/workbench-session` publishes tags by language runtime version, not by Workbench release
-    # (unlike `rstudio/r-session-complete`). Pick a published tag from
-    # https://hub.docker.com/r/rstudio/workbench-session/tags.
-    tag: "ubuntu2204-r4.5.2_4.4.3-py3.13.9_3.12.11"
+    repository: "posit/workbench-session"
+    # -- A tag override for the session image. Overrides rVersion, pythonVersion, and os. Default tag is `R{{ rVersion }}-python{{ pythonVersion }}-{{ os }}`
+    tag: ""
 
 # -- Session component delivery via init containers. When enabled (default), the chart
 # configures rserver.conf so the launcher injects init containers into session pods at startup.
@@ -44,7 +43,7 @@ components:
   sessionInit:
     image:
       # -- The repository for the session init container image
-      repository: "rstudio/workbench-session-init"
+      repository: "posit/workbench-session-init"
       # -- A tag override for the session init container. Default tag is the chart appVersion (or versionOverride)
       tag: ""
   positron:
@@ -54,7 +53,7 @@ components:
     version: ""
     image:
       # -- The image repository for the Positron init container
-      repository: "rstudio/workbench-positron-init"
+      repository: "posit/workbench-positron-init"
       # -- A tag override for the Positron init container image. Defaults to the positron version
       tag: ""
 
@@ -229,9 +228,9 @@ homeStorage:
 
 image:
   # -- the repository to use for the main pod image
-  repository: rstudio/rstudio-workbench
-  # -- A tag prefix for the server image (common selection: ubuntu2204-). Only used if tag is not defined
-  tagPrefix: ubuntu2204-
+  repository: posit/workbench
+  # -- The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined
+  os: "ubuntu-24.04"
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # -- the imagePullPolicy for the main pod image


### PR DESCRIPTION
## Summary

- Default server image: `posit/workbench` (was `rstudio/rstudio-workbench`)
- Default session image: `posit/workbench-session` (was `rstudio/workbench-session`)
- Session-init, positron-init images moved to `posit/` namespace
- Tag format: `{version}-{os}` (was `{tagPrefix}{version}`)
- Session tag format: `R{rVersion}-python{pythonVersion}-{os}`
- `image.tagPrefix` replaced by `image.os`; `session.image.tagPrefix` replaced by `session.image.os`, `rVersion`, `pythonVersion`
- `versionOverride` no longer affects session image tag
- Add fail-fast guards for removed `tagPrefix` keys
- Add 0.20.0 upgrade guidance in README
- Chart version bumped to 0.20.0

## Breaking changes

| Old value | New value |
|---|---|
| `image.repository: rstudio/rstudio-workbench` | `image.repository: posit/workbench` |
| `image.tagPrefix: ubuntu2204-` | `image.os: "ubuntu-24.04"` |
| `session.image.repository: rstudio/workbench-session` | `session.image.repository: posit/workbench-session` |
| `session.image.tagPrefix: ubuntu2204-` | `session.image.os`, `session.image.rVersion`, `session.image.pythonVersion` |
| `components.sessionInit.image.repository: rstudio/workbench-session-init` | `components.sessionInit.image.repository: posit/workbench-session-init` |
| `components.positron.image.repository: rstudio/workbench-positron-init` | `components.positron.image.repository: posit/workbench-positron-init` |

Images are also available at `ghcr.io/posit-dev/` on GitHub Container Registry.