### PR TITLE
Clarify nameservice.apiKey should use a nameservice:read service token

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.5
+version: 0.20.6
 apiVersion: v2
 appVersion: 2026.05.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.20.6
+
+- Clarify `nameservice.apiKey` documentation: use a Connect service token scoped
+  to `nameservice:read` rather than a Viewer API key.
+
 ## 0.20.5
 
 - Remove the `os` field from `backends.kubernetes.defaultInitContainer` and

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,8 +2,8 @@
 
 ## 0.20.6
 
-- Clarify `nameservice.apiKey` documentation: use a Connect service token scoped
-  to `nameservice:read` rather than a Viewer API key.
+- Clarify `nameservice.apiKey` documentation: use a Connect service token with the
+  `nameservice:read` scope.
 
 ## 0.20.5
 

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.20.6
 
-- Clarify `nameservice.apiKey` documentation: use a Connect service token with the
+- Clarify `nameservice.apiKey` documentation to use a Connect service token with the
   `nameservice:read` scope.
 
 ## 0.20.5

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -352,7 +352,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | Used to configure the container's livenessProbe. Only included if enabled = true |
 | nameOverride | string | `""` | The name of the chart deployment (can be overridden) |
 | nameservice | object | `{"apiKey":"","enabled":false,"secretName":"","server":"http://127.0.0.1:3939"}` | Nameservice configuration for current user execution (RunAsCurrentUser). This can only be enabled if using an SSO authentication provider (OAuth2, SAML, or LDAP). |
-| nameservice.apiKey | string | `""` | Connect service token (with the `nameservice:read` scope) used by the nameservice module. Use a service token scoped to `nameservice:read`, not a Viewer API key. |
+| nameservice.apiKey | string | `""` | The Connect service token used by the nameservice module. Create a service token with the `nameservice:read` scope. See https://docs.posit.co/connect/api/#post-/v1/system/service-tokens. |
 | nameservice.enabled | bool | `false` | Whether to enable nameservice integration. |
 | nameservice.secretName | string | `""` | Optional: name of existing secret containing libnss_connect.conf (overrides apiKey and server). The secret must be in the same namespace as the Connect deployment. |
 | nameservice.server | string | `"http://127.0.0.1:3939"` | Connect server URL for nameservice module. |

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.5](https://img.shields.io/badge/Version-0.20.5-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
+![Version: 0.20.6](https://img.shields.io/badge/Version-0.20.6-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.5:
+To install the chart with the release name `my-release` at version 0.20.6:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.5
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.6
 ```
 
 To explore other chart versions, look at:
@@ -352,7 +352,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | livenessProbe | object | `{"enabled":false,"failureThreshold":10,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":2}` | Used to configure the container's livenessProbe. Only included if enabled = true |
 | nameOverride | string | `""` | The name of the chart deployment (can be overridden) |
 | nameservice | object | `{"apiKey":"","enabled":false,"secretName":"","server":"http://127.0.0.1:3939"}` | Nameservice configuration for current user execution (RunAsCurrentUser). This can only be enabled if using an SSO authentication provider (OAuth2, SAML, or LDAP). |
-| nameservice.apiKey | string | `""` | Connect API key for nameservice module. Must be a Viewer API key. |
+| nameservice.apiKey | string | `""` | Connect service token (with the `nameservice:read` scope) used by the nameservice module. Use a service token scoped to `nameservice:read`, not a Viewer API key. |
 | nameservice.enabled | bool | `false` | Whether to enable nameservice integration. |
 | nameservice.secretName | string | `""` | Optional: name of existing secret containing libnss_connect.conf (overrides apiKey and server). The secret must be in the same namespace as the Connect deployment. |
 | nameservice.server | string | `"http://127.0.0.1:3939"` | Connect server URL for nameservice module. |

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -457,8 +457,7 @@ executionEnvironments: []
 nameservice:
   # -- Whether to enable nameservice integration.
   enabled: false
-  # -- Connect service token (with the `nameservice:read` scope) used by the nameservice module.
-  # Use a service token scoped to `nameservice:read`, not a Viewer API key.
+  # -- The Connect service token used by the nameservice module. Create a service token with the `nameservice:read` scope. See https://docs.posit.co/connect/api/#post-/v1/system/service-tokens.
   apiKey: ""
   # -- Connect server URL for nameservice module.
   server: "http://127.0.0.1:3939"

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -457,7 +457,8 @@ executionEnvironments: []
 nameservice:
   # -- Whether to enable nameservice integration.
   enabled: false
-  # -- Connect API key for nameservice module. Must be a Viewer API key.
+  # -- Connect service token (with the `nameservice:read` scope) used by the nameservice module.
+  # Use a service token scoped to `nameservice:read`, not a Viewer API key.
   apiKey: ""
   # -- Connect server URL for nameservice module.
   server: "http://127.0.0.1:3939"


### PR DESCRIPTION
## Summary

Clarifies the `nameservice.apiKey` documentation in the `rstudio-connect` chart to direct users to a Connect **service token** scoped to `nameservice:read`, rather than a Viewer API key.

- `values.yaml` — rewrites the `nameservice.apiKey` description to a concise, plain-sentence note pointing at the [Create service token API docs](https://docs.posit.co/connect/api/#post-/v1/system/service-tokens).
- `README.md` — regenerated via `just docs` to match.
- `Chart.yaml` — version bumped `0.20.5` → `0.20.6` (values change).
- `NEWS.md` — added a 0.20.6 entry.

Documentation-only change; no template/rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)