### PR TITLE
Clarify upgrade guide for migrating Launcher to Kubernetes

### DIFF
--- a/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd
+++ b/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd
@@ -19,7 +19,7 @@ If you haven't customized `launcher.templateValues`, the minimal upgrade is a si
 | Launcher setting | Action |
 | --- | --- |
 | `launcher.enabled` | Set to `false` and set `backends.kubernetes.enabled: true` |
-| `config.Launcher` | Move to `config.Kubernetes` (optional — only if you customized it) |
+| `config.Launcher` | Move applicable values to `config.Kubernetes` (optional — only if you customized it) |
 | `launcher.namespace` | Move to `backends.kubernetes.namespace` (optional — only if you customized it) |
 | `launcher.defaultInitContainer.*` | Move to `backends.kubernetes.defaultInitContainer.*` (optional — same structure) |
 

--- a/examples/connect/upgrade-launcher-to-kubernetes/rstudio-connect-minimal-upgrade.yaml
+++ b/examples/connect/upgrade-launcher-to-kubernetes/rstudio-connect-minimal-upgrade.yaml
@@ -1,13 +1,8 @@
 # Minimal upgrade from Launcher to direct Kubernetes runner.
-# One required change if you haven't customized templateValues.
-
-# sharedStorage values remain unchanged
-sharedStorage:
-  create: true
-  mount: true
-  storageClassName: nfs-sc-rwx # TODO: Change to your RWX StorageClass
-  requests:
-    storage: 100G
+#
+# If your values.yaml contains modifications to launcher.templateValues or
+# any other launcher.* fields use the examples below to move these values
+# to the new configuration structure.
 
 # Disable the Launcher
 launcher:
@@ -17,7 +12,3 @@ launcher:
 backends:
   kubernetes:
     enabled: true
-
-# Optional: if you had custom config.Launcher settings, move them to config.Kubernetes.
-# DataDirPVCName is auto-configured when sharedStorage.create or sharedStorage.mount is true
-# and sharedStorage.mountContent is true.


### PR DESCRIPTION
I removed the `sharedStorage` section from the example since no changes are required. 

I also tried to clarify that the `config.Launcher` section only has a few applicable values that can be moved. We should x-link the connect config appendix once it's published