### PR TITLE
Add events list RBAC permission to Connect direct Kubernetes runner

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.9.1
+version: 0.9.2
 apiVersion: v2
 appVersion: 2026.03.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.2
+
+- Add `events: list` permission to the direct Kubernetes runner Role. Connect 2026.04.0 lists events in the target namespace when a content pod fails to start and the failure reason cannot be determined from pod conditions.
+
 ## 0.9.1
 
 - Remove the default values for `launcher.customRuntimeYaml`. This configuration has been replaced by the `executionEnvironments` configuration which provides a mechanism for [managing execution environments declaratively](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/#declarative-management) and is better suited for IaC.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.1:
+To install the chart with the release name `my-release` at version 0.9.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.1
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/rbac.yaml
+++ b/charts/rstudio-connect/templates/rbac.yaml
@@ -94,6 +94,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - "events"
+    verbs:
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
       - "pods/attach"
     verbs:
       - "create"

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -429,6 +429,12 @@ tests:
           path: rules
           content:
             apiGroups: [""]
+            resources: ["events"]
+            verbs: ["list"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
             resources: ["services"]
             verbs: ["create", "get", "list", "watch"]
       - contains:


### PR DESCRIPTION
## Summary

- Adds `events: list` to the direct Kubernetes runner `Role` in `charts/rstudio-connect/templates/rbac.yaml`. Connect 2026.04.0 lists events in the target namespace when a content pod fails to start and the failure reason cannot be determined from pod conditions.
- Bumps `rstudio-connect` to `0.9.2` and updates `NEWS.md`.
- Extends the existing `should render correct Role rules for direct Kubernetes runner` unit test to assert the new rule.

Fixes #848

## Test plan

- [x] `just test rstudio-connect` — 102/102 pass
- [x] `helm lint --strict` — clean on complex / simple / empty / launcher values files
- [x] Rendered Role (via `helm template`) contains `events: list` in the target namespace only when `backends.kubernetes.enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)