### PR TITLE
Auto-apply connect.posit.co/service-account label on chart-managed SA (#846)

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.9.1
+version: 0.9.2
 apiVersion: v2
 appVersion: 2026.03.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.2
+
+- Auto-apply the `connect.posit.co/service-account=true` label on the chart-managed service account when `backends.kubernetes.enabled: true` and `rbac.serviceAccount.create: true`. The direct Kubernetes runner requires this label to launch content jobs; applying it automatically avoids a common gotcha. User-provided labels under `rbac.serviceAccount.labels` still apply alongside and win on conflict. Users bringing their own service account or pinning a different SA via `defaultResourceJobBase.spec.template.spec.serviceAccountName` must still apply the label manually.
+
 ## 0.9.1
 
 - Remove the default values for `launcher.customRuntimeYaml`. This configuration has been replaced by the `executionEnvironments` configuration which provides a mechanism for [managing execution environments declaratively](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/#declarative-management) and is better suited for IaC.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.1:
+To install the chart with the release name `my-release` at version 0.9.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.1
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/rbac.yaml
+++ b/charts/rstudio-connect/templates/rbac.yaml
@@ -49,6 +49,8 @@ subjects:
     namespace: {{ $namespace }}
 {{- end }}
 {{- if $serviceAccountCreate }}
+{{- /* Content jobs will not launch unless the SA has connect.posit.co/service-account=true, so the chart applies it automatically on the SA it manages. User-provided labels win on conflict. */}}
+{{- $mergedLabels := merge (deepCopy ($serviceAccountLabels | default dict)) (dict "connect.posit.co/service-account" "true") }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -59,10 +61,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with $serviceAccountLabels }}
   labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- toYaml $mergedLabels | nindent 4 }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -1126,3 +1126,92 @@ tests:
       - matchRegex:
           path: data["job.yaml"]
           pattern: "name: connect-content"
+
+  # Test: chart auto-applies connect.posit.co/service-account=true on the SA it manages
+  # so content jobs launch without users needing to label the SA manually.
+  # Template order without clusterRoleCreate: SA(0), Role(1), RoleBinding(2)
+  - it: should auto-apply connect.posit.co/service-account label on chart-managed SA
+    template: rbac.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      rbac:
+        create: true
+        clusterRoleCreate: false
+        serviceAccount:
+          create: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.labels["connect.posit.co/service-account"]
+          value: "true"
+
+  - it: should preserve user-provided labels alongside auto-applied label
+    template: rbac.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      rbac:
+        create: true
+        clusterRoleCreate: false
+        serviceAccount:
+          create: true
+          labels:
+            team: data-science
+            environment: prod
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.labels["connect.posit.co/service-account"]
+          value: "true"
+      - equal:
+          path: metadata.labels.team
+          value: data-science
+      - equal:
+          path: metadata.labels.environment
+          value: prod
+
+  - it: should let user-provided label override auto-applied connect.posit.co/service-account
+    template: rbac.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      rbac:
+        create: true
+        clusterRoleCreate: false
+        serviceAccount:
+          create: true
+          labels:
+            connect.posit.co/service-account: "false"
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.labels["connect.posit.co/service-account"]
+          value: "false"
+
+  - it: should not render a ServiceAccount when rbac.serviceAccount.create is false (no label to apply)
+    template: rbac.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      rbac:
+        create: true
+        clusterRoleCreate: false
+        serviceAccount:
+          create: false
+          name: byo-sa
+    asserts:
+      - hasDocuments:
+          count: 2 # Role + RoleBinding, no SA
+      - isKind:
+          of: Role
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        documentIndex: 1

--- a/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd
+++ b/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd
@@ -29,7 +29,14 @@ If you haven't customized `launcher.templateValues`, the minimal upgrade is a si
 ## Important notes
 
 :::{.callout-important}
-The direct Kubernetes runner requires content service accounts to have the `connect.posit.co/service-account=true` label. Apply this label to any service account that content should be allowed to use, including the default and any custom service accounts set via `serviceAccountName` in the job base:
+The direct Kubernetes runner requires content service accounts to have the `connect.posit.co/service-account=true` label.
+
+When the chart creates the service account (`rbac.serviceAccount.create: true`, the default), it applies this label automatically — no manual step required.
+
+You only need to apply the label manually with `kubectl` when the chart does not manage the service account:
+
+- `rbac.serviceAccount.create: false` (you bring your own service account), or
+- a different service account is pinned via `serviceAccountName` in `backends.kubernetes.defaultResourceJobBase.spec.template.spec`.
 
 ```bash
 kubectl label sa <service-account-name> connect.posit.co/service-account=true -n <namespace>


### PR DESCRIPTION
## Summary

- When `backends.kubernetes.enabled: true` and `rbac.serviceAccount.create: true`, the chart now automatically applies `connect.posit.co/service-account=true` to the service account it manages. This removes a common gotcha: the direct Kubernetes runner silently refuses to launch content jobs on service accounts without the label, and there's no clear signal at install time.
- User-provided labels under `rbac.serviceAccount.labels` are merged in alongside the auto-applied label; user values win on conflict, so it's still possible to override.
- Upgrade guide (`examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.qmd`) now scopes the manual `kubectl label sa` step to the cases the chart can't own: BYO service accounts (`rbac.serviceAccount.create: false`) or SAs pinned via `defaultResourceJobBase.spec.template.spec.serviceAccountName`.

Closes #846.

## Test plan

- [x] `just test rstudio-connect` (106 tests pass, including 4 new tests covering auto-apply, coexistence with user labels, user override on conflict, and the BYO-SA path)
- [x] `helm lint --strict -f ci/kubernetes-values.yaml` — clean
- [x] `helm template -f ci/kubernetes-values.yaml` shows the label on the rendered ServiceAccount
- [x] `helm template -f ci/kubernetes-values.yaml --set rbac.serviceAccount.create=false` renders no SA (as expected, no label to apply)
- [x] `just docs` regenerated `charts/rstudio-connect/README.md`
- [x] Chart version bumped `0.9.1` → `0.9.2` and `NEWS.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)