### PR TITLE
Accept python_version in product-release workflow

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -151,7 +151,6 @@ jobs:
           PRODUCT: ${{ inputs.product }}
           CHART_NAME: ${{ steps.chart.outputs.name }}
           CHART_VERSION: ${{ steps.update.outputs.chart-version }}
-          PYTHON_VERSION: ${{ inputs.python_version }}
         run: |
           NEWS="charts/${CHART_NAME}/NEWS.md"
 
@@ -165,9 +164,6 @@ jobs:
             echo "## ${CHART_VERSION}"
             echo ""
             echo "- Bump ${DISPLAY_NAME} version to ${APP_VERSION}"
-            if [ -n "${PYTHON_VERSION}" ]; then
-              echo "- Update Python to ${PYTHON_VERSION}"
-            fi
             echo ""
             tail -n +3 "$NEWS"
           } > "${NEWS}.tmp" && mv "${NEWS}.tmp" "$NEWS"

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -15,6 +15,11 @@ on:
         description: "Product version to set as appVersion (e.g. 2026.03.0)"
         required: true
         type: string
+      python_version:
+        description: "Python version baked into the server image (connect only, e.g. 3.14.6)"
+        required: false
+        type: string
+        default: ""
 
 defaults:
   run:
@@ -126,6 +131,19 @@ jobs:
 
           echo "chart-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Sync Connect interpreter paths
+        if: >-
+          steps.current.outputs.app-version != steps.app-version.outputs.value &&
+          inputs.product == 'connect' &&
+          inputs.python_version != ''
+        env:
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          PYTHON_VERSION: ${{ inputs.python_version }}
+        run: |
+          yq -i \
+            ".config.Python.Executable = [\"/opt/python/${PYTHON_VERSION}/bin/python\"]" \
+            "charts/${CHART_NAME}/values.yaml"
+
       - name: Add NEWS.md entry
         if: steps.current.outputs.app-version != steps.app-version.outputs.value
         env:
@@ -133,6 +151,7 @@ jobs:
           PRODUCT: ${{ inputs.product }}
           CHART_NAME: ${{ steps.chart.outputs.name }}
           CHART_VERSION: ${{ steps.update.outputs.chart-version }}
+          PYTHON_VERSION: ${{ inputs.python_version }}
         run: |
           NEWS="charts/${CHART_NAME}/NEWS.md"
 
@@ -146,6 +165,9 @@ jobs:
             echo "## ${CHART_VERSION}"
             echo ""
             echo "- Bump ${DISPLAY_NAME} version to ${APP_VERSION}"
+            if [ -n "${PYTHON_VERSION}" ]; then
+              echo "- Update Python to ${PYTHON_VERSION}"
+            fi
             echo ""
             tail -n +3 "$NEWS"
           } > "${NEWS}.tmp" && mv "${NEWS}.tmp" "$NEWS"
@@ -173,5 +195,6 @@ jobs:
 
             - Chart: `${{ steps.chart.outputs.name }}`
             - appVersion: `${{ steps.current.outputs.app-version }}` → `${{ steps.app-version.outputs.value }}`
+            ${{ inputs.python_version != '' && format('- Python: `{0}`', inputs.python_version) || '' }}
           commit-message: "Update ${{ inputs.product }} appVersion to ${{ steps.app-version.outputs.value }}"
           base: main


### PR DESCRIPTION
Extends `product-release.yml` to accept an optional `python_version` input. When provided for a Connect release, a new step writes the correct Python executable path into `charts/rstudio-connect/values.yaml` before the PR is created.

Receiving end of https://github.com/posit-dev/images-connect/pull/59, which passes the Python version from the images-connect production build.

- `python_version` is optional; Workbench and Package Manager dispatches are unaffected
- The sync step guards on `product == 'connect' && python_version != ''`
- The PR body surfaces the Python version when present