### PR TITLE
Default to new Kubernetes backend for off-host execution

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -94,7 +94,7 @@ test-connect-interpreter-versions:
   # find the default image
   image=$(
     helm template ./charts/rstudio-connect \
-    --set launcher.enabled=false \
+    --set backends.kubernetes.enabled=false \
     --show-only templates/deployment.yaml | \
     grep "image\:.*posit/connect\:.*" | \
     awk -F": " '{print $2}' | \
@@ -103,12 +103,12 @@ test-connect-interpreter-versions:
   for lang in "Python" "Quarto" "R"
   do
     echo "Testing $lang"
-    
+
     # print the default connect config file for local execution in ini format
     # print the section and grep for the Executables to find each interpreter
     executables=$(
       helm template ./charts/rstudio-connect \
-      --set launcher.enabled=false \
+      --set backends.kubernetes.enabled=false \
       --show-only templates/configmap.yaml | \
       sed -n -e "/\[$lang\]/,/\[*\]/ p" | \
       grep Executable | awk -F= '{print $2}' | \

--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.0
+version: 0.20.1
 apiVersion: v2
 appVersion: 2026.04.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,7 +2,10 @@
 
 ## 0.20.1
 
-- BREAKING: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`. New installations use the new implementation for Off-Host Execution by default. To continue using the Launcher implementation, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml. See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+- BREAKING: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`. 
+    - New installations use the new implementation for Off-Host Execution by default. 
+    - For existing installations, see the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+    - To continue using the Launcher implementation, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml. 
 
 ## 0.20.0
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -6,6 +6,7 @@
     - New installations use the new implementation for Off-Host Execution by default. 
     - For existing installations, see the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
     - To continue using the Launcher implementation, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml. 
+    - **IMPORTANT** When `backends.kubernetes.enabled=true`, service accounts used for content execution require the `connect.posit.co/service-account` label.
 
 ## 0.20.0
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.20.1
+
+- BREAKING: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`. New installations use the new implementation for Off-Host Execution by default. To continue using the Launcher implementation, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml. See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+
 ## 0.20.0
 
 - **BREAKING**: Default images now pull from the `posit/` namespace on Docker Hub

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: 2026.04.1](https://img.shields.io/badge/AppVersion-2026.04.1-informational?style=flat-square)
+![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![AppVersion: 2026.04.1](https://img.shields.io/badge/AppVersion-2026.04.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.0:
+To install the chart with the release name `my-release` at version 0.20.1:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.0
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.1
 ```
 
 To explore other chart versions, look at:
@@ -44,6 +44,12 @@ helm search repo rstudio/rstudio-connect -l
 ```
 
 ## Upgrade guidance
+
+### 0.20.1
+
+- Chart version 0.10.0 changes the default execution backend to use a new Off-Host Execution implementation: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`.
+New installations use the new implementation by default. To continue using the Launcher, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml.
+See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
 
 ### 0.20.0
 
@@ -281,7 +287,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | backends.kubernetes.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | backends.kubernetes.defaultResourceJobBase | object | `{}` | defaultResourceJobBase is an optional Kubernetes Job definition used as the base when launching content jobs. The chart automatically adds the init container and runtime volume when backends.kubernetes.defaultInitContainer.enabled is true. Only set this if you need to customize the job (e.g., add sidecars, node selectors, tolerations). https://kubernetes.io/docs/concepts/workloads/controllers/job/ |
 | backends.kubernetes.defaultResourceServiceBase | object | `{}` | defaultResourceServiceBase contains the Kubernetes Service definition which is used as an overlay "base" when creating a content job's Service in Kubernetes. Conceptually this is similar to a Kustomize base. Connect then applies any required Service configuration on-top of the overlay base to produce a final Service definition. https://kubernetes.io/docs/concepts/services-networking/service/ https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays |
-| backends.kubernetes.enabled | bool | `false` | Whether to enable off-host execution for running content-jobs in remote Kubernetes pods. |
+| backends.kubernetes.enabled | bool | `true` | Whether to enable off-host execution for running content-jobs in remote Kubernetes pods. |
 | backends.kubernetes.namespace | string | `""` | The namespace to launch connect-content jobs into. Uses the Release namespace by default |
 | chronicleAgent.agentEnvironment | string | `""` | An environment tag to apply to all metrics reported by this agent    ([reference](https://docs.posit.co/chronicle/appendix/library/advanced-agent.html#environment)) |
 | chronicleAgent.autoDiscovery | bool | `true` | If true, the chart will attempt to lookup the Chronicle Server address and version in the cluster |
@@ -326,7 +332,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | launcher.defaultInitContainer.resources | object | `{}` | Optional resources for the default initContainer |
 | launcher.defaultInitContainer.securityContext | object | `{}` | The securityContext for the default initContainer |
 | launcher.defaultInitContainer.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| launcher.enabled | bool | `true` | Whether to enable the launcher |
+| launcher.enabled | bool | `false` | Whether to enable the launcher |
 | launcher.extraTemplates | object | `{}` | extra templates to render in the template directory. |
 | launcher.includeDefaultTemplates | bool | `true` | whether to include the default `job.tpl` and `service.tpl` files included with the chart |
 | launcher.includeTemplateValues | bool | `true` | whether to include the templateValues rendering process |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -50,6 +50,7 @@ helm search repo rstudio/rstudio-connect -l
 - Chart version 0.10.0 changes the default execution backend to use a new Off-Host Execution implementation: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`.
 New installations use the new implementation by default. To continue using the Launcher, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml.
 See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+  - **IMPORTANT** When `backends.kubernetes.enabled=true`, service accounts used for content execution require the `connect.posit.co/service-account` label.
 
 ### 0.20.0
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -15,6 +15,7 @@
 - Chart version 0.10.0 changes the default execution backend to use a new Off-Host Execution implementation: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`.
 New installations use the new implementation by default. To continue using the Launcher, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml.
 See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+  - **IMPORTANT** When `backends.kubernetes.enabled=true`, service accounts used for content execution require the `connect.posit.co/service-account` label.
 
 ### 0.20.0
 

--- a/charts/rstudio-connect/README.md.gotmpl
+++ b/charts/rstudio-connect/README.md.gotmpl
@@ -10,6 +10,12 @@
 
 ## Upgrade guidance
 
+### 0.20.1
+
+- Chart version 0.10.0 changes the default execution backend to use a new Off-Host Execution implementation: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false`.
+New installations use the new implementation by default. To continue using the Launcher, set `launcher.enabled: true` and `backends.kubernetes.enabled: false` in your values.yaml.
+See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for details on transitioning to the new implementation.
+
 ### 0.20.0
 
 - Chart version 0.20.0 switches default images from `ghcr.io/rstudio/` to the `posit/` namespace on Docker Hub (also available at `ghcr.io/posit-dev/`). See the [migration guide](https://docs.posit.co/helm/docs/migrating-to-posit-images.html) for details.

--- a/charts/rstudio-connect/tests/deprecated_keys_test.yaml
+++ b/charts/rstudio-connect/tests/deprecated_keys_test.yaml
@@ -4,6 +4,9 @@ templates:
 tests:
   - it: should fail when launcher.customRuntimeYaml is set
     set:
+      backends:
+        kubernetes:
+          enabled: false
       launcher:
         enabled: true
         customRuntimeYaml: "base"
@@ -15,6 +18,9 @@ tests:
 
   - it: should fail when launcher.additionalRuntimeImages is set
     set:
+      backends:
+        kubernetes:
+          enabled: false
       launcher:
         enabled: true
         additionalRuntimeImages:
@@ -37,6 +43,9 @@ tests:
 
   - it: should fail when launcher.defaultInitContainer.tagPrefix is set
     set:
+      backends:
+        kubernetes:
+          enabled: false
       launcher:
         enabled: true
         defaultInitContainer:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -306,7 +306,7 @@ chronicleAgent:
 backends:
   kubernetes:
     # -- Whether to enable off-host execution for running content-jobs in remote Kubernetes pods.
-    enabled: false
+    enabled: true
     # -- The namespace to launch connect-content jobs into. Uses the Release namespace by default
     namespace: ""
     defaultInitContainer:
@@ -347,7 +347,7 @@ backends:
 
 launcher:
   # -- Whether to enable the launcher
-  enabled: true
+  enabled: false
   # -- The namespace to launch sessions into. Uses the Release namespace by default
   namespace: ""
   # -- User definition of launcher.kubernetes.profiles.conf for job customization


### PR DESCRIPTION
- BREAKING: `backends.kubernetes.enabled` now defaults to `true` and `launcher.enabled` now defaults to `false` for new installations. See the [upgrade guide](https://docs.posit.co/helm/examples/connect/upgrade-launcher-to-kubernetes/launcher-to-kubernetes.html) for migration details.