### PR TITLE
docs: add execution environment to Connect recommended-settings Helm example

### DIFF
--- a/examples/connect/application-configuration/index.qmd
+++ b/examples/connect/application-configuration/index.qmd
@@ -12,6 +12,11 @@ These settings are recommend for most deployments and are described below:
 - [Set a default Posit Package Manager CRAN URL](https://docs.posit.co/connect/admin/r/package-management/#configuring-on-posit-connect)
 - [Set a default Posit Package Manager PyPI URL](https://docs.posit.co/connect/admin/python/package-management/#configuring-pip)
 - [Enable Quarto content](https://docs.posit.co/connect/admin/quarto/#enabling-quarto-support)
+- [Define at least one execution environment](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/) so content can run under off-host execution
+
+::: {.callout-note}
+Off-host execution requires at least one execution environment. Content cannot run until you define one, so the example values files below include a minimal `executionEnvironments` entry. To manage execution environments in detail, including custom images and management through the Connect UI or API, see [Content execution environments](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/) in the Connect Admin Guide and the [Custom container images](../container-images/custom-images.qmd) example.
+:::
 
 {{< include ../_prereqs.qmd >}}
 

--- a/examples/connect/application-configuration/index.qmd
+++ b/examples/connect/application-configuration/index.qmd
@@ -12,11 +12,7 @@ These settings are recommend for most deployments and are described below:
 - [Set a default Posit Package Manager CRAN URL](https://docs.posit.co/connect/admin/r/package-management/#configuring-on-posit-connect)
 - [Set a default Posit Package Manager PyPI URL](https://docs.posit.co/connect/admin/python/package-management/#configuring-pip)
 - [Enable Quarto content](https://docs.posit.co/connect/admin/quarto/#enabling-quarto-support)
-- [Define at least one execution environment](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/) so content can run under off-host execution
-
-::: {.callout-note}
-Off-host execution requires at least one execution environment. Content cannot run until you define one, so the example values files below include a minimal `executionEnvironments` entry. To manage execution environments in detail, including custom images and management through the Connect UI or API, see [Content execution environments](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/) in the Connect Admin Guide and the [Custom container images](../container-images/custom-images.qmd) example.
-:::
+- Define at least one [execution environment](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/)
 
 {{< include ../_prereqs.qmd >}}
 

--- a/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
+++ b/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
@@ -108,6 +108,11 @@ securityContext:
 # Quarto versions available in a content image. Match these to the versions in
 # your content image. You can also manage execution environments through the
 # Connect UI or API. See:
+# Define the image used to execute content.
+# Each entry describes the runtime versions available in a content image.
+# Match these to the runtime versions in your content image.
+# You can also manage execution environments through the Connect UI or API.
+# See:
 # https://docs.posit.co/connect/admin/appendix/off-host/execution-environments
 executionEnvironments:
   - name: posit/connect-content:R4.6-python3.14-ubuntu-24.04-pro # TODO: Change to match your content image
@@ -123,7 +128,7 @@ executionEnvironments:
           version: 4.6.1 # TODO: Match the R version in your content image
     quarto:
       installations:
-        - path: /opt/quarto/1.9.38/bin/quarto # TODO: Match the Quarto path in your content image
+        - path: /opt/quarto/bin/quarto # TODO: Match the Quarto path in your content image
           version: 1.9.38 # TODO: Match the Quarto version in your content image
 
 # The config section overwrites values in Posit Connect's main

--- a/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
+++ b/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
@@ -103,6 +103,29 @@ backends:
 securityContext:
   privileged: false
 
+# Off-host execution requires at least one execution environment; content
+# cannot run until one is defined. Each entry describes the R, Python, and
+# Quarto versions available in a content image. Match these to the versions in
+# your content image. You can also manage execution environments through the
+# Connect UI or API. See:
+# https://docs.posit.co/connect/admin/appendix/off-host/execution-environments
+executionEnvironments:
+  - name: posit/connect-content:R4.6-python3.14-ubuntu-24.04-pro # TODO: Change to match your content image
+    title: "Default Runtime"
+    description: "Runtime with R, Python, and Quarto"
+    python:
+      installations:
+        - path: /opt/python/3.14.6/bin/python3 # TODO: Match the Python path in your content image
+          version: 3.14.6 # TODO: Match the Python version in your content image
+    r:
+      installations:
+        - path: /opt/R/4.6.1/bin/R # TODO: Match the R path in your content image
+          version: 4.6.1 # TODO: Match the R version in your content image
+    quarto:
+      installations:
+        - path: /opt/quarto/1.9.38/bin/quarto # TODO: Match the Quarto path in your content image
+          version: 1.9.38 # TODO: Match the Quarto version in your content image
+
 # The config section overwrites values in Posit Connect's main
 # .gcfg configuration file.
 config:

--- a/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
+++ b/examples/connect/application-configuration/rstudio-connect-recommended-app-config-kubernetes.yaml
@@ -103,11 +103,6 @@ backends:
 securityContext:
   privileged: false
 
-# Off-host execution requires at least one execution environment; content
-# cannot run until one is defined. Each entry describes the R, Python, and
-# Quarto versions available in a content image. Match these to the versions in
-# your content image. You can also manage execution environments through the
-# Connect UI or API. See:
 # Define the image used to execute content.
 # Each entry describes the runtime versions available in a content image.
 # Match these to the runtime versions in your content image.

--- a/examples/connect/application-configuration/rstudio-connect-recommended-app-config.yaml
+++ b/examples/connect/application-configuration/rstudio-connect-recommended-app-config.yaml
@@ -96,6 +96,31 @@ launcher:
 securityContext:
   privileged: false
 
+# Off-host execution requires at least one execution environment; content
+# cannot run until one is defined. launcher.customRuntimeYaml was removed in
+# chart 0.20.0, so use the top-level executionEnvironments key for both
+# backends. This key requires Connect 2026.03.0 or later. Each entry describes
+# the R, Python, and Quarto versions available in a content image. Match these
+# to the versions in your content image. You can also manage execution
+# environments through the Connect UI or API. See:
+# https://docs.posit.co/connect/admin/appendix/off-host/execution-environments
+executionEnvironments:
+  - name: posit/connect-content:R4.6-python3.14-ubuntu-24.04-pro # TODO: Change to match your content image
+    title: "Default Runtime"
+    description: "Runtime with R, Python, and Quarto"
+    python:
+      installations:
+        - path: /opt/python/3.14.6/bin/python3 # TODO: Match the Python path in your content image
+          version: 3.14.6 # TODO: Match the Python version in your content image
+    r:
+      installations:
+        - path: /opt/R/4.6.1/bin/R # TODO: Match the R path in your content image
+          version: 4.6.1 # TODO: Match the R version in your content image
+    quarto:
+      installations:
+        - path: /opt/quarto/1.9.38/bin/quarto # TODO: Match the Quarto path in your content image
+          version: 1.9.38 # TODO: Match the Quarto version in your content image
+
 # The config section overwrites values in Posit Connect's main
 # .gcfg configuration file.
 config:

--- a/examples/connect/application-configuration/rstudio-connect-recommended-app-config.yaml
+++ b/examples/connect/application-configuration/rstudio-connect-recommended-app-config.yaml
@@ -96,13 +96,13 @@ launcher:
 securityContext:
   privileged: false
 
-# Off-host execution requires at least one execution environment; content
-# cannot run until one is defined. launcher.customRuntimeYaml was removed in
+# Define the image used to execute content.
+# Each entry describes the runtime versions available in a content image.
+# Match these to the runtime versions in your content image.
+# You can also manage execution environments through the Connect UI or API.
+# launcher.customRuntimeYaml was removed in
 # chart 0.20.0, so use the top-level executionEnvironments key for both
-# backends. This key requires Connect 2026.03.0 or later. Each entry describes
-# the R, Python, and Quarto versions available in a content image. Match these
-# to the versions in your content image. You can also manage execution
-# environments through the Connect UI or API. See:
+# backends. This key requires Connect 2026.03.0 or later. 
 # https://docs.posit.co/connect/admin/appendix/off-host/execution-environments
 executionEnvironments:
   - name: posit/connect-content:R4.6-python3.14-ubuntu-24.04-pro # TODO: Change to match your content image


### PR DESCRIPTION
## Summary

The Connect Helm chart's recommended basic-configuration example (`examples/connect/application-configuration/`) enables off-host execution but defines no execution environment. Off-host execution (both the `backends.kubernetes` runner and the legacy Launcher) requires at least one execution environment before content can run, so a user following the recommended example verbatim cannot run content.

## Changes

- `index.qmd` — add a bullet to the recommended-settings list and a `note` callout explaining that off-host execution requires at least one execution environment, with cross-links to the Connect Admin Guide execution-environments appendix and the Custom container images example.
- `rstudio-connect-recommended-app-config-kubernetes.yaml` — add a minimal top-level `executionEnvironments` block.
- `rstudio-connect-recommended-app-config.yaml` (Launcher variant) — add the same block, noting that `launcher.customRuntimeYaml` was removed in chart 0.20.0 and that `executionEnvironments` requires Connect 2026.03.0 or later.

No chart version bump or NEWS entry: the edits are under `examples/`, not the chart.

Closes #903

Closes #903