### PR TITLE
fix(connect): propagate sharedStorage.subPath to direct Kubernetes runner content pods

### DIFF
--- a/charts/rstudio-connect/Chart.yaml
+++ b/charts/rstudio-connect/Chart.yaml
@@ -1,6 +1,6 @@
 name: rstudio-connect
 description: Official Helm chart for Posit Connect
-version: 0.20.11
+version: 0.20.12
 apiVersion: v2
 appVersion: 2026.07.0
 icon: https://raw.githubusercontent.com/rstudio/helm/main/images/posit-icon-fullcolor.svg

--- a/charts/rstudio-connect/NEWS.md
+++ b/charts/rstudio-connect/NEWS.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.20.12
+
+- `sharedStorage.subPath` now applies to content pods run by the direct
+  Kubernetes runner (`backends.kubernetes.enabled`), so content stored under a
+  subdirectory of a shared PersistentVolumeClaim is found correctly. The chart
+  maps it to `Kubernetes.DataDirPVCSubPath`. Requires Connect 2026.08.0 or later.
+
 ## 0.20.11
 
 - Bump Connect version to 2026.07.0

--- a/charts/rstudio-connect/README.md
+++ b/charts/rstudio-connect/README.md
@@ -1,6 +1,6 @@
 # Posit Connect
 
-![Version: 0.20.11](https://img.shields.io/badge/Version-0.20.11-informational?style=flat-square) ![AppVersion: 2026.07.0](https://img.shields.io/badge/AppVersion-2026.07.0-informational?style=flat-square)
+![Version: 0.20.12](https://img.shields.io/badge/Version-0.20.12-informational?style=flat-square) ![AppVersion: 2026.07.0](https://img.shields.io/badge/AppVersion-2026.07.0-informational?style=flat-square)
 
 #### _Official Helm chart for Posit Connect_
 
@@ -30,11 +30,11 @@ To ensure reproducibility in your environment and insulate yourself from future 
 
 ## Installing the chart
 
-To install the chart with the release name `my-release` at version 0.20.11:
+To install the chart with the release name `my-release` at version 0.20.12:
 
 ```{.bash}
 helm repo add rstudio https://helm.rstudio.com
-helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.11
+helm upgrade --install my-release rstudio/rstudio-connect --version=0.20.12
 ```
 
 To explore other chart versions, look at:
@@ -424,7 +424,7 @@ The Helm `config` values are converted into the `rstudio-connect.gcfg` service c
 | sharedStorage.requests.storage | string | `"10Gi"` | The volume of storage to request for this persistent volume claim |
 | sharedStorage.selector | object | `{}` | selector for PVC definition |
 | sharedStorage.storageClassName | bool | `false` | The type of storage to use. Must allow ReadWriteMany |
-| sharedStorage.subPath | string | `""` | an optional subPath for the volume mount |
+| sharedStorage.subPath | string | `""` | an optional subPath for the volume mount. Also applied to content pod mounts for the launcher and the direct Kubernetes runner (backends.kubernetes.enabled). The direct runner requires Connect 2026.08.0 or later. Must be a relative path. |
 | sharedStorage.volumeName | string | `""` | the volumeName passed along to the persistentVolumeClaim. Optional |
 | startupProbe | object | `{"enabled":false,"failureThreshold":30,"httpGet":{"path":"/__ping__","port":3939},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | Used to configure the container's startupProbe. Only included if enabled = true |
 | startupProbe.failureThreshold | int | `30` | failureThreshold * periodSeconds should be strictly > worst case startup time |

--- a/charts/rstudio-connect/templates/NOTES.txt
+++ b/charts/rstudio-connect/templates/NOTES.txt
@@ -66,6 +66,23 @@ Please consider removing this configuration value.
   {{- fail "\n\nWhen backends.kubernetes is enabled, persistent storage must be provided.\nThis is usually done via a PersistentVolumeClaim (PVC) with `sharedStorage.create=true`, although there are other options."}}
 {{- end }}
 
+{{- /* Validate sharedStorage.subPath for the direct Kubernetes runner. Connect maps
+       this to `Kubernetes.DataDirPVCSubPath`, which older Connect versions reject as an
+       unknown setting, so fail here instead of letting the Connect pod crash-loop. */ -}}
+{{- if and .Values.backends.kubernetes.enabled .Values.sharedStorage.subPath }}
+  {{- if not .Values.sharedStorage.mountContent }}
+    {{- fail "\n\n`sharedStorage.subPath` has no effect on content pods when `sharedStorage.mountContent` is false. Set `sharedStorage.mountContent: true` so the direct Kubernetes runner mounts the data directory under the subpath, or unset `sharedStorage.subPath`." }}
+  {{- end }}
+  {{- $connectVersion := .Values.versionOverride | default $.Chart.AppVersion }}
+  {{- if semverCompare "<2026.8.0" $connectVersion }}
+    {{- fail (printf "\n\n`sharedStorage.subPath` with `backends.kubernetes.enabled` requires Connect 2026.08.0 or later, but the configured version is %s.\nUpgrade Connect (or set `versionOverride`), or unset `sharedStorage.subPath`." $connectVersion) }}
+  {{- end }}
+  {{- /* Match the Kubernetes subPath rules Connect enforces: relative, no ".." element. */ -}}
+  {{- if or (hasPrefix "/" .Values.sharedStorage.subPath) (contains ".." .Values.sharedStorage.subPath) }}
+    {{- fail (printf "\n\n`sharedStorage.subPath` (%s) must be a relative path within the PersistentVolumeClaim and must not contain \"..\"." .Values.sharedStorage.subPath) }}
+  {{- end }}
+{{- end }}
+
 {{- if .Values.launcher.contentInitContainer }}
   {{- fail "\n\n`launcher.contentInitContainer` values are now stored at `launcher.defaultInitContainer`" }}
 {{- end }}

--- a/charts/rstudio-connect/templates/_helpers.tpl
+++ b/charts/rstudio-connect/templates/_helpers.tpl
@@ -96,6 +96,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if and (or .Values.sharedStorage.create .Values.sharedStorage.mount) .Values.sharedStorage.mountContent }}
       {{- $dataDirPVCName := default (print (include "rstudio-connect.fullname" .) "-shared-storage" ) .Values.sharedStorage.name }}
       {{- $_ := set $kubernetesSettingsDict "DataDirPVCName" $dataDirPVCName }}
+      {{- /* pass the shared storage subPath so content pods reference the same
+             location the Connect server mounts (rstudio/helm#916) */}}
+      {{- if .Values.sharedStorage.subPath }}
+        {{- $_ := set $kubernetesSettingsDict "DataDirPVCSubPath" .Values.sharedStorage.subPath }}
+      {{- end }}
     {{- end }}
     {{- $_ := set $kubernetesSettingsDict "DefaultResourceJobBase" (default "/etc/rstudio-connect/job.yaml" (dig "Kubernetes" "DefaultResourceJobBase" "" .Values.config)) }}
     {{- if .Values.backends.kubernetes.defaultResourceServiceBase }}

--- a/charts/rstudio-connect/tests/kubernetes_test.yaml
+++ b/charts/rstudio-connect/tests/kubernetes_test.yaml
@@ -564,6 +564,147 @@ tests:
           path: data["rstudio-connect.gcfg"]
           pattern: "DataDirPVCName"
 
+  # Test that sharedStorage.subPath propagates to the direct Kubernetes runner config
+  - it: should configure DataDirPVCSubPath when sharedStorage.subPath is set
+    template: configmap.yaml
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        mountContent: true
+        subPath: rstudio-connect-data
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "DataDirPVCSubPath = rstudio-connect-data"
+
+  - it: should not configure DataDirPVCSubPath when sharedStorage.subPath is empty
+    template: configmap.yaml
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        mountContent: true
+    documentIndex: 0
+    asserts:
+      - notMatchRegex:
+          path: data["rstudio-connect.gcfg"]
+          pattern: "DataDirPVCSubPath"
+
+  # Test chart-layer guards for sharedStorage.subPath on the direct Kubernetes runner
+  - it: should fail when sharedStorage.subPath is set on a Connect version without support
+    template: NOTES.txt
+    set:
+      versionOverride: "2026.07.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        subPath: rstudio-connect-data
+    asserts:
+      - failedTemplate:
+          errorPattern: "sharedStorage.subPath.*requires Connect.*2026.08.0"
+
+  - it: should fail when sharedStorage.subPath is an absolute path
+    template: NOTES.txt
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        subPath: /rstudio-connect-data
+    asserts:
+      - failedTemplate:
+          errorPattern: "sharedStorage.subPath.*must be a relative path"
+
+  - it: should fail when sharedStorage.subPath contains a parent reference
+    template: NOTES.txt
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        subPath: ../evil
+    asserts:
+      - failedTemplate:
+          errorPattern: "sharedStorage.subPath.*must be a relative path"
+
+  - it: should not fail when sharedStorage.subPath is a valid relative path on a supported version
+    template: NOTES.txt
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        subPath: rstudio-connect-data
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: should not apply the direct-runner subPath guards to a launcher deployment
+    template: NOTES.txt
+    set:
+      launcher:
+        enabled: true
+      backends:
+        kubernetes:
+          enabled: false
+      sharedStorage:
+        create: true
+        mount: true
+        subPath: rstudio-connect-data
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: should fail when sharedStorage.subPath is set but mountContent is false
+    template: NOTES.txt
+    set:
+      versionOverride: "2026.08.0"
+      launcher:
+        enabled: false
+      backends:
+        kubernetes:
+          enabled: true
+      sharedStorage:
+        create: true
+        mount: true
+        mountContent: false
+        subPath: rstudio-connect-data
+    asserts:
+      - failedTemplate:
+          errorPattern: "sharedStorage.subPath.*mountContent"
+
   # Test defaultInitContainer fields render on auto-generated init container
   - it: should apply imagePullPolicy, resources, and securityContext to init container
     template: configmap.yaml

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -479,10 +479,10 @@ config:
     InitTimeout: 5m
   Logging:
     ServiceLog: STDOUT
-    ServiceLogLevel: INFO # INFO, WARNING or ERROR
-    ServiceLogFormat: TEXT # TEXT or JSON
+    ServiceLogLevel: INFO  # INFO, WARNING or ERROR
+    ServiceLogFormat: TEXT  # TEXT or JSON
     AccessLog: STDOUT
-    AccessLogFormat: COMMON # COMMON, COMBINED, or JSON
+    AccessLogFormat: COMMON  # COMMON, COMBINED, or JSON
   Launcher: {}
   Kubernetes: {}
   Chronicle:

--- a/charts/rstudio-connect/values.yaml
+++ b/charts/rstudio-connect/values.yaml
@@ -30,7 +30,10 @@ sharedStorage:
   selector: {}
   # -- the volumeName passed along to the persistentVolumeClaim. Optional
   volumeName: ""
-  # -- an optional subPath for the volume mount
+  # -- an optional subPath for the volume mount. Also applied to content pod
+  # mounts for the launcher and the direct Kubernetes runner
+  # (backends.kubernetes.enabled). The direct runner requires Connect 2026.08.0
+  # or later. Must be a relative path.
   subPath: ""
 rbac:
   # -- Whether to create rbac. (also depends on launcher.enabled = true or backends.kubernetes.enabled = true)


### PR DESCRIPTION
When `backends.kubernetes.enabled` is set and Connect data lives under a subdirectory of a shared PersistentVolumeClaim, content job pods mounted the volume root instead of that subdirectory. This maps `sharedStorage.subPath` to the `Kubernetes.DataDirPVCSubPath` setting so the direct Kubernetes runner mounts content under the same subpath, matching what the launcher backend already does.

The chart also fails at template time with an actionable message when `sharedStorage.subPath` cannot take effect, so an unsupported Connect image never starts with an unknown setting. It fails when the effective Connect version is below 2026.08.0, when the subpath is absolute or contains a backstep, and when `mountContent` is false. This feature requires Connect 2026.08.0 or later.

Testing. `helm unittest` covers the rendered gcfg, the version and format guards, the `mountContent` guard, and that a launcher deployment is unaffected.

Fixes #916
