### PR TITLE
Fix product-release.yml image names and tag format

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -38,7 +38,7 @@ jobs:
         if: steps.project-url.outputs.project != 'none'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          client-id: ${{ secrets.POSIT_PLATFORM_CLIENT_ID }}
           private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
           owner: ${{ steps.project-url.outputs.ORG }}
           permission-organization-projects: write

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -64,7 +64,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.POSIT_PLATFORM_APP_ID }}
+          client-id: ${{ secrets.POSIT_PLATFORM_CLIENT_ID }}
           private-key: ${{ secrets.POSIT_PLATFORM_PEM }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -39,16 +39,20 @@ jobs:
           case "$PRODUCT" in
             connect)
               echo "name=rstudio-connect" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-connect" >> "$GITHUB_OUTPUT"
+              echo "image=posit/connect" >> "$GITHUB_OUTPUT"
+              echo "init-image=posit/connect-content-init" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             workbench)
               echo "name=rstudio-workbench" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-workbench" >> "$GITHUB_OUTPUT"
-              echo "session-image=rstudio/r-session-complete" >> "$GITHUB_OUTPUT"
+              echo "image=posit/workbench" >> "$GITHUB_OUTPUT"
+              echo "session-image=posit/workbench-session-init" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             package-manager)
               echo "name=rstudio-pm" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-package-manager" >> "$GITHUB_OUTPUT"
+              echo "image=posit/package-manager" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown product: $PRODUCT"
@@ -106,7 +110,9 @@ jobs:
           APP_VERSION: ${{ steps.app-version.outputs.value }}
           CHART_NAME: ${{ steps.chart.outputs.name }}
           IMAGE: ${{ steps.chart.outputs.image }}
+          INIT_IMAGE: ${{ steps.chart.outputs.init-image }}
           SESSION_IMAGE: ${{ steps.chart.outputs.session-image }}
+          OS_TAG: ${{ steps.chart.outputs.os-tag }}
         run: |
           CHART="charts/${CHART_NAME}/Chart.yaml"
 
@@ -121,12 +127,17 @@ jobs:
           NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
           yq -i ".version = \"$NEW_VERSION\"" "$CHART"
 
-          # Update image annotations (ubuntu2204-{version} format)
-          yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${IMAGE}:[^\n]*\", \"${IMAGE}:ubuntu2204-${APP_VERSION}\")" "$CHART"
+          # Update main image annotation ({version}-{os-tag} format)
+          yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${IMAGE}:[^\n]*\", \"${IMAGE}:${APP_VERSION}-${OS_TAG}\")" "$CHART"
 
-          # Workbench has a second image (r-session-complete)
+          # connect-content-init is OS-agnostic; tag is just the version
+          if [ -n "$INIT_IMAGE" ]; then
+            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${INIT_IMAGE}:[^\n]*\", \"${INIT_IMAGE}:${APP_VERSION}\")" "$CHART"
+          fi
+
+          # Workbench session-init uses the same OS-suffixed format as the main image
           if [ -n "$SESSION_IMAGE" ]; then
-            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${SESSION_IMAGE}:[^\n]*\", \"${SESSION_IMAGE}:ubuntu2204-${APP_VERSION}\")" "$CHART"
+            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${SESSION_IMAGE}:[^\n]*\", \"${SESSION_IMAGE}:${APP_VERSION}-${OS_TAG}\")" "$CHART"
           fi
 
           echo "chart-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -34,16 +34,20 @@ jobs:
           case "$PRODUCT" in
             connect)
               echo "name=rstudio-connect" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-connect" >> "$GITHUB_OUTPUT"
+              echo "image=posit/connect" >> "$GITHUB_OUTPUT"
+              echo "init-image=posit/connect-content-init" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             workbench)
               echo "name=rstudio-workbench" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-workbench" >> "$GITHUB_OUTPUT"
-              echo "session-image=rstudio/r-session-complete" >> "$GITHUB_OUTPUT"
+              echo "image=posit/workbench" >> "$GITHUB_OUTPUT"
+              echo "session-image=posit/workbench-session-init" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             package-manager)
               echo "name=rstudio-pm" >> "$GITHUB_OUTPUT"
-              echo "image=rstudio/rstudio-package-manager" >> "$GITHUB_OUTPUT"
+              echo "image=posit/package-manager" >> "$GITHUB_OUTPUT"
+              echo "os-tag=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown product: $PRODUCT"
@@ -101,7 +105,9 @@ jobs:
           APP_VERSION: ${{ steps.app-version.outputs.value }}
           CHART_NAME: ${{ steps.chart.outputs.name }}
           IMAGE: ${{ steps.chart.outputs.image }}
+          INIT_IMAGE: ${{ steps.chart.outputs.init-image }}
           SESSION_IMAGE: ${{ steps.chart.outputs.session-image }}
+          OS_TAG: ${{ steps.chart.outputs.os-tag }}
         run: |
           CHART="charts/${CHART_NAME}/Chart.yaml"
 
@@ -116,12 +122,17 @@ jobs:
           NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
           yq -i ".version = \"$NEW_VERSION\"" "$CHART"
 
-          # Update image annotations (ubuntu2204-{version} format)
-          yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${IMAGE}:[^\n]*\", \"${IMAGE}:ubuntu2204-${APP_VERSION}\")" "$CHART"
+          # Update main image annotation ({version}-{os-tag} format)
+          yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${IMAGE}:[^\n]*\", \"${IMAGE}:${APP_VERSION}-${OS_TAG}\")" "$CHART"
 
-          # Workbench has a second image (r-session-complete)
+          # connect-content-init is OS-agnostic; tag is just the version
+          if [ -n "$INIT_IMAGE" ]; then
+            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${INIT_IMAGE}:[^\n]*\", \"${INIT_IMAGE}:${APP_VERSION}\")" "$CHART"
+          fi
+
+          # Workbench session-init uses the same OS-suffixed format as the main image
           if [ -n "$SESSION_IMAGE" ]; then
-            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${SESSION_IMAGE}:[^\n]*\", \"${SESSION_IMAGE}:ubuntu2204-${APP_VERSION}\")" "$CHART"
+            yq -i "(.annotations.\"artifacthub.io/images\" | select(. != null)) |= sub(\"${SESSION_IMAGE}:[^\n]*\", \"${SESSION_IMAGE}:${APP_VERSION}-${OS_TAG}\")" "$CHART"
           fi
 
           echo "chart-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The `product-release.yml` workflow was using stale image names (pre-rename to `posit/`) and the old `ubuntu2204-{version}` tag format. This fixes all three products to match what is actually published.

- `posit/connect`, `posit/workbench`, `posit/package-manager` (renamed from `rstudio/`)
- `posit/workbench-session-init` (renamed from `rstudio/r-session-complete`)
- Tag format: `{version}-ubuntu-24.04` (was `ubuntu2204-{version}`)
- Add `posit/connect-content-init` annotation update with OS-agnostic tag (`{version}`, no OS suffix)

Related:
- https://github.com/rstudio/helm/pull/882