### PR TITLE
Add zizmor pre-commit hook

### DIFF
--- a/.github/workflows/chart-doc.yaml
+++ b/.github/workflows/chart-doc.yaml
@@ -8,9 +8,13 @@ jobs:
   document:
     runs-on: ubuntu-latest
     name: helm-docs
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
@@ -57,9 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     name: rbac
     needs: document
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0

--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -5,10 +5,14 @@ on:
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           ref: 'gh-pages'
           fetch-depth: 0
 
@@ -55,9 +59,12 @@ jobs:
           title: Rebuild index.yaml
 
       - name: Check outputs
+        env:
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
         run: |
-          echo "Created Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Created Pull Request Number - $PR_NUMBER"
+          echo "Pull Request URL - $PR_URL"
 
       - name: Notify Slack of index.yaml rebuild failure
         if: failure()

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -9,10 +9,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Configure Git

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -11,10 +11,13 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm
@@ -74,10 +77,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm
@@ -149,10 +155,13 @@ jobs:
   install:
     runs-on: ubuntu-latest-4x
     needs: [detect-fork]
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm
@@ -263,10 +272,13 @@ jobs:
 
   check-versions-connect:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,23 +11,26 @@ on:
 jobs:
   issues:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Map label to project URL
         id: project-url
+        env:
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          if [ "${{ github.event.label.name }}" = "team: connect" ]; then
+          if [ "$LABEL_NAME" = "team: connect" ]; then
             echo "PROJECT=https://github.com/orgs/posit-dev/projects/23" >> "$GITHUB_OUTPUT"
             echo "ORG=posit-dev" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.label.name }}" = "team: workbench" ]; then
+          elif [ "$LABEL_NAME" = "team: workbench" ]; then
             echo "PROJECT=https://github.com/orgs/rstudio/projects/92" >> "$GITHUB_OUTPUT"
             echo "ORG=rstudio" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.label.name }}" = "team: package manager" ]; then
+          elif [ "$LABEL_NAME" = "team: package manager" ]; then
             echo "PROJECT=https://github.com/orgs/rstudio/projects/48" >> "$GITHUB_OUTPUT"
             echo "ORG=rstudio" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.label.name }}" = "team: chronicle" ]; then
+          elif [ "$LABEL_NAME" = "team: chronicle" ]; then
             echo "PROJECT=https://github.com/orgs/rstudio/projects/134" >> "$GITHUB_OUTPUT"
             echo "ORG=rstudio" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.label.name }}" = "team: launcher" ]; then
+          elif [ "$LABEL_NAME" = "team: launcher" ]; then
             echo "PROJECT=https://github.com/orgs/rstudio/projects/222" >> "$GITHUB_OUTPUT"
             echo "ORG=rstudio" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -29,6 +29,8 @@ jobs:
   update:
     name: Update ${{ inputs.product }} to ${{ inputs.version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Map product to chart
@@ -72,6 +74,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate and normalize app version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+    -   id: zizmor


### PR DESCRIPTION
Tracked in https://github.com/rstudio/helm/issues/929

zizmor already runs in CI (chart-test.yaml), but findings only surface after a push. This adds it as a pre-commit hook so findings are caught locally, following the pattern from https://github.com/posit-dev/images-shared/pull/732.

Adding the hook required first getting the repo to a clean baseline:
- 5 high-confidence template-injection findings in issues.yml — `github.event.label.name` was interpolated directly into a shell `if` condition; a crafted label name could inject shell code. Moved into an env var.
- 10 checkouts missing `persist-credentials: false`. None of these jobs push using the checkout's ambient git credentials — writes go through `chart-releaser-action`, `create-pull-request`, or an explicit GitHub App token — so persisting the token in `.git/config` served no purpose.
- 8 jobs with no `permissions:` block, inheriting the default repo-wide `GITHUB_TOKEN`. Scoped each to what it actually uses.
- 2 low-confidence template-injection findings in chart-rebuild.yaml (PR number/URL echoed into a shell string) — same env var fix.

`.pre-commit-config.yaml` is new to this repo; it currently contains only the zizmor hook.