### PR TITLE
Add `get` verb to `pods/attach` in Connect service account role for new kubernetes backend

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.2
+version: 0.20.3
 apiVersion: v2
 appVersion: 2026.05.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.20.3
+
+- Add `get` on `pods/attach` and `pods/exec` to the direct Kubernetes runner Role in `templates/rbac.yaml` to support attach/exec authorization checks used by Kubernetes clients to support websocket connection upgrades.
+
 ## 0.20.2
 
 - Bump Connect version to 2026.05.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.2](https://img.shields.io/badge/Version-0.20.2-informational?style=flat-square) ![AppVersion: 2026.05.0](https://img.shields.io/badge/AppVersion-2026.05.0-informational?style=flat-square)
+![Version: 0.20.3](https://img.shields.io/badge/Version-0.20.3-informational?style=flat-square) ![AppVersion: 2026.05.0](https://img.shields.io/badge/AppVersion-2026.05.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.2:
+To install the chart with the release name `my-release` at version 0.20.3:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.2
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.3
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/rbac.yaml
+++ b/charts/rstudio-connect/templates/rbac.yaml
@@ -103,12 +103,14 @@ rules:
       - "pods/attach"
     verbs:
       - "create"
+      - "get"
   - apiGroups:
       - ""
     resources:
       - "pods/exec"
     verbs:
       - "create"
+      - "get"
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Bump `rstudio-connect` chart version to 0.20.3 and update NEWS.md

Update the rstudio-connect chart service account RBAC to allow websocket connections which are used by the kubernetes backend to execute jobs remotely on k8s. Connect 2026.04 correctly falls back to SPDY on websocket connection upgrade failures. The missing RBAC ensured that all connections were falling back to SPDY. 

Connect 2026.05.0 introduced a regression which prevented fallback to SPDY, meaning all steaming connections now fail (exec/attach). This PR allows the initial websocket connection to succeed. The next release of Connect will fix the SPDY fallback