### PR TITLE
stop yq from mangling values.yaml comments on version bump

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -151,8 +151,8 @@ jobs:
           CHART_NAME: ${{ steps.chart.outputs.name }}
           PYTHON_VERSION: ${{ inputs.python_version }}
         run: |
-          yq -i \
-            ".config.Python.Executable = [\"/opt/python/${PYTHON_VERSION}/bin/python\"]" \
+          sed -i -E \
+            "s#^([[:space:]]*- /opt/python/)[0-9]+\.[0-9]+\.[0-9]+(/bin/python)\$#\1${PYTHON_VERSION}\2#" \
             "charts/${CHART_NAME}/values.yaml"
 
       - name: Add NEWS.md entry


### PR DESCRIPTION
The `Sync Connect interpreter paths` step used `yq -i` to set the Python path, which reserializes the whole `values.yaml` and collapses the two-space gap before inline comments to one space. That resulted in linting failures on #921 and #917. This PR replaces the `yq` round-trip with a targeted `sed` that rewrites only the interpreter version.
