### PR TITLE
Use POSIT_PLATFORM secrets for app token

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -38,8 +38,8 @@ jobs:
         if: steps.project-url.outputs.project != 'none'
         uses: actions/create-github-app-token@v2
         with:
-          app-id: 1064714
-          private-key: ${{ secrets.POSIT_PLATFORM_PROJECTS_PEM }}
+          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
           owner: ${{ steps.project-url.outputs.ORG }}
       - name: Add issue to project
         id: add-to-project

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -55,8 +55,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Replace the generic `APP_ID` / `APP_PRIVATE_KEY` secrets with the app-specific
`POSIT_PLATFORM_APP_ID` / `POSIT_PLATFORM_PEM` secrets provisioned by
[rstudio/github-iac](https://github.com/rstudio/github-iac).

The `posit-platform` GitHub App is already installed on this repo and its
credentials are already shared with it via the Pulumi config, so this is a
drop-in rename with no infrastructure changes required.

## Test plan

- [ ] Trigger the issue automation workflow (open a test issue) and confirm
      the run still succeeds
- [ ] Confirm the bot actor on the resulting label / project-add events is
      still `posit-platform[bot]`