### PR TITLE
Bump helm-unittest to v1.1.0, fix errorPattern regexes

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -87,7 +87,7 @@ jobs:
           version: "v3.19.2"
 
       - name: Install helm unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.0
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.0
 
       - name: Run chart unit tests
         id: unittest

--- a/charts/posit-chronicle/tests/configmap_fail_test.yaml
+++ b/charts/posit-chronicle/tests/configmap_fail_test.yaml
@@ -27,7 +27,7 @@ tests:
           ServiceLogLevel: INVALID
     asserts:
       - failedTemplate:
-          errorPattern: ".*ServiceLogLevel: Does not match pattern.*"
+          errorPattern: ".*ServiceLogLevel.*does not match pattern.*"
   - it: should fail for invalid log level values
     set:
       config:
@@ -35,7 +35,7 @@ tests:
           ServiceLogFormat: INVALID
     asserts:
       - failedTemplate:
-          errorPattern: ".*ServiceLogFormat: Does not match pattern.*"
+          errorPattern: ".*ServiceLogFormat.*does not match pattern.*"
   - it: should fail if S3 is enabled but no bucket is specified
     set:
       config:

--- a/charts/posit-chronicle/tests/configmap_fail_test.yaml
+++ b/charts/posit-chronicle/tests/configmap_fail_test.yaml
@@ -27,7 +27,7 @@ tests:
           ServiceLogLevel: INVALID
     asserts:
       - failedTemplate:
-          errorPattern: ".*ServiceLogLevel.*does not match pattern.*"
+          errorPattern: "(?i).*ServiceLogLevel.*does not match pattern.*"
   - it: should fail for invalid log level values
     set:
       config:
@@ -35,7 +35,7 @@ tests:
           ServiceLogFormat: INVALID
     asserts:
       - failedTemplate:
-          errorPattern: ".*ServiceLogFormat.*does not match pattern.*"
+          errorPattern: "(?i).*ServiceLogFormat.*does not match pattern.*"
   - it: should fail if S3 is enabled but no bucket is specified
     set:
       config:


### PR DESCRIPTION
Follow-up to #884.

Helm 3.18.5 changed its JSON schema parser, producing a different error string for schema validation failures. The helm-unittest v1.0.1 release notes documented this as a known breaking change that could cause test failures.

The `posit-chronicle` `configmap_fail_test.yaml` tests had `errorPattern` values that matched the old format but not the new one. This caused silent failure: tests passed in CI (pinned to v1.0.0) while failing locally with helm-unittest >= v1.0.1 — a latent break waiting for the version bump.

- Bump `helm-unittest` in CI from `v1.0.0` to `v1.1.0`
- Relax both `errorPattern` regexes to match both old and new error formats: `.*ServiceLogLevel.*does not match pattern.*`

All 68 `posit-chronicle` tests pass locally with v1.0.3 (the version that exposed the break).