### PR TITLE
Bump rstudio-pm chart to 0.5.55

### DIFF
--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,8 +1,8 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.54
+version: 0.5.55
 apiVersion: v2
-appVersion: 2026.04.0
+appVersion: 2026.04.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg
 home: https://www.rstudio.com
 sources:
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: rstudio-package-manager
-      image: rstudio/rstudio-package-manager:ubuntu2204-2026.04.0
+      image: rstudio/rstudio-package-manager:ubuntu2204-2026.04.1
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: RStudio Community

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.55
+
+- Update default Posit Package Manager version to 2026.04.1
+
 ## 0.5.54
 
 - Update default Posit Package Manager version to 2026.04.0

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.54](https://img.shields.io/badge/Version-0.5.54-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
+![Version: 0.5.55](https://img.shields.io/badge/Version-0.5.55-informational?style=flat-square) ![AppVersion: 2026.04.1](https://img.shields.io/badge/AppVersion-2026.04.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.54:
+To install the chart with the release name `my-release` at version 0.5.55:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.54
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.55
 ```
 
 To explore other chart versions, look at:


### PR DESCRIPTION
Update Helm chart for Posit Package Manager to 0.5.55: bump Chart.yaml version and appVersion to 0.5.55 / 2026.04.1, update the default rstudio-package-manager image tag, refresh README badges and install example, and add a NEWS entry noting the upgrade to 2026.04.1.