### PR TITLE
Expose revision history limit

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.9.2
+version: 0.9.3
 apiVersion: v2
 appVersion: 2026.03.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3
+
+- Add `revisionHistoryLimit` value (default `3`) for the Connect deployment, exposing a knob to tune retained ReplicaSets and prevent old pods from accumulating across rolling updates.
+
 ## 0.9.2
 
 - Add `events: list` permission to the direct Kubernetes runner Role. Connect 2026.04.0 lists events in the target namespace when a content pod fails to start and the failure reason cannot be determined from pod conditions.

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
+![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![AppVersion: 2026.03.1](https://img.shields.io/badge/AppVersion-2026.03.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.9.2:
+To install the chart with the release name `my-release` at version 0.9.3:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.2
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.9.3
 ```
 
 To explore other chart versions, look at:
@@ -370,6 +370,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":3,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Used to configure the container's readinessProbe. Only included if enabled = true |
 | replicas | int | `1` | The number of replica pods to maintain for this service |
 | resources | object | `{}` | Defines resources for the rstudio-connect container |
+| revisionHistoryLimit | int | `3` | The revisionHistoryLimit to use for the pod deployment. Do not set to 0 |
 | securityContext | object | `{}` | Values to set the `securityContext` for the Connect container. It must include "privileged: true" or "CAP_SYS_ADMIN" when running in local execution mode. If launcher or backends.kubernetes is enabled, this can be removed with `securityContext: {}` |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |
 | service.clusterIP | string | `""` | The cluster-internal IP to use with `service.type` ClusterIP |

--- a/charts/rstudio-connect/templates/deployment.yaml
+++ b/charts/rstudio-connect/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       {{- include "rstudio-connect.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       annotations:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -66,6 +66,9 @@ priorityClassName: ""
 # -- Pod disruption budget
 podDisruptionBudget: {}
 
+# -- The revisionHistoryLimit to use for the pod deployment. Do not set to 0
+revisionHistoryLimit: 3
+
 # -- Defines the Posit Connect image to deploy
 image:
   # -- The repository to use for the main pod image

--- a/charts/rstudio-pm/Chart.yaml
+++ b/charts/rstudio-pm/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-pm
 description: Official Helm chart for Posit Package Manager
-version: 0.5.54
+version: 0.5.55
 apiVersion: v2
 appVersion: 2026.04.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-pm/NEWS.md
+++ b/charts/rstudio-pm/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.55
+
+- Add `revisionHistoryLimit` value (default `3`) for the Package Manager deployment, exposing a knob to tune retained ReplicaSets and prevent old pods from accumulating across rolling updates.
+
 ## 0.5.54
 
 - Update default Posit Package Manager version to 2026.04.0

--- a/charts/rstudio-pm/README.md
+++ b/charts/rstudio-pm/README.md
@@ -1,6 +1,6 @@
 # Posit Package Manager
 
-![Version: 0.5.54](https://img.shields.io/badge/Version-0.5.54-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
+![Version: 0.5.55](https://img.shields.io/badge/Version-0.5.55-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Package Manager_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.5.54:
+To install the chart with the release name `my-release` at version 0.5.55:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.54
+helm upgrade --install my-release rstudio/rstudio-pm --version=0.5.55
 ```
 
 To explore other chart versions, look at:
@@ -246,6 +246,7 @@ The Helm `config` values are converted into the `rstudio-pm.gcfg` service config
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/__ping__","port":4242},"initialDelaySeconds":3,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | readinessProbe is used to configure the container's readinessProbe |
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-pm pod |
+| revisionHistoryLimit | int | `3` | The revisionHistoryLimit to use for the pod deployment. Do not set to 0 |
 | rootCheckIsFatal | bool | `true` | Whether the check for root accounts in the config file is fatal. This is meant to simplify migration to the new helm chart version. |
 | rstudioPMKey | bool | `false` | rstudioPMKey is the rstudio-pm key used for the RStudio Package Manager service |
 | service.annotations | object | `{}` | Annotations for the service, for example to specify [an internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) |

--- a/charts/rstudio-pm/templates/deployment.yaml
+++ b/charts/rstudio-pm/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "rstudio-pm.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       annotations:

--- a/charts/rstudio-pm/values.yaml
+++ b/charts/rstudio-pm/values.yaml
@@ -256,3 +256,6 @@ tolerations: []
 priorityClassName: ""
 # -- Pod disruption budget
 podDisruptionBudget: {}
+
+# -- The revisionHistoryLimit to use for the pod deployment. Do not set to 0
+revisionHistoryLimit: 3

--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.10.15
+version: 0.10.16
 apiVersion: v2
 appVersion: 2026.04.0
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.10.16
+
+- Lower the default `revisionHistoryLimit` from `10` to `3` to prevent old ReplicaSets and their completed pods from accumulating across rolling updates. Operators can override via `revisionHistoryLimit` in values.
+
 ## 0.10.15
 
 - Bump Workbench version to 2026.04.0

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.10.15](https://img.shields.io/badge/Version-0.10.15-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
+![Version: 0.10.16](https://img.shields.io/badge/Version-0.10.16-informational?style=flat-square) ![AppVersion: 2026.04.0](https://img.shields.io/badge/AppVersion-2026.04.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.10.15:
+To install the chart with the release name `my-release` at version 0.10.16:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.15
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.10.16
 ```
 
 To explore other chart versions, look at:
@@ -680,7 +680,7 @@ Use of [Sealed secrets](https://github.com/bitnami-labs/sealed-secrets) disables
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/health-check","port":8787},"initialDelaySeconds":10,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | readinessProbe is used to configure the container's readinessProbe |
 | replicas | int | `1` | replicas is the number of replica pods to maintain for this service. Use 2 or more to enable HA |
 | resources | object | `{"limits":{"cpu":"2000m","enabled":false,"ephemeralStorage":"200Mi","memory":"4Gi"},"requests":{"cpu":"100m","enabled":false,"ephemeralStorage":"100Mi","memory":"2Gi"}}` | resources define requests and limits for the rstudio-server pod |
-| revisionHistoryLimit | int | `10` | The revisionHistoryLimit to use for the pod deployment. Do not set to 0 |
+| revisionHistoryLimit | int | `3` | The revisionHistoryLimit to use for the pod deployment. Do not set to 0 |
 | sealedSecret.annotations | object | `{}` | annotations for SealedSecret resources |
 | sealedSecret.enabled | bool | `false` | use SealedSecret instead of Secret to deploy secrets |
 | secureCookieKey | object | `{"existingSecret":"","value":""}` | global.secureCookieKey takes precedence over secureCookieKey |

--- a/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default-sa-values.yaml.lock
@@ -517,7 +517,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/default.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/default.yaml.lock
@@ -524,7 +524,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/empty-values.yaml.lock
@@ -524,7 +524,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress-values.yaml.lock
@@ -524,7 +524,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/ingress2-values.yaml.lock
@@ -524,7 +524,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/launcher-template-values.yaml.lock
@@ -859,7 +859,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-secret-values.yaml.lock
@@ -524,7 +524,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-file-values.yaml.lock
@@ -535,7 +535,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-server-values.yaml.lock
@@ -525,7 +525,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/license-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/license-values.yaml.lock
@@ -534,7 +534,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/other-complex-values.yaml.lock
@@ -623,7 +623,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values-new.yaml.lock
@@ -576,7 +576,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/overrides-values.yaml.lock
@@ -554,7 +554,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-profiles-values.yaml.lock
@@ -556,7 +556,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
+++ b/charts/rstudio-workbench/snapshot/simple-values.yaml.lock
@@ -553,7 +553,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: rstudio-workbench
       app.kubernetes.io/instance: release-name
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 3
   template:
     metadata:
       annotations:

--- a/charts/rstudio-workbench/values.yaml
+++ b/charts/rstudio-workbench/values.yaml
@@ -372,7 +372,7 @@ tolerations: []
 podDisruptionBudget: {}
 
 # -- The revisionHistoryLimit to use for the pod deployment. Do not set to 0
-revisionHistoryLimit: 10
+revisionHistoryLimit: 3
 
 pod:
   # -- env is an array of maps that is injected as-is into the "env:" component of the pod.container spec


### PR DESCRIPTION
I saw https://github.com/rstudio/helm/issues/855 come through and seemed simple enough to bring in and made sense to do. This exposes the revision limit for connect and package manager- it was already there for workbench.  And have a default of 3 everywhere.