### PR TITLE
move connect runtime mount location

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.6
+version: 0.20.7
 apiVersion: v2
 appVersion: 2026.05.1
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.7
+
+- The init container's `rsc-volume` now mounts at `/opt/rstudio-connect-runtime`
+  (previously `/opt/rstudio-connect`), and the chart sets
+  `Kubernetes.ConnectRuntimeDir` to match so Connect finds the runtime there.
+
 ## 0.20.6
 
 - Clarify `nameservice.apiKey` documentation to use a Connect service token with the

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.6](https://img.shields.io/badge/Version-0.20.6-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
+![Version: 0.20.7](https://img.shields.io/badge/Version-0.20.7-informational?style=flat-square) ![AppVersion: 2026.05.1](https://img.shields.io/badge/AppVersion-2026.05.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.6:
+To install the chart with the release name `my-release` at version 0.20.7:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.6
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.7
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -101,6 +101,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.backends.kubernetes.defaultResourceServiceBase }}
       {{- $_ := set $kubernetesSettingsDict "DefaultResourceServiceBase" (default "/etc/rstudio-connect/service.yaml" (dig "Kubernetes" "DefaultResourceServiceBase" "" .Values.config)) }}
     {{- end }}
+    {{- /* When the default init container is enabled, default ConnectRuntimeDir to
+           the runtime mount path. This default MUST match the $runtimeDir default
+           in rstudio-connect.jobBase, which derives the content container's
+           mountPath from this same value so the config and mount cannot diverge. */}}
+    {{- if and .Values.backends.kubernetes.defaultInitContainer.enabled (not (dig "Kubernetes" "ConnectRuntimeDir" "" .Values.config)) }}
+      {{- $_ := set $kubernetesSettingsDict "ConnectRuntimeDir" "/opt/rstudio-connect-runtime" }}
+    {{- end }}
     {{- $kubernetesDict := dict "Kubernetes" ( $kubernetesSettingsDict ) }}
     {{- $defaultConfig = merge $defaultConfig $kubernetesDict }}
   {{- end }}
@@ -166,7 +173,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       {{- $_ := set $initContainer "securityContext" .Values.backends.kubernetes.defaultInitContainer.securityContext }}
     {{- end }}
     {{- /* build the content container */}}
-    {{- $contentVolumeMount := dict "name" "rsc-volume" "mountPath" "/opt/rstudio-connect" }}
+    {{- /* The content container mounts the runtime volume at ConnectRuntimeDir,
+           where Connect expects to find the runtime components. Derive the
+           mountPath from the resolved config value so the two can never diverge.
+           The default here MUST match the ConnectRuntimeDir default injected in
+           rstudio-connect.config. */}}
+    {{- $runtimeDir := dig "Kubernetes" "ConnectRuntimeDir" "/opt/rstudio-connect-runtime" .Values.config }}
+    {{- $contentVolumeMount := dict "name" "rsc-volume" "mountPath" $runtimeDir }}
     {{- $contentContainer := dict "name" "connect-content" "volumeMounts" (list $contentVolumeMount) }}
     {{- /* build the shared volume */}}
     {{- $rscVolume := dict "name" "rsc-volume" "emptyDir" (dict) }}
@@ -227,10 +240,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
         {{- $mounts := default list .volumeMounts }}
         {{- $hasMount := false }}
         {{- range $mounts }}
-          {{- if and (eq .name "rsc-volume") (eq .mountPath "/opt/rstudio-connect") }}
+          {{- if and (eq .name "rsc-volume") (eq .mountPath $runtimeDir) }}
             {{- $hasMount = true }}
-          {{- else if eq .mountPath "/opt/rstudio-connect" }}
-            {{- fail "backends.kubernetes.defaultResourceJobBase: connect-content container has a volumeMount at /opt/rstudio-connect using a volume other than rsc-volume. This mountPath is reserved for the runtime volume shared with the init container." }}
+          {{- else if eq .mountPath $runtimeDir }}
+            {{- fail (printf "backends.kubernetes.defaultResourceJobBase: connect-content container has a volumeMount at %s using a volume other than rsc-volume. This mountPath is reserved for the runtime volume (ConnectRuntimeDir) shared with the init container." $runtimeDir) }}
           {{- end }}
         {{- end }}
         {{- if not $hasMount }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -128,6 +128,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if not (dig "Kubernetes" "DefaultResourceServiceBase" "" $configCopy) }}
       {{- $_ := unset (index $configCopy "Kubernetes") "DefaultResourceServiceBase" }}
     {{- end }}
+    {{- /* drop an empty/null ConnectRuntimeDir so the injected default applies and
+           the rendered gcfg value stays aligned with the content container mount */}}
+    {{- if not (dig "Kubernetes" "ConnectRuntimeDir" "" $configCopy) }}
+      {{- $_ := unset (index $configCopy "Kubernetes") "ConnectRuntimeDir" }}
+    {{- end }}
   {{- end }}
   {{- include "rstudio-library.config.gcfg" ( mergeOverwrite $defaultConfig $configCopy ) }}
 {{- end -}}
@@ -178,7 +183,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
            mountPath from the resolved config value so the two can never diverge.
            The default here MUST match the ConnectRuntimeDir default injected in
            rstudio-connect.config. */}}
-    {{- $runtimeDir := dig "Kubernetes" "ConnectRuntimeDir" "/opt/rstudio-connect-runtime" .Values.config }}
+    {{- /* default handles empty/null overrides (dig only fills in a missing key),
+           so config.Kubernetes.ConnectRuntimeDir: "" still falls back here. */}}
+    {{- $runtimeDir := default "/opt/rstudio-connect-runtime" (dig "Kubernetes" "ConnectRuntimeDir" "" .Values.config) }}
     {{- $contentVolumeMount := dict "name" "rsc-volume" "mountPath" $runtimeDir }}
     {{- $contentContainer := dict "name" "connect-content" "volumeMounts" (list $contentVolumeMount) }}
     {{- /* build the shared volume */}}
@@ -244,6 +251,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
             {{- $hasMount = true }}
           {{- else if eq .mountPath $runtimeDir }}
             {{- fail (printf "backends.kubernetes.defaultResourceJobBase: connect-content container has a volumeMount at %s using a volume other than rsc-volume. This mountPath is reserved for the runtime volume (ConnectRuntimeDir) shared with the init container." $runtimeDir) }}
+          {{- else if eq .mountPath "/opt/rstudio-connect" }}
+            {{- fail "backends.kubernetes.defaultResourceJobBase: connect-content container has a volumeMount at /opt/rstudio-connect. This is the Connect installation and content bind-mount root (/opt/rstudio-connect/mnt/app) and must not be mounted over." }}
           {{- end }}
         {{- end }}
         {{- if not $hasMount }}

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -791,6 +791,53 @@ tests:
       - matchRegex:
           path: data["job.yaml"]
           pattern: "name: rsc-volume"
+      - matchRegex:
+          path: data["job.yaml"]
+          pattern: "(?m)mountPath: /opt/rstudio-connect-runtime$"
+
+  - it: should set ConnectRuntimeDir to /opt/rstudio-connect-runtime when defaultInitContainer is enabled
+    template: configmap.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ConnectRuntimeDir = /opt/rstudio-connect-runtime"
+
+  - it: should derive the content mount from ConnectRuntimeDir when user sets it explicitly
+    template: configmap.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      config:
+        Kubernetes:
+          ConnectRuntimeDir: /custom/runtime
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ConnectRuntimeDir = /custom/runtime"
+      - notMatchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ConnectRuntimeDir = /opt/rstudio-connect-runtime"
+      # The content mount must follow the configured ConnectRuntimeDir, or
+      # Connect would look for the runtime where nothing is mounted.
+      - matchRegex:
+          path: data["job.yaml"]
+          pattern: "(?m)mountPath: /custom/runtime$"
+      - notMatchRegex:
+          path: data["job.yaml"]
+          pattern: "(?m)mountPath: /opt/rstudio-connect-runtime$"
 
   - it: should ensure rsc-volume mount on user-provided connect-content-init
     template: configmap.yaml
@@ -820,7 +867,7 @@ tests:
           path: data["job.yaml"]
           pattern: "name: rsc-volume"
 
-  - it: should fail when connect-content has /opt/rstudio-connect mounted from a non-rsc-volume
+  - it: should fail when connect-content has /opt/rstudio-connect-runtime mounted from a non-rsc-volume
     template: deployment.yaml
     values:
       - kubernetes-values.yaml
@@ -838,7 +885,7 @@ tests:
                     - name: connect-content
                       volumeMounts:
                         - name: other-volume
-                          mountPath: /opt/rstudio-connect
+                          mountPath: /opt/rstudio-connect-runtime
     asserts:
       - failedTemplate:
           errorPattern: "mountPath is reserved for the runtime volume"

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -839,6 +839,27 @@ tests:
           path: data["job.yaml"]
           pattern: "(?m)mountPath: /opt/rstudio-connect-runtime$"
 
+  - it: should fall back to the default runtime dir when ConnectRuntimeDir is empty
+    template: configmap.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      config:
+        Kubernetes:
+          ConnectRuntimeDir: ""
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "ConnectRuntimeDir = /opt/rstudio-connect-runtime"
+      - matchRegex:
+          path: data["job.yaml"]
+          pattern: "(?m)mountPath: /opt/rstudio-connect-runtime$"
+
   - it: should ensure rsc-volume mount on user-provided connect-content-init
     template: configmap.yaml
     values:
@@ -889,6 +910,31 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "mountPath is reserved for the runtime volume"
+
+  # /opt/rstudio-connect is the Connect install and content bind-mount root
+  # (/opt/rstudio-connect/mnt/app), so it must never be mounted over.
+  - it: should fail when connect-content has /opt/rstudio-connect mounted over
+    template: deployment.yaml
+    values:
+      - kubernetes-values.yaml
+    set:
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+          defaultResourceJobBase:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: connect-content
+                      volumeMounts:
+                        - name: other-volume
+                          mountPath: /opt/rstudio-connect
+    asserts:
+      - failedTemplate:
+          errorPattern: "must not be mounted over"
 
   - it: should fail when connect-content-init has /mnt/rstudio-connect-runtime/ mounted from a non-rsc-volume
     template: deployment.yaml


### PR DESCRIPTION
This mounts the Connect runtime at `/opt/rstudio-connect-runtime` instead of `/opt/rstudio-connect` and sets `config.Kubernetes.ConnectRuntimeDir` to match, so the content mount and the path Connect looks at can't diverge.

The reason for this is that containerized content lives inside the built images at `/opt/rstudio-connect/mnt/app` but with the runtime mounted to `/opt/rstudio-connect` that path is obscured and containerized content fails to run.

Previous versions of the chart mounted the runtime components at subpaths under `/opt/rsudio-connect` (0.8.14 did this for the launcher), but I opted against that to avoid having to maintain separate mounts in the event the runtime directory structure changes.

Relocating the app content instead would also be a possibility but would break existing containerized applications that have already put their content at `mnt/app`.