### PR TITLE
pwb: Fix positron subPath mismatch with init container

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.11.0
+version: 0.11.1
 apiVersion: v2
 appVersion: 2026.04.0
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 0.11.1
+
+- Fix `components.positron.version` breaking the server pod with
+  `CreateContainerConfigError` due to subPath mismatch with the
+  positron-init container's flat copy layout (#856)
+
 ## 0.11.0
 
 - **BREAKING**: Change default session image from `rstudio/r-session-complete` to `rstudio/workbench-session` and enable session component delivery via init containers by default.

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.11.0:
+To install the chart with the release name `my-release` at version 0.11.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.11.0
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.11.1
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -189,13 +189,8 @@ containers:
       subPath: "service.tpl"
     {{- end }}
     {{- if (include "rstudio-workbench.positronInitEnabled" .) }}
-    {{- /* subPath and exe paths mirror posit-dev/images-workbench/workbench-positron-init */}}
     - name: positron-components
       mountPath: {{ include "rstudio-workbench.positronMountPath" . | quote }}
-      subPath: bin/positron-server/bundled
-    - name: positron-components
-      mountPath: {{ printf "%s/docs" (include "rstudio-workbench.positronMountPath" .) | quote }}
-      subPath: docs/positron
     {{- end }}
     {{- if .Values.pod.volumeMounts }}
     {{- toYaml .Values.pod.volumeMounts | nindent 4 }}
@@ -447,9 +442,8 @@ true
 
 {{/*
 Versioned mount path for Positron on the Workbench pod. The positron-init
-container (posit-dev/images-workbench → workbench-positron-init) writes
-artifacts to /mnt/init at fixed subpaths; subPath mounts and the
-positron.conf `exe` in configmap-general.yaml derive from this path.
+container flattens artifacts into /mnt/init; this emptyDir is mounted at
+the version path so positron.conf `exe` resolves correctly.
 Returns empty when the gate is off, so callers compose safely.
 */}}
 {{- define "rstudio-workbench.positronMountPath" -}}

--- a/charts/rstudio-workbench/tests/deployment_test.yaml
+++ b/charts/rstudio-workbench/tests/deployment_test.yaml
@@ -792,7 +792,7 @@ tests:
           path: 'spec.template.spec.initContainers[?(@.name=="positron-init")].image'
           value: "my-registry/positron-init:2026.03.0"
 
-  - it: should add positron binary mount to server container
+  - it: should add positron volume mount to server container
     template: deployment.yaml
     set:
       components:
@@ -804,22 +804,6 @@ tests:
           content:
             name: "positron-components"
             mountPath: "/usr/lib/rstudio-server/bin/positron-server/2026.03.0"
-            subPath: "bin/positron-server/bundled"
-          any: true
-
-  - it: should add positron docs mount to server container
-    template: deployment.yaml
-    set:
-      components:
-        positron:
-          version: "2026.03.0"
-    asserts:
-      - contains:
-          path: 'spec.template.spec.containers[0].volumeMounts'
-          content:
-            name: "positron-components"
-            mountPath: "/usr/lib/rstudio-server/bin/positron-server/2026.03.0/docs"
-            subPath: "docs/positron"
           any: true
 
   - it: should add positron-components emptyDir volume


### PR DESCRIPTION
## Summary

- Remove `subPath` mounts from the positron-components volume that don't match the positron-init container's flat copy layout
- Mount the emptyDir root directly at the versioned path — the `exe` path in `positron.conf` already resolves correctly against this layout

## Context

The positron-init Go binary (`session-components/positron-init`) copies the contents of `bin/positron-server/bundled/` into the emptyDir root (flat), but the Helm chart used `subPath: bin/positron-server/bundled` which assumes a nested directory structure. The kubelet fails with `CreateContainerConfigError` because the subPath doesn't exist in the emptyDir.

Fixes #856