### PR TITLE
Remove default for launcher.customRuntimeYaml in Connect chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@
 
 Individual helm charts have their own documentation
 
-- [Posit Connect](./charts/rstudio-connect)
-- [Posit Workbench](./charts/rstudio-workbench)
-- [Posit Package Manager](./charts/rstudio-pm)
+- [Posit Connect](./charts/rstudio-connect) ([documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html))
+- [Posit Workbench](./charts/rstudio-workbench) ([documentation](https://docs.posit.co/helm/charts/rstudio-workbench/README.html))
+- [Posit Package Manager](./charts/rstudio-pm) ([documentation](https://docs.posit.co/helm/charts/rstudio-pm/README.html))
+- [Posit Chronicle](./charts/posit-chronicle) ([documentation](https://docs.posit.co/helm/charts/posit-chronicle/README.html))
 
 Examples:
 

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.9.0
+version: 0.9.1
 apiVersion: v2
 appVersion: 2026.03.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+- Remove the default values for `launcher.customRuntimeYaml`. This configuration has been replaced by the `executionEnvironments` configuration which provides a mechanism for [managing execution environments declaratively](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/#declarative-management) and is better suited for IaC.
+
 ## 0.9.0
 
 - Add support for an alternative Kubernetes backend via `backends.kubernetes.enabled`, which replaces the Launcher's template system with standard Kubernetes Job and Service manifests configured through `defaultResourceJobBase` and `defaultResourceServiceBase`. This backend will be available starting with Connect 2026.04.0.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.0:
+To install the chart with the release name `my-release` at version 0.9.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.0
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.1
 ```
 
 To explore other chart versions, look at:
@@ -312,8 +312,8 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | ingress.ingressClassName | string | `""` | The ingressClassName for the ingress resource. Only used for clusters that support networking.k8s.io/v1 Ingress resources |
 | ingress.tls | list | `[]` |  |
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
-| launcher.additionalRuntimeImages | list | `[]` | Optional. Additional images to append to the end of the "launcher.customRuntimeYaml" (in the "images" key). If `customRuntimeYaml` is a "map", then "additionalRuntimeImages" will only be used if it is a "list". |
-| launcher.customRuntimeYaml | string | `"base"` | Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "base", which pulls in the default runtime.yaml file. If changing this value, be careful to include the images that you have already used. If set to "pro", will pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the cost of a larger image). Starting with Connect v2023.05.0, this configuration is used to bootstrap the initial set of execution environments the first time the server starts. If any execution environments already exist in the database, these values are ignored; execution environments are not created or modified during subsequent restarts. |
+| launcher.additionalRuntimeImages | list | `[]` | Deprecated, use `executionEnvironments` instead. Optional. Additional images to append to the end of the "launcher.customRuntimeYaml" (in the "images" key). If `customRuntimeYaml` is a "map", then "additionalRuntimeImages" will only be used if it is a "list". |
+| launcher.customRuntimeYaml | string | `""` | Deprecated, use `executionEnvironments` instead. Optional. The runtime.yaml definition of Kubernetes runtime containers. If set to "base", will pull in the default runtime.yaml file. If set to "pro", will pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the cost of a larger image). Starting with Connect v2023.05.0, this configuration is used to bootstrap the initial set of execution environments the first time the server starts. If any execution environments already exist in the database, these values are ignored; execution environments are not created or modified during subsequent restarts. |
 | launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"ghcr.io/rstudio/rstudio-connect-content-init","resources":{},"securityContext":{},"tag":"","tagPrefix":"ubuntu2204-"}` | Image definition for the default Posit Connect Content InitContainer |
 | launcher.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. |
 | launcher.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -71,7 +71,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- /* default launcher configuration */}}
   {{- if .Values.launcher.enabled }}
     {{- $namespace := default $.Release.Namespace .Values.launcher.namespace }}
-    {{- $launcherSettingsDict := dict "Enabled" ("true") "Kubernetes" ("true") "ClusterDefinition" (list "/etc/rstudio-connect/runtime.yaml") "KubernetesNamespace" ($namespace) "KubernetesProfilesConfig" ("/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf") }}
+    {{- $launcherSettingsDict := dict "Enabled" ("true") "Kubernetes" ("true") "KubernetesNamespace" ($namespace) "KubernetesProfilesConfig" ("/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf") }}
+    {{- if include "rstudio-connect.runtimeYaml" . }}
+      {{- $_ := set $launcherSettingsDict "ClusterDefinition" (list "/etc/rstudio-connect/runtime.yaml") }}
+    {{- end }}
     {{- if and (or .Values.sharedStorage.create .Values.sharedStorage.mount) .Values.sharedStorage.mountContent }}
       {{- $dataDirPVCName := default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
       {{- $_ := set $launcherSettingsDict "DataDirPVCName" $dataDirPVCName }}
@@ -142,7 +145,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     the end of the runtimeImages file is still in the context of the "images" key
 */}}
 {{- define "rstudio-connect.runtimeYaml" -}}
-  {{- $runtimeYaml := deepCopy .Values.launcher.customRuntimeYaml }}
+  {{- $runtimeYaml := deepCopy (.Values.launcher.customRuntimeYaml | default "") }}
   {{- $additionalImages := deepCopy .Values.launcher.additionalRuntimeImages }}
   {{- if kindIs "string" $runtimeYaml }}
     {{- if eq $runtimeYaml "pro" }}
@@ -165,10 +168,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{- $_ := set $runtimeYaml "images" (append $runtimeYaml.images $additionalImages) }}
     {{- end }}
     {{- toYaml $runtimeYaml }}
-  {{- else }}
-    {{- /* falsy or catch-all */ -}}
-    {{- .Files.Get "default-runtime.yaml" }}
-    {{- include "rstudio-connect.additionalImagesString" $additionalImages }}
   {{- end }}
 {{- end -}}
 

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -26,8 +26,11 @@ data:
 {{- end }}
 {{- $sessionTemplate := deepCopy .Values.launcher.templateValues }}
 {{- if .Values.launcher.enabled }}
+  {{- $runtimeYamlContent := include "rstudio-connect.runtimeYaml" . }}
+  {{- if $runtimeYamlContent }}
   runtime.yaml: |
-    {{- include "rstudio-connect.runtimeYaml" . | nindent 4 }}
+    {{- $runtimeYamlContent | nindent 4 }}
+  {{- end }}
   {{- /* configuration for job customization (also used below) */ -}}
     {{- /* 1 - volume */ -}}
       {{- $emptyRscVolume := dict "name" ("rsc-volume") "emptydir" (dict) }}

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -208,9 +208,11 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.launcher.enabled }}
+          {{- if include "rstudio-connect.runtimeYaml" . }}
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/runtime.yaml"
             subPath: "runtime.yaml"
+          {{- end }}
           - name: rstudio-connect-config
             mountPath: "/etc/rstudio-connect/launcher/launcher.kubernetes.profiles.conf"
             subPath: "launcher.kubernetes.profiles.conf"

--- a/charts/rstudio-connect/tests/execution_environments_test.yaml
+++ b/charts/rstudio-connect/tests/execution_environments_test.yaml
@@ -270,3 +270,114 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "executionEnvironments[0].name is required"
+
+  # =============================================================================
+  # configmap.yaml - runtime.yaml key omitted when customRuntimeYaml is empty
+  # =============================================================================
+
+  - it: should not include runtime.yaml key in configmap when customRuntimeYaml is empty (default)
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+    asserts:
+      - notExists:
+          path: data["runtime.yaml"]
+
+  - it: should not include runtime.yaml key in configmap when customRuntimeYaml is null
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+        customRuntimeYaml: null
+    asserts:
+      - notExists:
+          path: data["runtime.yaml"]
+
+  - it: should include runtime.yaml key in configmap when customRuntimeYaml is "base"
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+        customRuntimeYaml: "base"
+    asserts:
+      - exists:
+          path: data["runtime.yaml"]
+
+  - it: should include runtime.yaml key in configmap when customRuntimeYaml is "pro"
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+        customRuntimeYaml: "pro"
+    asserts:
+      - exists:
+          path: data["runtime.yaml"]
+
+  # =============================================================================
+  # configmap.yaml - ClusterDefinition omitted when customRuntimeYaml is empty
+  # =============================================================================
+
+  - it: should not set ClusterDefinition in gcfg when customRuntimeYaml is empty (default)
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ClusterDefinition"
+
+  - it: should set ClusterDefinition in gcfg when customRuntimeYaml is "base"
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      launcher:
+        enabled: true
+        customRuntimeYaml: "base"
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ClusterDefinition = /etc/rstudio-connect/runtime.yaml"
+
+  # =============================================================================
+  # deployment.yaml - runtime.yaml volumeMount omitted when customRuntimeYaml is empty
+  # =============================================================================
+
+  - it: should not mount runtime.yaml when customRuntimeYaml is empty (default)
+    template: deployment.yaml
+    set:
+      launcher:
+        enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-config
+            mountPath: "/etc/rstudio-connect/runtime.yaml"
+            subPath: "runtime.yaml"
+
+  - it: should mount runtime.yaml when customRuntimeYaml is "base"
+    template: deployment.yaml
+    set:
+      launcher:
+        enabled: true
+        customRuntimeYaml: "base"
+      sharedStorage:
+        create: true
+        mount: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-config
+            mountPath: "/etc/rstudio-connect/runtime.yaml"
+            subPath: "runtime.yaml"

--- a/charts/rstudio-connect/tests/scratch_path_test.yaml
+++ b/charts/rstudio-connect/tests/scratch_path_test.yaml
@@ -11,9 +11,12 @@ tests:
         enabled: true
         useTemplates: true
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /var/lib/rstudio-connect-launcher/Kubernetes/rstudio-library-templates-data.tpl
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-templates
+            mountPath: /var/lib/rstudio-connect-launcher/Kubernetes/rstudio-library-templates-data.tpl
+            subPath: rstudio-library-templates-data.tpl
   - it: should use custom scratch path when specified
     template: deployment.yaml
     set:
@@ -24,12 +27,21 @@ tests:
         Launcher:
           KubernetesScratchPath: /custom/path
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /custom/path/Kubernetes/rstudio-library-templates-data.tpl
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
-          value: /custom/path/Kubernetes/job.tpl
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[5].mountPath
-          value: /custom/path/Kubernetes/service.tpl
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-templates
+            mountPath: /custom/path/Kubernetes/rstudio-library-templates-data.tpl
+            subPath: rstudio-library-templates-data.tpl
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-templates
+            mountPath: /custom/path/Kubernetes/job.tpl
+            subPath: job.tpl
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: rstudio-connect-templates
+            mountPath: /custom/path/Kubernetes/service.tpl
+            subPath: service.tpl

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -347,14 +347,16 @@ launcher:
   enabled: true
   # -- The namespace to launch sessions into. Uses the Release namespace by default
   namespace: ""
-  # -- Optional. The runtime.yaml definition of Kubernetes runtime containers. Defaults to "base", which pulls in the default
-  # runtime.yaml file. If changing this value, be careful to include the images that you have already used. If set to "pro", will
-  # pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the cost of a larger image).
+  # -- Deprecated, use `executionEnvironments` instead. Optional. The runtime.yaml definition of Kubernetes runtime containers.
+  # If set to "base", will pull in the default runtime.yaml file.
+  # If set to "pro", will pull in the "pro" versions of the default runtime images (i.e. including the pro drivers at the
+  # cost of a larger image).
   # Starting with Connect v2023.05.0, this configuration is used to bootstrap the initial set of execution environments
   # the first time the server starts. If any execution environments already exist in the database, these values are ignored;
   # execution environments are not created or modified during subsequent restarts.
-  customRuntimeYaml: "base"
-  # -- Optional. Additional images to append to the end of the "launcher.customRuntimeYaml" (in the "images" key).
+  customRuntimeYaml: ""
+  # -- Deprecated, use `executionEnvironments` instead. Optional. Additional images to append to the end of
+  # the "launcher.customRuntimeYaml" (in the "images" key).
   # If `customRuntimeYaml` is a "map", then "additionalRuntimeImages" will only be used if it is a "list".
   additionalRuntimeImages: []
   # -- User definition of launcher.kubernetes.profiles.conf for job customization


### PR DESCRIPTION
## Summary

- Removes the `"base"` default for `launcher.customRuntimeYaml`, replacing it with an empty string so no `runtime.yaml` is bootstrapped by default
- Marks `launcher.customRuntimeYaml` and `launcher.additionalRuntimeImages` as deprecated in favor of `executionEnvironments`, which supports [declarative management](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/#declarative-management) and takes effect on every helm upgrade without a pod restart or database reset
- Conditionally omits the `runtime.yaml` key from the ConfigMap entirely when `customRuntimeYaml` is empty or null — previously an empty key was always emitted

## Test plan

- [x] All existing tests pass (`just test rstudio-connect`)
- [x] New tests added for `customRuntimeYaml` empty (default), null, `"base"`, and `"pro"` cases in `execution_environments_test.yaml`
- [x] Verify Connect handles absence of `runtime.yaml` in the ConfigMap gracefully on a fresh install (ci should cover this)
- [x] Verify existing installs with `customRuntimeYaml: "base"` or `"pro"` set explicitly continue to behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)