### PR TITLE
Allow Connect doc changes without a chart version bump

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run chart-testing (lint all)
         id: ct-lint-all
-        run: ct lint --target-branch main --all --chart-dirs charts --chart-dirs other-charts
+        run: ct lint --use-helmignore --target-branch main --all --chart-dirs charts --chart-dirs other-charts
         continue-on-error: true
 
       - name: Notify Slack of chart linting failure if on main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ charts/<chart-name>/
 
 ## Critical Workflow Requirements
 
-1. **Version bumping is mandatory**: Any change (including README templates) requires bumping the chart version in `Chart.yaml`
+1. **Version bumping is mandatory for non-doc changes**: Any change to chart templates, values, or Chart.yaml requires bumping the chart version. Documentation-only changes (`README.md`, `README.md.gotmpl`, `_templates.gotmpl`, `NEWS.md`) do **not** require a version bump — these files are listed in `.helmignore` so `ct lint` will not flag them.
 2. **NEWS update required**: All chart changes require an update to the chart's NEWS.md file
 3. **Run `make lint`**: Run `make lint` in the chart directory for all chart changes
 4. **CI runs only on local branches**: PRs from forks won't trigger full CI - contributors need branch access

--- a/charts/rstudio-connect/.helmignore
+++ b/charts/rstudio-connect/.helmignore
@@ -23,6 +23,11 @@
 *.tmproj
 .vscode/
 
+# documentation changes should not require a version bump
+README.md
+*.gotmpl
+NEWS.md
+
 # chart tests
 ci/
 lint/


### PR DESCRIPTION
## Summary

- Add `README.md`, `*.gotmpl`, and `NEWS.md` to the Connect chart's `.helmignore` so `ct lint` doesn't require a version bump for documentation-only changes
- Add `--use-helmignore` to the "lint all" CI step for consistency with the "lint changed" step
- Update `CLAUDE.md` to reflect the new rule

The docs site (`docs.posit.co/helm/`) already publishes on every merge to `main` regardless of chart versions, so doc changes go live without a release. Other product teams can adopt the same pattern in their own `.helmignore` if they want.

Closes #839

## Test plan

- [x] CI passes — `ct lint` should not flag this PR for a missing version bump since only `.helmignore`, CI config, and `CLAUDE.md` changed
- [ ] Verify a follow-up PR that only changes Connect's `README.md.gotmpl` or `NEWS.md` does not require a version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)