### PR TITLE
Regenerate RBAC examples for Helm 4.2.4

### DIFF
--- a/examples/rbac/rstudio-launcher-rbac-0.2.26.yaml
+++ b/examples/rbac/rstudio-launcher-rbac-0.2.26.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rstudio-launcher-rbac
+
 ---
 # Source: rstudio-launcher-rbac/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -73,6 +74,7 @@ rules:
       - "pods"
     verbs:
       - "get"
+
 ---
 # Source: rstudio-launcher-rbac/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/rbac/rstudio-launcher-rbac.yaml
+++ b/examples/rbac/rstudio-launcher-rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rstudio-launcher-rbac
+
 ---
 # Source: rstudio-launcher-rbac/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -73,6 +74,7 @@ rules:
       - "pods"
     verbs:
       - "get"
+
 ---
 # Source: rstudio-launcher-rbac/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Helm 4.2.4 fixed a manifest-splitting regex bug that was silently stripping blank lines adjacent to `---` document separators. That fix now preserves a trailing blank line the `rstudio-launcher-rbac` chart's rendered output always had, which the committed example files in `examples/rbac/` didn't reflect.

This regenerates those files via `just rbac` against current Helm to match. Unrelated to any chart logic — pure output-format drift from an upstream Helm bugfix.

The `rbac` CI check currently fails on every PR (unrelated to their content) because `main` is out of sync with Helm's new output. This does not pin the Helm version, so a future Helm release could reintroduce the same failure.

Fixes failing job from #927 