### PR TITLE
Switch dependabot GHA updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       - "/"
       - "/.github/actions/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Weekly is too frequent for these types of changes. Switching to monthly.
