### PR TITLE
fix(workbench): correct job.tpl to check suppressStdinAnnotation

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.20.1
+version: 0.20.2
 apiVersion: v2
 appVersion: 2026.05.0
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.20.2
+-  correct job.tpl to check `suppressStdinAnnotation` instead of `limitStdinAnnotation` 
+   to supress stdin annotation from pod metadata (#842)
 
 ## 0.20.1
 

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![AppVersion: 2026.05.0](https://img.shields.io/badge/AppVersion-2026.05.0-informational?style=flat-square)
+![Version: 0.20.2](https://img.shields.io/badge/Version-0.20.2-informational?style=flat-square) ![AppVersion: 2026.05.0](https://img.shields.io/badge/AppVersion-2026.05.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.1:
+To install the chart with the release name `my-release` at version 0.20.2:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.20.1
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.20.2
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/files/job.tpl
+++ b/charts/rstudio-workbench/files/job.tpl
@@ -47,7 +47,7 @@ spec:
         {{- $i = add $i 1 }}
         {{- end }}
         {{- end }}
-        {{- if not $templateData.pod.limitStdinAnnotation }}
+        {{- if not $templateData.pod.suppressStdinAnnotation }}
         stdin: {{ toYaml .Job.stdin | indent 8 | trimPrefix (repeat 8 " ") }}
         {{- end }}
         user: {{ toYaml .Job.user }}


### PR DESCRIPTION
## Summary
Fixes a regression introduced in #842 where the values.yaml key was 
renamed from `limitStdinAnnotation` to `suppressStdinAnnotation` during 
review, but the condition in `job.tpl` was not updated to match.

As a result, `suppressStdinAnnotation: true` has no effect — the stdin 
annotation is always written regardless of the configured value.

## Changes
- `charts/rstudio-workbench/files/job.tpl` — update condition to check 
  `suppressStdinAnnotation` instead of `limitStdinAnnotation`

Fixes #861