### PR TITLE
Pin all third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -9,21 +9,21 @@ jobs:
     name: helm-docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: install Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
       - name: Install Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
         with:
           version: pre-release
 
       - name: Render Quarto Project
-        uses: quarto-dev/quarto-actions/render@v2
+        uses: quarto-dev/quarto-actions/render@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
         env:
           HELM_DOCS_VERSION: 1.13.1
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Notify Slack of chart documentation failure on main
         if: github.ref == 'refs/heads/main' && failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |
@@ -60,16 +60,16 @@ jobs:
     needs: document
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
       - name: install Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
       - name: Compute and update dependent files
         run: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Notify Slack of chart documentation (rbac) failure on main
         if: github.ref == 'refs/heads/main' && failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |

--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: 'gh-pages'
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6.1.0
         with:
           commit-message: Rebuild index.yaml
           title: Rebuild index.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Notify Slack of index.yaml rebuild failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -21,21 +21,21 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
       # Uses the default cr.yaml config file in the repository
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         with:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser (other)
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         with:
           charts_dir: other-charts
           skip_existing: true
@@ -44,7 +44,7 @@ jobs:
 
       - name: Notify Slack of chart release failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -50,7 +50,7 @@ jobs:
 
       - name: Notify Slack of chart linting failure if on main
         if: github.ref == 'refs/heads/main' && (steps.ct-lint.outcome == 'failure' || steps.ct-lint-all.outcome == 'failure')
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
           version: "v3.19.2"
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Notify Slack of chart unittest failure if on main
         if: github.ref == 'refs/heads/main' && steps.unittest.outcome == 'failure'
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |
@@ -141,22 +141,22 @@ jobs:
     runs-on: ubuntu-latest-4x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -167,7 +167,7 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
 
       - name: Install SealedSecrets Helm Chart
         run: |
@@ -213,7 +213,7 @@ jobs:
 
       - name: Notify Slack of chart install failure if on main
         if: github.ref == 'refs/heads/main' && (steps.ct-install.outcome == 'failure' || steps.ct-install-all.outcome == 'failure')
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |
@@ -240,18 +240,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Add rstudio helm repo
         run: helm repo add rstudio https://helm.rstudio.com
 
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
       - name: Run executable verification for default interpreters
         run: |
           just test-connect-interpreter-versions
+
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # SARIF upload needs security-events:write; fork PRs get read-only but
+      # zizmor still runs as a pass/fail check — only the upload is skipped.
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8  # v0.5.2
+        with:
+          advanced-security: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate token for GitHub App
         id: generate-token
         if: steps.project-url.outputs.project != 'none'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
           app-id: 1064714
           private-key: ${{ secrets.POSIT_PLATFORM_PROJECTS_PEM }}
@@ -44,7 +44,7 @@ jobs:
       - name: Add issue to project
         id: add-to-project
         if: steps.project-url.outputs.project != 'none'
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           project-url: ${{ steps.project-url.outputs.PROJECT }}
           github-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -53,13 +53,13 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install Just
         if: steps.current.outputs.app-version != steps.app-version.outputs.value
-        uses: extractions/setup-just@v4
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
       - name: Generate docs
         if: steps.current.outputs.app-version != steps.app-version.outputs.value
@@ -160,7 +160,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.current.outputs.app-version != steps.app-version.outputs.value
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-${{ inputs.product }}-${{ steps.app-version.outputs.value }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,30 +15,30 @@ jobs:
     steps:
       - name: Configure AWS credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: install Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
         with:
           version: pre-release
           
       - name: Render Quarto Project
-        uses: quarto-dev/quarto-actions/render@v2
+        uses: quarto-dev/quarto-actions/render@8a96df13519ee81fd526f2dfca5962811136661b  # v2.2.0
       
       - run: just push-docs
 
       - name: Notify Slack of publishing chart documentation failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
           payload-delimiter: "_"
           payload: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin


### PR DESCRIPTION
## Summary

- Pin every external action to its full-length commit SHA with a version comment
- Eliminates mutable tag refs, including `@master` on `aws-actions/configure-aws-credentials`
- Added Zizmor static analysis (https://docs.zizmor.sh/) to catch any future un-pinned action versions
- Dependabot (configured in rstudio/helm#836) will keep these updated

## Version upgrades

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `v6.0.2` |
| `actions/create-github-app-token` | `@v2` / `@v3` | `v3.1.1` |
| `actions/setup-python` | `@v5` | `v6.2.0` |
| `aws-actions/configure-aws-credentials` | `@master` | `v6.1.0` |
| `azure/setup-helm` | `@v4` | `v5.0.0` |
| `extractions/setup-just` | `@v2` | `v4` |
| `peter-evans/create-pull-request` | `@v6` (chart-rebuild) | `v6.1.0` |
| `slackapi/slack-github-action` | `@v1.27.0` | `v3.0.1` |

## Test plan

- [x] CI passes on this PR
- [ ] Verify `slackapi/slack-github-action` v3 payload format is compatible (v1 → v3 is a major bump)
- [ ] Verify `azure/setup-helm` v5 works (v4 → v5)
- [ ] Verify `actions/setup-python` v6 works (v5 → v6)