### PR TITLE
Use posit-dev images for Package Manager chart

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.57
+version: 0.20.0
 apiVersion: v2
 appVersion: 2026.04.2
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg
@@ -18,8 +18,8 @@ dependencies:
     repository: https://helm.rstudio.com
 annotations:
   artifacthub.io/images: |
-    - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:ubuntu2204-2026.04.2
+    - name: package-manager
+      image: posit/package-manager:2026.04.2-ubuntu-24.04
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.20.0
+
+- **BREAKING**: Default images now pull from the `posit/` namespace on Docker Hub
+  - `image.repository` changed from `rstudio/rstudio-package-manager` to `posit/package-manager`
+  - Image tag format changed from `{os}{version}` to `{version}-{os}`
+  - `image.tagPrefix` replaced by `image.os`
+
 ## 0.5.57
 
 - Update default Posit Package Manager version to 2026.04.2

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -4,7 +4,7 @@
 
 - **BREAKING**: Default images now pull from the `posit/` namespace on Docker Hub
   - `image.repository` changed from `rstudio/rstudio-package-manager` to `posit/package-manager`
-  - Image tag format changed from `{os}{version}` to `{version}-{os}`
+  - Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`
   - `image.tagPrefix` replaced by `image.os`
 
 ## 0.5.57

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.57](https://img.shields.io/badge/Version-0.5.57-informational?style=flat-square) ![AppVersion: 2026.04.2](https://img.shields.io/badge/AppVersion-2026.04.2-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: 2026.04.2](https://img.shields.io/badge/AppVersion-2026.04.2-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.57:
+To install the chart with the release name `my-release` at version 0.20.0:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.57
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.20.0
 ```
 
 To explore other chart versions, look at:
@@ -38,6 +38,11 @@ helm search repo rstudio/rstudio-pm -l
 ```
 
 ## Upgrade guidance
+
+### 0.20.0
+
+- Chart version 0.20.0 switches default images from `rstudio/` to the `posit/` namespace on Docker Hub (also available at `ghcr.io/posit-dev/`). See the [migration guide](https://docs.posit.co/helm/docs/migrating-to-posit-images.html) for details.
+- Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`. The chart will fail with a clear error if you have `image.tagPrefix` set — replace it with `image.os`.
 
 ### 0.4.0
 
@@ -209,9 +214,9 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | fullnameOverride | string | `""` | the full name of the release (can be overridden) |
 | image.imagePullPolicy | string | `"IfNotPresent"` | the imagePullPolicy for the main pod image |
 | image.imagePullSecrets | list | `[]` | an array of kubernetes secrets for pulling the main pod image from private registries |
-| image.repository | string | `"rstudio/rstudio-package-manager"` | the repository to use for the main pod image |
-| image.tag | string | `""` | the tag to use for the main pod image |
-| image.tagPrefix | string | `"ubuntu2204-"` | A tag prefix for the server image (common selection: ubuntu2204-). Only used if tag is not defined |
+| image.os | string | `"ubuntu-24.04"` | The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined |
+| image.repository | string | `"posit/package-manager"` | the repository to use for the main pod image |
+| image.tag | string | `""` | the tag to use for the main pod image. Overrides os and appVersion |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | string | `nil` |  |

--- a/charts/rstudio-pm/README.md.gotmpl
+++ b/charts/rstudio-pm/README.md.gotmpl
@@ -10,6 +10,11 @@
 
 ## Upgrade guidance
 
+### 0.20.0
+
+- Chart version 0.20.0 switches default images from `rstudio/` to the `posit/` namespace on Docker Hub (also available at `ghcr.io/posit-dev/`). See the [migration guide](https://docs.posit.co/helm/docs/migrating-to-posit-images.html) for details.
+- Image tag format changed from `{tagPrefix}{appVersion}` to `{appVersion}-{os}`. The chart will fail with a clear error if you have `image.tagPrefix` set — replace it with `image.os`.
+
 ### 0.4.0
 
 - When upgrading to version 0.4.0 or later, the Package Manager service moves from running as `root` to running as

--- a/charts/rstudio-pm/lint/all-values.yaml
+++ b/charts/rstudio-pm/lint/all-values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: rstudio/rstudio-package-manager
-  tag: 1.1.6.1-5
+  repository: ghcr.io/posit-dev/package-manager
+  tag: 2026.04.2-ubuntu-24.04
   imagePullPolicy: Always
   imagePullSecrets:
     - name: "some-secret"

--- a/charts/rstudio-pm/lint/all-values.yaml
+++ b/charts/rstudio-pm/lint/all-values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/posit-dev/package-manager
+  repository: posit/package-manager
   tag: 2026.04.2-ubuntu-24.04
   imagePullPolicy: Always
   imagePullSecrets:

--- a/charts/rstudio-pm/templates/NOTES.txt
+++ b/charts/rstudio-pm/templates/NOTES.txt
@@ -36,3 +36,7 @@ WARNING: `image.pullPolicy` value has been removed in chart version 0.2.7. Pleas
 NOTE: `pod.serviceAccountName` is deprecated and will be removed in the future.
 Please use `serviceAccount.name` instead.
 {{- end }}
+
+{{- if .Values.image.tagPrefix }}
+  {{- fail "\n\n`image.tagPrefix` has been removed. Use `image.os` instead (e.g. `ubuntu-24.04`). The image tag format is now `{version}-{os}`." }}
+{{- end }}

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
       - name: rspm
         {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-        {{- $imageTag := .Values.image.tag | default (printf "%s%s" .Values.image.tagPrefix $defaultVersion )}}
+        {{- $imageTag := .Values.image.tag | default (printf "%s-%s" $defaultVersion .Values.image.os )}}
         image: "{{ .Values.image.repository }}:{{ $imageTag }}"
         env:
         {{- include "rstudio-library.license-env" (dict "license" ( .Values.license ) "product" ("rstudio-pm") "envVarPrefix" ("RSPM") "fullName" (include "rstudio-pm.fullname" .)) | nindent 8 }}

--- a/charts/rstudio-pm/tests/deprecated_keys_test.yaml
+++ b/charts/rstudio-pm/tests/deprecated_keys_test.yaml
@@ -1,0 +1,11 @@
+suite: Package Manager Deprecated Keys
+templates:
+  - NOTES.txt
+tests:
+  - it: should fail when image.tagPrefix is set
+    set:
+      image:
+        tagPrefix: "ubuntu2204-"
+    asserts:
+      - failedTemplate:
+          errorPattern: "image.tagPrefix.*has been removed.*image.os"

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -33,10 +33,10 @@ sharedStorage:
 
 image:
   # -- the repository to use for the main pod image
-  repository: rstudio/rstudio-package-manager
-  # -- A tag prefix for the server image (common selection: ubuntu2204-). Only used if tag is not defined
-  tagPrefix: ubuntu2204-
-  # -- the tag to use for the main pod image
+  repository: posit/package-manager
+  # -- The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined
+  os: "ubuntu-24.04"
+  # -- the tag to use for the main pod image. Overrides os and appVersion
   tag: ""
   # -- the imagePullPolicy for the main pod image
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Default image: `posit/package-manager` (was `rstudio/rstudio-package-manager`)
- Tag format: `{version}-{os}` (was `{tagPrefix}{version}`)
- `image.tagPrefix` replaced by `image.os`
- Add fail-fast guard for removed `tagPrefix` key
- Add 0.20.0 upgrade guidance in README
- Chart version bumped to 0.20.0

## Breaking changes

| Old value | New value |
|---|---|
| `image.repository: rstudio/rstudio-package-manager` | `image.repository: posit/package-manager` |
| `image.tagPrefix: ubuntu2204-` | `image.os: "ubuntu-24.04"` |

Images are also available at `ghcr.io/posit-dev/` on GitHub Container Registry.