### PR TITLE
Fix SSSD/LDAP sign-in broken by rootless fsGroup

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.21.2
+version: 0.21.3
 apiVersion: v2
 appVersion: 2026.07.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.21.3
+
+- Fix SSSD/LDAP (and Active Directory) sign-in that broke under the rootless changes. The rootless setup made Kubernetes re-own the pod's mounted files to a non-root group, which included the SSSD config. SSSD ignores its config unless it is owned by `root:root` with `0600` permissions, so logins failed. The config is now given the correct owner and permissions before SSSD starts.
+
 ## 0.21.2
 
 - Bump Workbench version to 2026.07.0

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.21.2](https://img.shields.io/badge/Version-0.21.2-informational?style=flat-square) ![AppVersion: 2026.07.0](https://img.shields.io/badge/AppVersion-2026.07.0-informational?style=flat-square)
+![Version: 0.21.3](https://img.shields.io/badge/Version-0.21.3-informational?style=flat-square) ![AppVersion: 2026.07.0](https://img.shields.io/badge/AppVersion-2026.07.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.21.2:
+To install the chart with the release name `my-release` at version 0.21.3:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.21.2
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.21.3
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/templates/_helpers.tpl
+++ b/charts/rstudio-workbench/templates/_helpers.tpl
@@ -41,7 +41,10 @@ Rendered into the user-provisioning startup ConfigMap when sssd is active.
 */}}
 {{- define "rstudio-workbench.sssd.program" -}}
 [program:sssd]
-command=/usr/sbin/sssd -i -c /etc/sssd/sssd.conf --logger=stderr
+{{- /* SSSD ignores its config unless it is root:root mode 0600, but the mounted secret arrives
+       owned by a non-root group. Copy it into place with the right owner and permissions right
+       before starting the daemon (this runs as root, since sssd only runs in a root pod). */}}
+command=/bin/bash -c 'mkdir -p /etc/sssd/conf.d && for f in /mnt/user-provisioning/*; do [ -e "$f" ] && install -m 0600 "$f" /etc/sssd/conf.d/; done; exec /usr/sbin/sssd -i -c /etc/sssd/sssd.conf --logger=stderr'
 autorestart=false
 numprocs=1
 stdout_logfile=/dev/stdout
@@ -179,8 +182,10 @@ containers:
       mountPath: "/mnt/secret-configmap/rstudio/"
     {{- end }}
     {{- if and (include "rstudio-workbench.sssd.active" .) (or $sssd.conf .Values.config.userProvisioning) }}
+    {{- /* Not mounted straight to /etc/sssd/conf.d: the mount would arrive owned by a non-root
+           group, which SSSD rejects. The sssd program copies it there as root:root 0600. */}}
     - name: rstudio-user
-      mountPath: "/etc/sssd/conf.d/"
+      mountPath: "/mnt/user-provisioning/"
     {{- end }}
     - name: etc-rstudio
       mountPath: "/etc/rstudio"

--- a/charts/rstudio-workbench/tests/deployment_test.yaml
+++ b/charts/rstudio-workbench/tests/deployment_test.yaml
@@ -337,7 +337,7 @@ tests:
     asserts:
       - equal:
           path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-user")].mountPath'
-          value: "/etc/sssd/conf.d/"
+          value: "/mnt/user-provisioning/"
       - equal:
           path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-user")].name'
           value: "rstudio-user"

--- a/charts/rstudio-workbench/tests/sssd_test.yaml
+++ b/charts/rstudio-workbench/tests/sssd_test.yaml
@@ -21,6 +21,9 @@ tests:
       - matchRegex:
           path: data['sssd.conf']
           pattern: "/usr/sbin/sssd -i -c /etc/sssd/sssd.conf"
+      - matchRegex:
+          path: data['sssd.conf']
+          pattern: "install -m 0600 .* /etc/sssd/conf.d/"
 
   - it: does not start the sssd daemon when runAsRoot is false
     template: configmap-startup.yaml
@@ -100,7 +103,7 @@ tests:
     asserts:
       - equal:
           path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-user")].mountPath'
-          value: "/etc/sssd/conf.d/"
+          value: "/mnt/user-provisioning/"
       - equal:
           path: 'spec.template.spec.containers[0].volumeMounts[?(@.name=="rstudio-user-startup")].mountPath'
           value: "/startup/user-provisioning"


### PR DESCRIPTION
Fixes #909.

## Problem

The rootless changes (#879) set `fsGroup: <serviceAccountUserId>` on the Workbench pod. `fsGroup` makes Kubernetes re-own the pod's mounted volumes to a non-root group, and that swept up the SSSD config secret mounted at `/etc/sssd/conf.d/`. The config arrived as `root:<gid>` mode `0640` instead of `root:root` mode `0600`.

SSSD only loads `conf.d` snippets owned by `root:root` with mode `0600`, so it rejected the config (`"...did not pass access check. Skipping."`), ignored the domain, and LDAP/AD sign-in failed. SSSD requires `pod.runAsRoot: true`, so any SSSD + launcher deployment (the default) is affected.

## Fix

Stage the config secret at `/mnt/user-provisioning` instead of mounting it straight onto `/etc/sssd/conf.d/`, and have the `sssd` program copy it into `/etc/sssd/conf.d/` as `root:root` mode `0600` right before it execs the daemon. The copy lives in the daemon command rather than `prestart-workbench.bash` because that prestart is a separate supervisord program that would race the daemon. This mirrors the existing `launcher.pem` staging pattern (f68b0d40).

## Testing

- `just test rstudio-workbench` — 169/169 pass (updated the two tests that pinned the old `/etc/sssd/conf.d/` mount path; added an assertion that the daemon installs the config as `0600`).
- **Verified in-cluster on the real Workbench image** (k3d), deploying this chart and the pre-fix `main` chart with identical values (`runAsRoot: true`, launcher + `launcherPem` + SSSD LDAP config). Both pods came up with `fsGroup: 999`, `runAsUser: 0`:

  | | SSSD config (file the daemon opens) | SSSD outcome | launcher key copy |
  |---|---|---|---|
  | pre-fix (`main`) | `root:<gid>` `0640` | falls back to `sssd_be --domain placeholder` — LDAP config skipped | — |
  | this PR | `root:root` `0600` | `sssd_be --domain LDAP` spawns — config loaded | `root:<gid>` `0600` (rserver-acceptable) |

  Failure mode is proven behaviorally (LDAP domain backend loads vs. silently falling back to a placeholder domain); the literal `"did not pass access check"` line only surfaces at a higher SSSD `debug_level`.
