### PR TITLE
Remove OS suffix from connect-content-init image tag

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.4
+version: 0.20.5
 apiVersion: v2
 appVersion: 2026.05.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg
@@ -18,9 +18,9 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: connect
-      image: posit/connect:2026.04.1-ubuntu-24.04
+      image: posit/connect:2026.05.1-ubuntu-24.04
     - name: connect-content-init
-      image: posit/connect-content-init:2026.04.1-ubuntu-24.04
+      image: posit/connect-content-init:2026.05.1
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: About Connect

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.20.5
+
+- Remove the `os` field from `backends.kubernetes.defaultInitContainer` and
+  `launcher.defaultInitContainer`. The `connect-content-init` image copies an
+  architecture-specific binary and is not OS-specific; the tag is now the chart
+  `appVersion` (e.g. `2026.05.1`) rather than `2026.05.1-ubuntu-24.04`. Any
+  `os:` values in your `values.yaml` can be removed.
+
 ## 0.20.4
 
 - Bump Connect version to 2026.05.1

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.4](https://img.shields.io/badge/Version-0.20.4-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
+![Version: 0.20.5](https://img.shields.io/badge/Version-0.20.5-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.4:
+To install the chart with the release name `my-release` at version 0.20.5:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.4
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.5
 ```
 
 To explore other chart versions, look at:
@@ -281,7 +281,6 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | args | list | `[]` | The pod's run arguments. By default, it uses the container's default |
 | backends.kubernetes.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. Changing the default setting is an advanced option and not recommended. For more information on how Connect uses the session init container refer to https://docs.posit.co/connect/admin/appendix/off-host/arch-overview/#runtime-init-container |
 | backends.kubernetes.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |
-| backends.kubernetes.defaultInitContainer.os | string | `"ubuntu-24.04"` | The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined |
 | backends.kubernetes.defaultInitContainer.repository | string | `"posit/connect-content-init"` | The repository to use for the Content InitContainer image |
 | backends.kubernetes.defaultInitContainer.resources | object | `{}` | Optional resources for the default initContainer |
 | backends.kubernetes.defaultInitContainer.securityContext | object | `{}` | The securityContext for the default initContainer |
@@ -325,10 +324,9 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | ingress.ingressClassName | string | `""` | The ingressClassName for the ingress resource. Only used for clusters that support networking.k8s.io/v1 Ingress resources |
 | ingress.tls | list | `[]` |  |
 | initContainers | bool | `false` | The initContainer spec that will be used verbatim |
-| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","os":"ubuntu-24.04","repository":"posit/connect-content-init","resources":{},"securityContext":{},"tag":""}` | Image definition for the default Posit Connect Content InitContainer |
+| launcher.defaultInitContainer | object | `{"enabled":true,"imagePullPolicy":"","repository":"posit/connect-content-init","resources":{},"securityContext":{},"tag":""}` | Image definition for the default Posit Connect Content InitContainer |
 | launcher.defaultInitContainer.enabled | bool | `true` | Whether to enable the defaultInitContainer. If disabled, you must ensure that the session components are available another way. |
 | launcher.defaultInitContainer.imagePullPolicy | string | `""` | The imagePullPolicy for the default initContainer |
-| launcher.defaultInitContainer.os | string | `"ubuntu-24.04"` | The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined |
 | launcher.defaultInitContainer.repository | string | `"posit/connect-content-init"` | The repository to use for the Content InitContainer image |
 | launcher.defaultInitContainer.resources | object | `{}` | Optional resources for the default initContainer |
 | launcher.defaultInitContainer.securityContext | object | `{}` | The securityContext for the default initContainer |

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -83,11 +83,11 @@ Please consider removing this configuration value.
 {{- end }}
 
 {{- if .Values.launcher.defaultInitContainer.tagPrefix }}
-  {{- fail "\n\n`launcher.defaultInitContainer.tagPrefix` has been removed. Use `launcher.defaultInitContainer.os` instead (e.g. `ubuntu-24.04`). The image tag format is now `{version}-{os}`." }}
+  {{- fail "\n\n`launcher.defaultInitContainer.tagPrefix` has been removed. The default tag is now the chart appVersion. Use `launcher.defaultInitContainer.tag` to override." }}
 {{- end }}
 
 {{- if .Values.backends.kubernetes.defaultInitContainer.tagPrefix }}
-  {{- fail "\n\n`backends.kubernetes.defaultInitContainer.tagPrefix` has been removed. Use `backends.kubernetes.defaultInitContainer.os` instead (e.g. `ubuntu-24.04`). The image tag format is now `{version}-{os}`." }}
+  {{- fail "\n\n`backends.kubernetes.defaultInitContainer.tagPrefix` has been removed. The default tag is now the chart appVersion. Use `backends.kubernetes.defaultInitContainer.tag` to override." }}
 {{- end }}
 
 {{- if .Values.pod.serviceAccountName }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -151,7 +151,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.backends.kubernetes.defaultInitContainer.enabled }}
     {{- /* build init container image tag */}}
     {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-    {{- $tag := .Values.backends.kubernetes.defaultInitContainer.tag | default (printf "%s-%s" $defaultVersion .Values.backends.kubernetes.defaultInitContainer.os) }}
+    {{- $tag := .Values.backends.kubernetes.defaultInitContainer.tag | default $defaultVersion }}
     {{- $image := printf "%s:%s" .Values.backends.kubernetes.defaultInitContainer.repository $tag }}
     {{- /* build the init container */}}
     {{- $initVolumeMount := dict "name" "rsc-volume" "mountPath" "/mnt/rstudio-connect-runtime/" }}

--- a/charts/rstudio-connect/templates/configmap.yaml
+++ b/charts/rstudio-connect/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
       {{- $jobJsonRuntimeMountExt := dict "target" ("/spec/template/spec/containers/0/volumeMounts/-") "name" ("defaultRuntimeContainerVolumeMountExt") "json" ( $rscVolumeMountExt ) }}
     {{- /* 3 - init container */ -}}
       {{- $defaultVersion := .Values.versionOverride | default $.Chart.AppVersion }}
-      {{- $initContainerImageTag := .Values.launcher.defaultInitContainer.tag | default (printf "%s-%s" $defaultVersion .Values.launcher.defaultInitContainer.os )}}
+      {{- $initContainerImageTag := .Values.launcher.defaultInitContainer.tag | default $defaultVersion }}
       {{- $initContainerImage := print .Values.launcher.defaultInitContainer.repository ":" ( $initContainerImageTag ) }}
       {{- $initContainerPullPolicy := default "IfNotPresent" .Values.launcher.defaultInitContainer.imagePullPolicy }}
       {{- $initContainerResources := .Values.launcher.defaultInitContainer.resources }}

--- a/charts/rstudio-connect/tests/deprecated_keys_test.yaml
+++ b/charts/rstudio-connect/tests/deprecated_keys_test.yaml
@@ -54,7 +54,7 @@ tests:
         create: true
     asserts:
       - failedTemplate:
-          errorPattern: "launcher.defaultInitContainer.tagPrefix.*has been removed.*launcher.defaultInitContainer.os"
+          errorPattern: "launcher.defaultInitContainer.tagPrefix.*has been removed.*launcher.defaultInitContainer.tag"
 
   - it: should fail when backends.kubernetes.defaultInitContainer.tagPrefix is set
     set:
@@ -69,4 +69,4 @@ tests:
         create: true
     asserts:
       - failedTemplate:
-          errorPattern: "backends.kubernetes.defaultInitContainer.tagPrefix.*has been removed.*backends.kubernetes.defaultInitContainer.os"
+          errorPattern: "backends.kubernetes.defaultInitContainer.tagPrefix.*has been removed.*backends.kubernetes.defaultInitContainer.tag"

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -784,7 +784,7 @@ tests:
           pattern: "name: connect-content-init"
       - matchRegex:
           path: data["job.yaml"]
-          pattern: "image: posit/connect-content-init:\\d+\\.\\d+\\.\\d+-ubuntu-24\\.04"
+          pattern: "(?m)^.*image: posit/connect-content-init:\\d+\\.\\d+\\.\\d+$"
       - matchRegex:
           path: data["job.yaml"]
           pattern: "name: connect-content"
@@ -1082,23 +1082,6 @@ tests:
       - matchRegex:
           path: data["job.yaml"]
           pattern: "image: posit/connect-content-init:custom-tag-1.2.3"
-
-  - it: should use appVersion-os when tag is not set
-    template: configmap.yaml
-    values:
-      - kubernetes-values.yaml
-    set:
-      launcher:
-        enabled: false
-      backends:
-        kubernetes:
-          enabled: true
-          defaultInitContainer:
-            os: "ubuntu-22.04"
-    asserts:
-      - matchRegex:
-          path: data["job.yaml"]
-          pattern: "image: posit/connect-content-init:\\d+\\.\\d+\\.\\d+-ubuntu-22\\.04"
 
   - it: should preserve user-provided sidecar and nodeSelector in job base
     template: configmap.yaml

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -318,8 +318,6 @@ backends:
       enabled: true
       # -- The repository to use for the Content InitContainer image
       repository: posit/connect-content-init
-      # -- The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined
-      os: "ubuntu-24.04"
       # -- Overrides the image tag whose default is the chart appVersion.
       tag: ""
       # -- The imagePullPolicy for the default initContainer
@@ -410,8 +408,6 @@ launcher:
     enabled: true
     # -- The repository to use for the Content InitContainer image
     repository: posit/connect-content-init
-    # -- The OS version for the image tag (e.g. ubuntu-24.04, ubuntu-22.04). Only used if tag is not defined
-    os: "ubuntu-24.04"
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
     # -- The imagePullPolicy for the default initContainer


### PR DESCRIPTION
The `connect-content-init` image copies an architecture-specific runtime binary and is not OS-specific. Simplify the tag to use the chart `appVersion` directly (e.g. `2026.05.1`) rather than `2026.05.1-ubuntu-24.04`.

- Remove `os` field from `backends.kubernetes.defaultInitContainer` and `launcher.defaultInitContainer`
- Update tag construction in `_helpers.tpl` and `configmap.yaml`
- Remove duplicate test that asserted the old OS-suffixed tag format

Any `os:` entries in existing `values.yaml` files can be removed, but are harmlessly ignored.