### PR TITLE
Add merge_group trigger to CI workflows

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -2,6 +2,7 @@ name: Document Charts
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   document:

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `merge_group:` trigger to `chart-doc` and `chart-test` workflows in preparation for enabling a merge queue on this repository.