### PR TITLE
Fix upgrade guidance link to point to published docs

### DIFF
--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -47,7 +47,7 @@ helm search repo rstudio/rstudio-connect -l
 
 ### 0.9.0
 
-- Chart version 0.9.0 adds support for the direct Kubernetes runner via `backends.kubernetes.enabled`. See the [upgrade guide](../../examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd) for details on transitioning from `launcher.enabled`.
+- Chart version 0.9.0 adds support for the direct Kubernetes runner via `backends.kubernetes.enabled`. See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning from `launcher.enabled`.
 
 ### 0.8.0
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -12,7 +12,7 @@
 
 ### 0.9.0
 
-- Chart version 0.9.0 adds support for the direct Kubernetes runner via `backends.kubernetes.enabled`. See the [upgrade guide](../../examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd) for details on transitioning from `launcher.enabled`.
+- Chart version 0.9.0 adds support for the direct Kubernetes runner via `backends.kubernetes.enabled`. See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning from `launcher.enabled`.
 
 ### 0.8.0
 


### PR DESCRIPTION
## Summary
- Update the 0.9.0 upgrade guide link in the Connect chart README from a relative `.qmd` path to the absolute published docs URL (`docs.posit.co/helm/...`)
- The previous relative link pointed to the raw Quarto source file on GitHub, which is not human-readable

## Test plan
- [x] Verify the [upgrade guide link](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) resolves to the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)