### PR TITLE
Pass launcher capabilities through to session container in job.tpl

### DIFF
--- a/charts/rstudio-workbench/Chart.yaml
+++ b/charts/rstudio-workbench/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-workbench
 description: Official Helm chart for Posit Workbench
-version: 0.21.4
+version: 0.21.5
 apiVersion: v2
 appVersion: 2026.07.1
 icon:

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -3,7 +3,7 @@
 
 ## 0.21.5
 
-- The session job template (`files/job.tpl`) now passes through the Linux capabilities the launcher requests for the session container (`.Job.container.capabilitiesAdd` / `.Job.container.capabilitiesDrop`), merging them into `launcher.templateValues.pod.containerSecurityContext`. Previously these were silently dropped, which broke rootless sessions (`launcher-kubernetes-identity=server-user-capabilities`) because `pwb-mkhomedir` requires `CAP_CHOWN`/`CAP_DAC_OVERRIDE`.
+- The session job template (`files/job.tpl`) now passes through the Linux capabilities the launcher requests for the session container (`.Job.container.capabilitiesAdd` / `.Job.container.capabilitiesDrop`), merging them into `launcher.templateValues.pod.containerSecurityContext`. Previously these were silently dropped.
 
 ## 0.21.4
 

--- a/charts/rstudio-workbench/NEWS.md
+++ b/charts/rstudio-workbench/NEWS.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.21.5
+
+- The session job template (`files/job.tpl`) now passes through the Linux capabilities the launcher requests for the session container (`.Job.container.capabilitiesAdd` / `.Job.container.capabilitiesDrop`), merging them into `launcher.templateValues.pod.containerSecurityContext`. Previously these were silently dropped, which broke rootless sessions (`launcher-kubernetes-identity=server-user-capabilities`) because `pwb-mkhomedir` requires `CAP_CHOWN`/`CAP_DAC_OVERRIDE`.
+
 ## 0.21.4
 
 - Bump Workbench version to 2026.07.1

--- a/charts/rstudio-workbench/README.md
+++ b/charts/rstudio-workbench/README.md
@@ -1,6 +1,6 @@
 # Posit Workbench
 
-![Version: 0.21.4](https://img.shields.io/badge/Version-0.21.4-informational?style=flat-square) ![AppVersion: 2026.07.1](https://img.shields.io/badge/AppVersion-2026.07.1-informational?style=flat-square)
+![Version: 0.21.5](https://img.shields.io/badge/Version-0.21.5-informational?style=flat-square) ![AppVersion: 2026.07.1](https://img.shields.io/badge/AppVersion-2026.07.1-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Workbench_
 
@@ -24,11 +24,11 @@ To ensure a stable production deployment:
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.21.4:
+To install the chart with the release name `my-release` at version 0.21.5:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-workbench --version=0.21.4
+helm upgrade --install my-release rstudio/rstudio-workbench --version=0.21.5
 ```
 
 To explore other chart versions, look at:

--- a/charts/rstudio-workbench/files/job.tpl
+++ b/charts/rstudio-workbench/files/job.tpl
@@ -271,9 +271,20 @@ spec:
               {{- toYaml $templateData.pod.env | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with $templateData.pod.containerSecurityContext }}
+          {{- $containerSecurityContext := $templateData.pod.containerSecurityContext | default dict }}
+          {{- if or .Job.container.capabilitiesAdd .Job.container.capabilitiesDrop }}
+            {{- $capabilities := $containerSecurityContext.capabilities | default dict }}
+            {{- with .Job.container.capabilitiesAdd }}
+              {{- $_ := set $capabilities "add" (concat ($capabilities.add | default list) .) }}
+            {{- end }}
+            {{- with .Job.container.capabilitiesDrop }}
+              {{- $_ := set $capabilities "drop" (concat ($capabilities.drop | default list) .) }}
+            {{- end }}
+            {{- $_ := set $containerSecurityContext "capabilities" $capabilities }}
+          {{- end }}
+          {{- if $containerSecurityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $containerSecurityContext | nindent 12 }}
           {{- end }}
           {{- $exposedPorts := list }}
           {{- range .Job.exposedPorts }}


### PR DESCRIPTION
## Problem

Under `use-templating=1` the chart-owned session job template (`files/job.tpl`) fully owns the pod spec but only maps `runAsUser`/`runAsGroup`/`supplementalGroups`. It never reads `.Job.container.capabilitiesAdd` / `.Job.container.capabilitiesDrop`, so Linux capabilities rserver requests for the session container are silently dropped.

This breaks rootless sessions (`launcher-kubernetes-identity=server-user-capabilities`), which need `CHOWN`/`DAC_OVERRIDE`: `pwb-mkhomedir` starts with an empty capability set and fails with `missing required capability: cap_chown`. The launcher's native render (`use-templating=0`) already emits these caps; only full-templating deployments are affected. The default root identity sends no caps and is unaffected.

## Fix

Merge the launcher-sent capabilities into the container-level `securityContext`, alongside `launcher.templateValues.pod.containerSecurityContext` (launcher caps are concatenated onto any chart-configured `add`/`drop` lists), mirroring the launcher's built-in template. Merging rather than emitting a separate block avoids a duplicate `securityContext:` key when a deployment also sets `containerSecurityContext`.

When no caps are sent, rendering is unchanged.

## Testing

- Rendered `job.tpl` through a Go harness reproducing the launcher's templating (text/template + sprig + `toYaml`/`include`, with `rstudio-library.templates.data` defined as `configmap-general.yaml` ships it). Verified valid YAML and correct `securityContext` for: caps only; caps merged with an existing `containerSecurityContext`; no caps with/without `containerSecurityContext` (byte-identical to previous output).
- `just test rstudio-workbench`: 169/169 pass
- `helm lint --strict` with default values and every `ci/*.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)